### PR TITLE
Remove one more instance of SSH key from deploy

### DIFF
--- a/.github/workflows/verision.yml
+++ b/.github/workflows/verision.yml
@@ -19,10 +19,6 @@ jobs:
               with:
                   node-version: '14.x'
 
-            - uses: webfactory/ssh-agent@v0.4.1
-              with:
-                  ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-
             - name: Install dependencies
               run: npm ci
 


### PR DESCRIPTION
Please review @Jag96 - We no longer need SSH keys as everything is open source!