### PR TITLE
Init onyxKeys empty to not crash on race

### DIFF
--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -11,7 +11,7 @@ let lastConnectionID = 0;
 const callbackToStateMapping = {};
 
 // Stores all of the keys that Onyx can use. Must be defined in init().
-let onyxKeys;
+let onyxKeys = {};
 
 // Holds a list of keys that have been directly subscribed to or recently modified from least to most recent
 let recentlyAccessedKeys = [];


### PR DESCRIPTION
Fixes a potential race condition where someone checks if a key is a collection key before init is finished