### PR TITLE
Make withOnyx forwardRef

### DIFF
--- a/lib/withOnyx.js
+++ b/lib/withOnyx.js
@@ -20,7 +20,7 @@ function getDisplayName(component) {
 
 export default function (mapOnyxToState) {
     return (WrappedComponent) => {
-        class withOnyx extends React.Component {
+        class WithOnyx extends React.Component {
             constructor(props) {
                 super(props);
 
@@ -147,7 +147,7 @@ export default function (mapOnyxToState) {
                 stateToPass = _.omit(stateToPass, value => _.isNull(value));
 
                 // Remove any null values so that React replaces them with default props
-                const propsToPass = _.omit(this.props, value => _.isNull(value));
+                const propsToPass = _.omit(this.props, (value, key) => _.isNull(value) || key === 'forwardedRef');
 
                 // Spreading props and state is necessary in an HOC where the data cannot be predicted
                 return (
@@ -156,12 +156,16 @@ export default function (mapOnyxToState) {
                         {...propsToPass}
                         // eslint-disable-next-line react/jsx-props-no-spreading
                         {...stateToPass}
+                        ref={this.props.forwardedRef}
                     />
                 );
             }
         }
 
-        withOnyx.displayName = `withOnyx(${getDisplayName(WrappedComponent)})`;
-        return withOnyx;
+        WithOnyx.displayName = `withOnyx(${getDisplayName(WrappedComponent)})`;
+        // return withOnyx;
+        return React.forwardRef((props, ref) => {
+            return <WithOnyx {...props} forwardedRef={ref} />
+        });
     };
 }

--- a/lib/withOnyx.js
+++ b/lib/withOnyx.js
@@ -163,9 +163,9 @@ export default function (mapOnyxToState) {
         }
 
         WithOnyx.displayName = `withOnyx(${getDisplayName(WrappedComponent)})`;
-        // return withOnyx;
-        return React.forwardRef((props, ref) => {
-            return <WithOnyx {...props} forwardedRef={ref} />
-        });
+        return React.forwardRef((props, ref) => (
+            // eslint-disable-next-line react/jsx-props-no-spreading
+            <WithOnyx {...props} forwardedRef={ref} />
+        ));
     };
 }


### PR DESCRIPTION
In order for refs to work with a component wrapped in a HOC, the HOC must forward the ref to the wrapped component.

This PR is required so that https://github.com/Expensify/ReactNativeChat/pull/939 will work.