### PR TITLE
Tweak to use open source botify, remove unneeded SSH key.

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -21,7 +21,7 @@ jobs:
             - name: Check for an auto merge
               uses: pascalgn/automerge-action@v0.9.0
               env:
-                  GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
             # This Slack step is duplicated in all workflows, if you make a change to this step, make sure to update all
             # the other workflows with the same change

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -15,7 +15,7 @@ jobs:
               uses: cla-assistant/github-action@v2.0.2-alpha
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  PERSONAL_ACCESS_TOKEN : ${{ secrets.BOTIFY_TOKEN }}
+                  PERSONAL_ACCESS_TOKEN : ${{ secrets.OS_BOTIFY_TOKEN }}
               with:
                   path-to-signatures: '${{ github.repository }}/cla.json'
                   path-to-document: 'https://github.com/${{ github.repository }}/blob/master/CLA.md'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,10 +22,6 @@ jobs:
               with:
                   node-version: '14.x'
 
-            - uses: webfactory/ssh-agent@v0.4.1
-              with:
-                  ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-
             - run: npm ci
 
             - run: npm run lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,10 +22,6 @@ jobs:
               with:
                   node-version: '14.x'
 
-            - uses: webfactory/ssh-agent@v0.4.1
-              with:
-                  ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-
             - run: npm ci
 
             - run: npm run test

--- a/.github/workflows/verision.yml
+++ b/.github/workflows/verision.yml
@@ -12,7 +12,7 @@ jobs:
             - uses: actions/checkout@v2
               with:
                   fetch-depth: 0
-                  token: ${{ secrets.BOTIFY_TOKEN }}
+                  token: ${{ secrets.OS_BOTIFY_TOKEN }}
 
             - name: Setup Node
               uses: actions/setup-node@v1
@@ -50,7 +50,7 @@ jobs:
                     source_branch: version-bump-${{ github.sha }}
                     destination_branch: "master"
                     pr_label: "automerge"
-                    github_token: ${{ secrets.BOTIFY_TOKEN }}
+                    github_token: ${{ secrets.OS_BOTIFY_TOKEN }}
 
             # This Slack step is duplicated in all workflows, if you make a change to this step, make sure to update all
             # the other workflows with the same change


### PR DESCRIPTION
Please review @rafecolton 

Let's make a few changes in the settings:
1. Remove `BOTIFY` secret from this repo
2. Remove `SSH_PRIVATE_KEY` secret from this repo (unused)
3. Add `OS_BOTIFY_TOKEN`
4. Then let's merge this PR and I will verify everything is good.