### PR TITLE
Shallowly copy a collection before updating it and setting it to withOnyx state

### DIFF
--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -178,7 +178,7 @@ function keyChanged(key, data) {
             // Check if we are subscribing to a collection key and add this item as a collection
             if (isCollectionKey(subscriber.key)) {
                 subscriber.withOnyxInstance.setState((prevState) => {
-                    const collection = prevState[subscriber.statePropertyName] || {};
+                    const collection = _.clone(prevState[subscriber.statePropertyName] || {});
                     collection[key] = data;
                     return {
                         [subscriber.statePropertyName]: collection,


### PR DESCRIPTION
Fixes https://github.com/Expensify/Expensify/issues/151770

**To reproduce the bug and test this fix we can:**

1. Navigate to a report
2. Add this diff to a react component subscribing to all reports via Onyx
```js
componentDidUpdate(prevProps) {
    console.log(prevProps.reports);
    console.log(this.props.reports);
}
```
3. Toggle a report from pinned to unpinned or vice versa
4. Verify that the `isPinned` property on the active report is the _different_ for both the `prevProps` and `this.props`