### PR TITLE
Code for mergeCollection

### DIFF
--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -164,8 +164,8 @@ function keysChanged(collectionKey, collection) {
             && isCollectionKey(subscriber.key)
         ) {
             if (_.isFunction(subscriber.callback)) {
-                _.each(collection, (data) => {
-                    subscriber.callback(data, collectionKey);
+                _.each(collection, (data, dataKey) => {
+                    subscriber.callback(data, dataKey);
                 });
             } else if (subscriber.withOnyxInstance) {
                 subscriber.withOnyxInstance.setState((prevState) => {
@@ -529,10 +529,11 @@ function mergeCollection(collectionKey, collection) {
             ]), []);
 
             // New keys will be added via multiSet while existing keys will be updated using multiMerge
+            // This is because setting a key that doesn't exist yet with multiMerge will throw errors
             const existingCollectionPromise = AsyncStorage.multiMerge(keyValuePairsForExistingCollection);
             const newCollectionPromise = AsyncStorage.multiSet(keyValuePairsForNewCollection);
 
-            Promise.all([existingCollectionPromise, newCollectionPromise])
+            return Promise.all([existingCollectionPromise, newCollectionPromise])
                 .then(() => keysChanged(collectionKey, collection))
                 .catch(error => evictStorageAndRetry(error, mergeCollection, collection));
         });

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -517,7 +517,7 @@ function mergeCollection(collectionKey, collection) {
                 } else {
                     newCollection[key] = data;
                 }
-            })
+            });
 
             const keyValuePairsForExistingCollection = _.reduce(existingKeyCollection, (finalArray, val, key) => ([
                 ...finalArray,

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -505,7 +505,7 @@ function mergeCollection(parentKey, collection) {
     // Confirm all the collection keys belong to the same parent
     _.each(collection, (data, dataKey) => {
         if (!isKeyMatch(parentKey, dataKey)) {
-            throw `Provided collection does not have all its data belonging to the same parent. ParentKey: ${parentKey}, DataKey: ${dataKey}`;
+            throw new Error(`Provided collection does not have all its data belonging to the same parent. ParentKey: ${parentKey}, DataKey: ${dataKey}`);
         }
     });
 

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -151,6 +151,41 @@ function addAllSafeEvictionKeysToRecentlyAccessedList() {
 }
 
 /**
+ * When a collection of keys change, search for any callbacks matching the collection key and trigger those callbacks
+ *
+ * @param {string} parentKey
+ * @param {Object} collection
+ */
+function keysChanged(parentKey, collection) {
+    // Add or remove this parentKey from the recentlyAccessedKeys lists
+    if (!_.isNull(collection)) {
+        addLastAccessedKey(parentKey);
+    } else {
+        removeLastAccessedKey(parentKey);
+    }
+
+    // Find all subscribers that were added with connect() and trigger the callback or setState() with the new data
+    _.each(callbackToStateMapping, (subscriber) => {
+        if (subscriber && isKeyMatch(subscriber.key, parentKey) && isCollectionKey(subscriber.key) && subscriber.withOnyxInstance) {
+            subscriber.withOnyxInstance.setState((prevState) => {
+                const finalCollection = _.clone(prevState[subscriber.statePropertyName] || {});
+                _.each(collection, (data, dataKey) => {
+                    if (finalCollection[dataKey]) {
+                        lodashMerge(finalCollection[dataKey], data);
+                    } else {
+                        finalCollection[dataKey] = data;
+                    }
+                });
+
+                return {
+                    [subscriber.statePropertyName]: finalCollection,
+                };
+            });
+        }
+    });
+}
+
+/**
  * When a key change happens, search for any callbacks matching the key or collection key and trigger those callbacks
  *
  * @param {string} key
@@ -456,6 +491,28 @@ function merge(key, val) {
 }
 
 /**
+ * Merges a collection based on their keys
+ *
+ * @param {string} parentKey
+ * @param {object} collection
+ * @returns {Promise}
+ */
+function multiMerge(parentKey, collection) {
+    // AsyncStorage expenses the data in an array like:
+    // [["@MyApp_user", "value_1"], ["@MyApp_key", "value_2"]]
+    // This method will transform the params from a better JSON format like:
+    // {'@MyApp_user': 'myUserValue', '@MyApp_key': 'myKeyValue'}
+    const keyValuePairs = _.reduce(collection, (finalArray, val, parentKey) => ([
+        ...finalArray,
+        [parentKey, JSON.stringify(val)],
+    ]), []);
+
+    return AsyncStorage.multiMerge(keyValuePairs)
+        .then(() => keysChanged(parentKey, collection))
+        .catch(error => evictStorageAndRetry(error, multiMerge, collection));
+}
+
+/**
  * Initialize the store with actions and listening for storage events
  *
  * @param {Object} [options]
@@ -493,6 +550,7 @@ const Onyx = {
     set,
     multiSet,
     merge,
+    multiMerge,
     clear,
     init,
     registerLogger,

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -507,18 +507,35 @@ function mergeCollection(collectionKey, collection) {
         }
     });
 
-    // AsyncStorage expenses the data in an array like:
-    // [["@MyApp_user", "value_1"], ["@MyApp_key", "value_2"]]
-    // This method will transform the params from a better JSON format like:
-    // {'@MyApp_user': 'myUserValue', '@MyApp_key': 'myKeyValue'}
-    const keyValuePairs = _.reduce(collection, (finalArray, val, key) => ([
-        ...finalArray,
-        [key, JSON.stringify(val)],
-    ]), []);
+    const existingKeyCollection = {};
+    const newCollection = {};
+    return AsyncStorage.getAllKeys()
+        .then((keys) => {
+            _.each(collection, (data, key) => {
+                if (keys.includes(key)) {
+                    existingKeyCollection[key] = data;
+                } else {
+                    newCollection[key] = data;
+                }
+            })
 
-    return AsyncStorage.multiMerge(keyValuePairs)
-        .then(() => keysChanged(collectionKey, collection))
-        .catch(error => evictStorageAndRetry(error, mergeCollection, collection));
+            const keyValuePairsForExistingCollection = _.reduce(existingKeyCollection, (finalArray, val, key) => ([
+                ...finalArray,
+                [key, JSON.stringify(val)],
+            ]), []);
+            const keyValuePairsForNewCollection = _.reduce(newCollection, (finalArray, val, key) => ([
+                ...finalArray,
+                [key, JSON.stringify(val)],
+            ]), []);
+
+            // New keys will be added via multiSet while existing keys will be updated using multiMerge
+            const existingCollectionPromise = AsyncStorage.multiMerge(keyValuePairsForExistingCollection);
+            const newCollectionPromise = AsyncStorage.multiSet(keyValuePairsForNewCollection);
+
+            Promise.all([existingCollectionPromise, newCollectionPromise])
+                .then(() => keysChanged(collectionKey, collection))
+                .catch(error => evictStorageAndRetry(error, mergeCollection, collection));
+        });
 }
 
 /**

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -166,9 +166,9 @@ function keysChanged(parentKey, collection) {
 
     // Find all subscribers that were added with connect() and trigger the callback or setState() with the new data
     _.each(callbackToStateMapping, (subscriber) => {
-        if (subscriber 
+        if (subscriber
             && isKeyMatch(subscriber.key, parentKey) 
-            && isCollectionKey(subscriber.key) 
+            && isCollectionKey(subscriber.key)
             && subscriber.withOnyxInstance
         ) {
             subscriber.withOnyxInstance.setState((prevState) => {

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -167,7 +167,7 @@ function keysChanged(parentKey, collection) {
     // Find all subscribers that were added with connect() and trigger the callback or setState() with the new data
     _.each(callbackToStateMapping, (subscriber) => {
         if (subscriber
-            && isKeyMatch(subscriber.key, parentKey) 
+            && isKeyMatch(subscriber.key, parentKey)
             && isCollectionKey(subscriber.key)
             && subscriber.withOnyxInstance
         ) {

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -520,7 +520,7 @@ function mergeCollection(parentKey, collection) {
 
     return AsyncStorage.multiMerge(keyValuePairs)
         .then(() => keysChanged(parentKey, collection))
-        .catch(error => evictStorageAndRetry(error, multiMerge, collection));
+        .catch(error => evictStorageAndRetry(error, mergeCollection, collection));
 }
 
 /**

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -511,11 +511,11 @@ function mergeCollection(collectionKey, collection) {
     const newCollection = {};
     return AsyncStorage.getAllKeys()
         .then((keys) => {
-            _.each(collection, (data, key) => {
-                if (keys.includes(key)) {
-                    existingKeyCollection[key] = data;
+            _.each(collection, (data, dataKey) => {
+                if (keys.includes(dataKey)) {
+                    existingKeyCollection[dataKey] = data;
                 } else {
-                    newCollection[key] = data;
+                    newCollection[dataKey] = data;
                 }
             });
 

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -153,38 +153,36 @@ function addAllSafeEvictionKeysToRecentlyAccessedList() {
 /**
  * When a collection of keys change, search for any callbacks matching the collection key and trigger those callbacks
  *
- * @param {String} parentKey
+ * @param {String} collectionKey
  * @param {Object} collection
  */
-function keysChanged(parentKey, collection) {
-    // Add or remove this parentKey from the recentlyAccessedKeys lists
-    if (!_.isNull(collection)) {
-        addLastAccessedKey(parentKey);
-    } else {
-        removeLastAccessedKey(parentKey);
-    }
-
+function keysChanged(collectionKey, collection) {
     // Find all subscribers that were added with connect() and trigger the callback or setState() with the new data
     _.each(callbackToStateMapping, (subscriber) => {
         if (subscriber
-            && isKeyMatch(subscriber.key, parentKey)
+            && isKeyMatch(subscriber.key, collectionKey)
             && isCollectionKey(subscriber.key)
-            && subscriber.withOnyxInstance
         ) {
-            subscriber.withOnyxInstance.setState((prevState) => {
-                const finalCollection = _.clone(prevState[subscriber.statePropertyName] || {});
-                _.each(collection, (data, dataKey) => {
-                    if (finalCollection[dataKey]) {
-                        lodashMerge(finalCollection[dataKey], data);
-                    } else {
-                        finalCollection[dataKey] = data;
-                    }
+            if (_.isFunction(subscriber.callback)) {
+                _.each(collection, (data) => {
+                    subscriber.callback(data, collectionKey);
                 });
+            } else if (subscriber.withOnyxInstance) {
+                subscriber.withOnyxInstance.setState((prevState) => {
+                    const finalCollection = _.clone(prevState[subscriber.statePropertyName] || {});
+                    _.each(collection, (data, dataKey) => {
+                        if (finalCollection[dataKey]) {
+                            lodashMerge(finalCollection[dataKey], data);
+                        } else {
+                            finalCollection[dataKey] = data;
+                        }
+                    });
 
-                return {
-                    [subscriber.statePropertyName]: finalCollection,
-                };
-            });
+                    return {
+                        [subscriber.statePropertyName]: finalCollection,
+                    };
+                });
+            }
         }
     });
 }
@@ -497,15 +495,15 @@ function merge(key, val) {
 /**
  * Merges a collection based on their keys
  *
- * @param {String} parentKey
+ * @param {String} collectionKey
  * @param {Object} collection
  * @returns {Promise}
  */
-function mergeCollection(parentKey, collection) {
+function mergeCollection(collectionKey, collection) {
     // Confirm all the collection keys belong to the same parent
     _.each(collection, (data, dataKey) => {
-        if (!isKeyMatch(parentKey, dataKey)) {
-            throw new Error(`Provided collection does not have all its data belonging to the same parent. ParentKey: ${parentKey}, DataKey: ${dataKey}`);
+        if (!isKeyMatch(collectionKey, dataKey)) {
+            throw new Error(`Provided collection does not have all its data belonging to the same parent. CollectionKey: ${collectionKey}, DataKey: ${dataKey}`);
         }
     });
 
@@ -519,7 +517,7 @@ function mergeCollection(parentKey, collection) {
     ]), []);
 
     return AsyncStorage.multiMerge(keyValuePairs)
-        .then(() => keysChanged(parentKey, collection))
+        .then(() => keysChanged(collectionKey, collection))
         .catch(error => evictStorageAndRetry(error, mergeCollection, collection));
 }
 

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -153,7 +153,7 @@ function addAllSafeEvictionKeysToRecentlyAccessedList() {
 /**
  * When a collection of keys change, search for any callbacks matching the collection key and trigger those callbacks
  *
- * @param {string} parentKey
+ * @param {String} parentKey
  * @param {Object} collection
  */
 function keysChanged(parentKey, collection) {
@@ -166,7 +166,11 @@ function keysChanged(parentKey, collection) {
 
     // Find all subscribers that were added with connect() and trigger the callback or setState() with the new data
     _.each(callbackToStateMapping, (subscriber) => {
-        if (subscriber && isKeyMatch(subscriber.key, parentKey) && isCollectionKey(subscriber.key) && subscriber.withOnyxInstance) {
+        if (subscriber 
+            && isKeyMatch(subscriber.key, parentKey) 
+            && isCollectionKey(subscriber.key) 
+            && subscriber.withOnyxInstance
+        ) {
             subscriber.withOnyxInstance.setState((prevState) => {
                 const finalCollection = _.clone(prevState[subscriber.statePropertyName] || {});
                 _.each(collection, (data, dataKey) => {
@@ -493,8 +497,8 @@ function merge(key, val) {
 /**
  * Merges a collection based on their keys
  *
- * @param {string} parentKey
- * @param {object} collection
+ * @param {String} parentKey
+ * @param {Object} collection
  * @returns {Promise}
  */
 function multiMerge(parentKey, collection) {
@@ -502,9 +506,9 @@ function multiMerge(parentKey, collection) {
     // [["@MyApp_user", "value_1"], ["@MyApp_key", "value_2"]]
     // This method will transform the params from a better JSON format like:
     // {'@MyApp_user': 'myUserValue', '@MyApp_key': 'myKeyValue'}
-    const keyValuePairs = _.reduce(collection, (finalArray, val, parentKey) => ([
+    const keyValuePairs = _.reduce(collection, (finalArray, val, key) => ([
         ...finalArray,
-        [parentKey, JSON.stringify(val)],
+        [key, JSON.stringify(val)],
     ]), []);
 
     return AsyncStorage.multiMerge(keyValuePairs)

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -501,7 +501,14 @@ function merge(key, val) {
  * @param {Object} collection
  * @returns {Promise}
  */
-function multiMerge(parentKey, collection) {
+function mergeCollection(parentKey, collection) {
+    // Confirm all the collection keys belong to the same parent
+    _.each(collection, (data, dataKey) => {
+        if (!isKeyMatch(parentKey, dataKey)) {
+            throw `Provided collection does not have all its data belonging to the same parent. ParentKey: ${parentKey}, DataKey: ${dataKey}`;
+        }
+    });
+
     // AsyncStorage expenses the data in an array like:
     // [["@MyApp_user", "value_1"], ["@MyApp_key", "value_2"]]
     // This method will transform the params from a better JSON format like:
@@ -554,7 +561,7 @@ const Onyx = {
     set,
     multiSet,
     merge,
-    multiMerge,
+    mergeCollection,
     clear,
     init,
     registerLogger,

--- a/tests/components/ViewWithCollections.js
+++ b/tests/components/ViewWithCollections.js
@@ -7,15 +7,16 @@ const propTypes = {
     collections: PropTypes.objectOf(PropTypes.shape({
         ID: PropTypes.number,
     })),
+    onRender: PropTypes.func,
 };
 
 const defaultProps = {
     collections: {},
+    onRender: () => {},
 };
 
 const ViewWithCollections = (props) => {
-    /* eslint-disable no-console */
-    console.log('rendering ViewWithCollections');
+    props.onRender();
 
     return (
         <View>

--- a/tests/components/ViewWithCollections.js
+++ b/tests/components/ViewWithCollections.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {View, Text} from 'react-native';
+import _ from 'underscore';
+
+const propTypes = {
+    collections: PropTypes.objectOf(PropTypes.shape({
+        ID: PropTypes.number,
+    })),
+};
+
+const defaultProps = {
+    collections: {},
+};
+
+const ViewWithCollections = props => (
+    <View>
+        {_.map(props.collections, collection => (
+            <Text>{collection.ID}</Text>
+        ))}
+    </View>
+);
+
+ViewWithCollections.propTypes = propTypes;
+ViewWithCollections.defaultProps = defaultProps;
+export default ViewWithCollections;

--- a/tests/components/ViewWithCollections.js
+++ b/tests/components/ViewWithCollections.js
@@ -13,13 +13,17 @@ const defaultProps = {
     collections: {},
 };
 
-const ViewWithCollections = props => (
-    <View>
-        {_.map(props.collections, collection => (
-            <Text>{collection.ID}</Text>
-        ))}
-    </View>
-);
+const ViewWithCollections = props => {
+    console.log('rendering ViewWithCollections');
+
+    return (
+        <View>
+            {_.map(props.collections, collection => (
+                <Text>{collection.ID}</Text>
+            ))}
+        </View>
+    );
+};
 
 ViewWithCollections.propTypes = propTypes;
 ViewWithCollections.defaultProps = defaultProps;

--- a/tests/components/ViewWithCollections.js
+++ b/tests/components/ViewWithCollections.js
@@ -14,6 +14,7 @@ const defaultProps = {
 };
 
 const ViewWithCollections = (props) => {
+    /* eslint-disable no-console */
     console.log('rendering ViewWithCollections');
 
     return (

--- a/tests/components/ViewWithCollections.js
+++ b/tests/components/ViewWithCollections.js
@@ -13,7 +13,7 @@ const defaultProps = {
     collections: {},
 };
 
-const ViewWithCollections = props => {
+const ViewWithCollections = (props) => {
     console.log('rendering ViewWithCollections');
 
     return (

--- a/tests/unit/onyxTest.js
+++ b/tests/unit/onyxTest.js
@@ -162,14 +162,12 @@ describe('Onyx', () => {
                 expect(testKeyValue).toEqual(['test1', 'test2']);
             });
     });
-});
 
-describe('withOnyx', () => {
     it('should properly set and merge when using mergeCollection', () => {
         const valuesReceived = {};
         let numberOfCallbacks = 0;
 
-        Onyx.connect({
+        connectionID = Onyx.connect({
             key: ONYX_KEYS.COLLECTION.TEST_KEY,
             initWithStoredValues: false,
             callback: (data) => {
@@ -225,9 +223,7 @@ describe('withOnyx', () => {
             expect(valuesReceived[567]).toEqual('one');
         });
     });
-});
 
-describe('withOnyx', () => {
     it('should throw error when a key not belonging to collection key is present in mergeCollection', () => {
         try {
             Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {test_1: {ID: 123}, not_my_test: {beep: 'boop'}})

--- a/tests/unit/onyxTest.js
+++ b/tests/unit/onyxTest.js
@@ -180,48 +180,48 @@ describe('Onyx', () => {
             test_1: {
                 ID: 123,
                 value: 'one'
-            }, 
+            },
             test_2: {
                 ID: 234,
                 value: 'two'
-            }, 
+            },
             test_3: {
                 ID: 345,
                 value: 'three'
             }
         })
-        .then(() => {
-            // 2 key values to update and 2 new keys to add. 
-            // MergeCollection will perform a mix of multiSet and multiMerge
-            Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
-                test_1: {
-                    ID: 123,
-                    value: 'five'
-                }, 
-                test_2: {
-                    ID: 234,
-                    value: 'four'
-                }, 
-                test_4: {
-                    ID: 456,
-                    value: 'two'
-                },
-                test_5: {
-                    ID: 567,
-                    value: 'one'
-                }
+            .then(() => {
+                // 2 key values to update and 2 new keys to add.
+                // MergeCollection will perform a mix of multiSet and multiMerge
+                Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
+                    test_1: {
+                        ID: 123,
+                        value: 'five'
+                    },
+                    test_2: {
+                        ID: 234,
+                        value: 'four'
+                    },
+                    test_4: {
+                        ID: 456,
+                        value: 'two'
+                    },
+                    test_5: {
+                        ID: 567,
+                        value: 'one'
+                    }
+                })
+                return waitForPromisesToResolve();
             })
-            return waitForPromisesToResolve();
-        })
-        .then(() => {
-            // 3 items on the first mergeCollection + 4 items the next mergeCollection
-            expect(numberOfCallbacks).toEqual(7);
-            expect(valuesReceived[123]).toEqual('five');
-            expect(valuesReceived[234]).toEqual('four');
-            expect(valuesReceived[345]).toEqual('three');
-            expect(valuesReceived[456]).toEqual('two');
-            expect(valuesReceived[567]).toEqual('one');
-        });
+            .then(() => {
+                // 3 items on the first mergeCollection + 4 items the next mergeCollection
+                expect(numberOfCallbacks).toEqual(7);
+                expect(valuesReceived[123]).toEqual('five');
+                expect(valuesReceived[234]).toEqual('four');
+                expect(valuesReceived[345]).toEqual('three');
+                expect(valuesReceived[456]).toEqual('two');
+                expect(valuesReceived[567]).toEqual('one');
+            });
     });
 
     it('should throw error when a key not belonging to collection key is present in mergeCollection', () => {

--- a/tests/unit/onyxTest.js
+++ b/tests/unit/onyxTest.js
@@ -186,10 +186,10 @@ describe('Onyx', () => {
                 value: 'three'
             }
         })
-            .then(() => {
+            .then(() => (
                 // 2 key values to update and 2 new keys to add.
                 // MergeCollection will perform a mix of multiSet and multiMerge
-                return Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
+                Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
                     test_1: {
                         ID: 123,
                         value: 'five'
@@ -206,8 +206,8 @@ describe('Onyx', () => {
                         ID: 567,
                         value: 'one'
                     }
-                });
-            })
+                })
+            ))
             .then(() => {
                 // 3 items on the first mergeCollection + 4 items the next mergeCollection
                 expect(mockCallback.mock.calls.length).toBe(7);

--- a/tests/unit/onyxTest.js
+++ b/tests/unit/onyxTest.js
@@ -187,6 +187,7 @@ describe('Onyx', () => {
             }
         })
             .then(() => (
+
                 // 2 key values to update and 2 new keys to add.
                 // MergeCollection will perform a mix of multiSet and multiMerge
                 Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
@@ -217,10 +218,10 @@ describe('Onyx', () => {
 
                 expect(mockCallback.mock.calls[1][0]).toEqual({ID: 234, value: 'two'});
                 expect(mockCallback.mock.calls[1][1]).toEqual('test_2');
-                
+
                 expect(mockCallback.mock.calls[2][0]).toEqual({ID: 345, value: 'three'});
                 expect(mockCallback.mock.calls[2][1]).toEqual('test_3');
-                
+
                 expect(mockCallback.mock.calls[3][0]).toEqual({ID: 123, value: 'five'});
                 expect(mockCallback.mock.calls[3][1]).toEqual('test_1');
 

--- a/tests/unit/onyxTest.js
+++ b/tests/unit/onyxTest.js
@@ -2,13 +2,12 @@ import 'react-native';
 import Onyx from '../../index';
 import waitForPromisesToResolve from '../utils/waitForPromisesToResolve';
 
-const TEST_KEY = 'test';
 const ONYX_KEYS = {
     TEST_KEY: 'test',
     COLLECTION: {
         TEST_KEY: 'test_',
     }
-}
+};
 
 Onyx.registerLogger(() => {});
 Onyx.init({
@@ -179,35 +178,36 @@ describe('Onyx', () => {
         // The first time we call mergeCollection we'll be doing a multiSet internally
         return Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
             test_1: {
-                ID: 123, 
+                ID: 123,
                 value: 'one'
             }, 
             test_2: {
-                ID: 234, 
+                ID: 234,
                 value: 'two'
             }, 
             test_3: {
-                ID: 345, 
+                ID: 345,
                 value: 'three'
             }
         })
         .then(() => {
-            // 2 key values to update and 2 new keys to add. MergeCollection will perform a mix of multiSet and multiMerge
+            // 2 key values to update and 2 new keys to add. 
+            // MergeCollection will perform a mix of multiSet and multiMerge
             Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
                 test_1: {
-                    ID: 123, 
+                    ID: 123,
                     value: 'five'
                 }, 
                 test_2: {
-                    ID: 234, 
+                    ID: 234,
                     value: 'four'
                 }, 
                 test_4: {
-                    ID: 456, 
+                    ID: 456,
                     value: 'two'
                 },
                 test_5: {
-                    ID: 567, 
+                    ID: 567,
                     value: 'one'
                 }
             })

--- a/tests/unit/onyxTest.js
+++ b/tests/unit/onyxTest.js
@@ -3,13 +3,16 @@ import Onyx from '../../index';
 import waitForPromisesToResolve from '../utils/waitForPromisesToResolve';
 
 const TEST_KEY = 'test';
+const ONYX_KEYS = {
+    TEST_KEY: 'test',
+    COLLECTION: {
+        TEST_KEY: 'test_',
+    }
+}
 
 Onyx.registerLogger(() => {});
 Onyx.init({
-    keys: {
-        TEST_KEY,
-        COLLECTOnyx: {},
-    },
+    keys: ONYX_KEYS,
     registerStorageEventListener: () => {},
 });
 
@@ -25,7 +28,7 @@ describe('Onyx', () => {
         let testKeyValue;
 
         connectionID = Onyx.connect({
-            key: TEST_KEY,
+            key: ONYX_KEYS.TEST_KEY,
             initWithStoredValues: false,
             callback: (value) => {
                 testKeyValue = value;
@@ -33,7 +36,7 @@ describe('Onyx', () => {
         });
 
         // Set a simple key
-        return Onyx.set(TEST_KEY, 'test')
+        return Onyx.set(ONYX_KEYS.TEST_KEY, 'test')
             .then(() => {
                 expect(testKeyValue).toBe('test');
             });
@@ -43,17 +46,17 @@ describe('Onyx', () => {
         let testKeyValue;
 
         connectionID = Onyx.connect({
-            key: TEST_KEY,
+            key: ONYX_KEYS.TEST_KEY,
             initWithStoredValues: false,
             callback: (value) => {
                 testKeyValue = value;
             },
         });
 
-        return Onyx.set(TEST_KEY, {test1: 'test1'})
+        return Onyx.set(ONYX_KEYS.TEST_KEY, {test1: 'test1'})
             .then(() => {
                 expect(testKeyValue).toEqual({test1: 'test1'});
-                Onyx.merge(TEST_KEY, {test2: 'test2'});
+                Onyx.merge(ONYX_KEYS.TEST_KEY, {test2: 'test2'});
                 return waitForPromisesToResolve();
             })
             .then(() => {
@@ -64,14 +67,14 @@ describe('Onyx', () => {
     it('should notify subscribers when data has been cleared', () => {
         let testKeyValue;
         connectionID = Onyx.connect({
-            key: TEST_KEY,
+            key: ONYX_KEYS.TEST_KEY,
             initWithStoredValues: false,
             callback: (value) => {
                 testKeyValue = value;
             }
         });
 
-        return Onyx.set(TEST_KEY, 'test')
+        return Onyx.set(ONYX_KEYS.TEST_KEY, 'test')
             .then(() => {
                 expect(testKeyValue).toBe('test');
                 return Onyx.clear();
@@ -84,18 +87,18 @@ describe('Onyx', () => {
     it('should not notify subscribers after they have disconnected', () => {
         let testKeyValue;
         connectionID = Onyx.connect({
-            key: TEST_KEY,
+            key: ONYX_KEYS.TEST_KEY,
             initWithStoredValues: false,
             callback: (value) => {
                 testKeyValue = value;
             },
         });
 
-        return Onyx.set(TEST_KEY, 'test')
+        return Onyx.set(ONYX_KEYS.TEST_KEY, 'test')
             .then(() => {
                 expect(testKeyValue).toBe('test');
                 Onyx.disconnect(connectionID);
-                return Onyx.set(TEST_KEY, 'test updated');
+                return Onyx.set(ONYX_KEYS.TEST_KEY, 'test updated');
             })
             .then(() => {
                 // Test value has not changed
@@ -106,17 +109,17 @@ describe('Onyx', () => {
     it('should merge arrays by appending new items to the end of a value', () => {
         let testKeyValue;
         connectionID = Onyx.connect({
-            key: TEST_KEY,
+            key: ONYX_KEYS.TEST_KEY,
             initWithStoredValues: false,
             callback: (value) => {
                 testKeyValue = value;
             },
         });
 
-        return Onyx.set(TEST_KEY, ['test1'])
+        return Onyx.set(ONYX_KEYS.TEST_KEY, ['test1'])
             .then(() => {
                 expect(testKeyValue).toStrictEqual(['test1']);
-                Onyx.merge(TEST_KEY, ['test2', 'test3', 'test4']);
+                Onyx.merge(ONYX_KEYS.TEST_KEY, ['test2', 'test3', 'test4']);
                 return waitForPromisesToResolve();
             })
             .then(() => {
@@ -127,15 +130,15 @@ describe('Onyx', () => {
     it('should merge 2 objects when it has no initial stored value for test key', () => {
         let testKeyValue;
         connectionID = Onyx.connect({
-            key: TEST_KEY,
+            key: ONYX_KEYS.TEST_KEY,
             initWithStoredValues: false,
             callback: (value) => {
                 testKeyValue = value;
             },
         });
 
-        Onyx.merge(TEST_KEY, {test1: 'test1'});
-        Onyx.merge(TEST_KEY, {test2: 'test2'});
+        Onyx.merge(ONYX_KEYS.TEST_KEY, {test1: 'test1'});
+        Onyx.merge(ONYX_KEYS.TEST_KEY, {test2: 'test2'});
         return waitForPromisesToResolve()
             .then(() => {
                 expect(testKeyValue).toStrictEqual({test1: 'test1', test2: 'test2'});
@@ -145,18 +148,91 @@ describe('Onyx', () => {
     it('should merge 2 arrays when it has no initial stored value for test key', () => {
         let testKeyValue;
         connectionID = Onyx.connect({
-            key: TEST_KEY,
+            key: ONYX_KEYS.TEST_KEY,
             initWithStoredValues: false,
             callback: (value) => {
                 testKeyValue = value;
             },
         });
 
-        Onyx.merge(TEST_KEY, ['test1']);
-        Onyx.merge(TEST_KEY, ['test2']);
+        Onyx.merge(ONYX_KEYS.TEST_KEY, ['test1']);
+        Onyx.merge(ONYX_KEYS.TEST_KEY, ['test2']);
         return waitForPromisesToResolve()
             .then(() => {
                 expect(testKeyValue).toEqual(['test1', 'test2']);
             });
+    });
+});
+
+describe('withOnyx', () => {
+    it('should properly set and merge when using mergeCollection', () => {
+        const valuesReceived = {};
+        let numberOfCallbacks = 0;
+
+        Onyx.connect({
+            key: ONYX_KEYS.COLLECTION.TEST_KEY,
+            initWithStoredValues: false,
+            callback: (data) => {
+                ++numberOfCallbacks;
+                valuesReceived[data.ID] = data.value;
+            },
+        });
+
+        // The first time we call mergeCollection we'll be doing a multiSet internally
+        return Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
+            test_1: {
+                ID: 123, 
+                value: 'one'
+            }, 
+            test_2: {
+                ID: 234, 
+                value: 'two'
+            }, 
+            test_3: {
+                ID: 345, 
+                value: 'three'
+            }
+        })
+        .then(() => {
+            // 2 key values to update and 2 new keys to add. MergeCollection will perform a mix of multiSet and multiMerge
+            Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
+                test_1: {
+                    ID: 123, 
+                    value: 'five'
+                }, 
+                test_2: {
+                    ID: 234, 
+                    value: 'four'
+                }, 
+                test_4: {
+                    ID: 456, 
+                    value: 'two'
+                },
+                test_5: {
+                    ID: 567, 
+                    value: 'one'
+                }
+            })
+            return waitForPromisesToResolve();
+        })
+        .then(() => {
+            // 3 items on the first mergeCollection + 4 items the next mergeCollection
+            expect(numberOfCallbacks).toEqual(7);
+            expect(valuesReceived[123]).toEqual('five');
+            expect(valuesReceived[234]).toEqual('four');
+            expect(valuesReceived[345]).toEqual('three');
+            expect(valuesReceived[456]).toEqual('two');
+            expect(valuesReceived[567]).toEqual('one');
+        });
+    });
+});
+
+describe('withOnyx', () => {
+    it('should throw error when a key not belonging to collection key is present in mergeCollection', () => {
+        try {
+            Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {test_1: {ID: 123}, not_my_test: {beep: 'boop'}})
+        } catch (error) {
+            expect(error.message).toEqual(`Provided collection does not have all its data belonging to the same parent. CollectionKey: ${ONYX_KEYS.COLLECTION.TEST_KEY}, DataKey: not_my_test`);
+        }
     });
 });

--- a/tests/unit/onyxTest.js
+++ b/tests/unit/onyxTest.js
@@ -210,7 +210,7 @@ describe('Onyx', () => {
                         ID: 567,
                         value: 'one'
                     }
-                })
+                });
                 return waitForPromisesToResolve();
             })
             .then(() => {
@@ -226,7 +226,7 @@ describe('Onyx', () => {
 
     it('should throw error when a key not belonging to collection key is present in mergeCollection', () => {
         try {
-            Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {test_1: {ID: 123}, not_my_test: {beep: 'boop'}})
+            Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {test_1: {ID: 123}, not_my_test: {beep: 'boop'}});
         } catch (error) {
             expect(error.message).toEqual(`Provided collection does not have all its data belonging to the same parent. CollectionKey: ${ONYX_KEYS.COLLECTION.TEST_KEY}, DataKey: not_my_test`);
         }

--- a/tests/unit/withOnyxTest.js
+++ b/tests/unit/withOnyxTest.js
@@ -37,6 +37,46 @@ describe('withOnyx', () => {
             .then(() => {
                 const textComponent = result.getByText('test1');
                 expect(textComponent).toBeTruthy();
+                expect(result).toHaveBeenCalledTimes(999);
+            });
+    });
+});
+
+// describe('withOnyx', () => {
+//     it('should update withOnyx subscriber just once when mergeCollection is used', () => {
+//         const logSpy = jest.spyOn(console, 'log');
+//         const TestComponentWithOnyx = withOnyx({
+//             text: {
+//                 key: ONYX_KEYS.COLLECTION.TEST_KEY,
+//             },
+//         })(ViewWithCollections);
+//         const result = render(<TestComponentWithOnyx />);
+
+//         // Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {test_1: {ID: 123}, test_2: {ID: 234}, test_3: {ID: 345}});
+//         Onyx.merge(ONYX_KEYS.COLLECTION.TEST_KEY+'1',{ID: 123});
+//         Onyx.merge(ONYX_KEYS.COLLECTION.TEST_KEY+'2',{ID: 234});
+//         Onyx.merge(ONYX_KEYS.COLLECTION.TEST_KEY+'3',{ID: 345});
+//         return waitForPromisesToResolve()
+//             .then(() => {
+//                 expect(logSpy).toHaveBeenCalledTimes(4);
+//             });
+//     });
+// });
+
+describe('withOnyx', () => {
+    it('should update withOnyx subscriber just once when mergeCollection is used', () => {
+        const logSpy2 = jest.spyOn(console, 'log');
+        const TestComponentWithOnyx = withOnyx({
+            text: {
+                key: ONYX_KEYS.COLLECTION.TEST_KEY,
+            },
+        })(ViewWithCollections);
+        const result = render(<TestComponentWithOnyx />);
+
+        Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {test_1: {ID: 123}, test_2: {ID: 234}, test_3: {ID: 345}});
+        return waitForPromisesToResolve()
+            .then(() => {
+                expect(logSpy2).toHaveBeenCalledTimes(1);
             });
     });
 });
@@ -54,7 +94,7 @@ describe('withOnyx', () => {
             },
         });
 
-        Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {test_1: {ID: 123}, test_2: {ID: 234}, test_3: {ID: 345}})
+        Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {test_1: {ID: 123}})
             .then(() => {
                 expect(numberOfCallbacks).toEqual(3);
                 expect(valuesReceived[0]).toEqual({ID: 123});
@@ -71,21 +111,5 @@ describe('withOnyx', () => {
         } catch (error) {
             expect(error.message).toEqual(`Provided collection does not have all its data belonging to the same parent. CollectionKey: ${ONYX_KEYS.COLLECTION.TEST_KEY}, DataKey: not_my_test`);
         }
-    });
-});
-
-describe('withOnyx', () => {
-    it('should update withOnyx subscriber just once when mergeCollection is used', () => {
-        const TestComponentWithOnyx = withOnyx({
-            text: {
-                key: ONYX_KEYS.COLLECTION.TEST_KEY,
-            },
-        })(ViewWithCollections);
-        const result = render(<TestComponentWithOnyx />);
-
-        Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {test_1: {ID: 123}, test_2: {ID: 234}, test_3: {ID: 345}})
-            .then(() => {
-                expect(result).toHaveBeenCalledTimes(5);
-            })
     });
 });

--- a/tests/unit/withOnyxTest.js
+++ b/tests/unit/withOnyxTest.js
@@ -94,7 +94,7 @@ describe('withOnyx', () => {
             },
         });
 
-        Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {test_1: {ID: 123}})
+        Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {test_1: {ID: 123}, test_2: {ID: 234}, test_3: {ID: 345}})
             .then(() => {
                 expect(numberOfCallbacks).toEqual(3);
                 expect(valuesReceived[0]).toEqual({ID: 123});

--- a/tests/unit/withOnyxTest.js
+++ b/tests/unit/withOnyxTest.js
@@ -42,74 +42,42 @@ describe('withOnyx', () => {
     });
 });
 
-// describe('withOnyx', () => {
-//     it('should update withOnyx subscriber just once when mergeCollection is used', () => {
-//         const logSpy = jest.spyOn(console, 'log');
-//         const TestComponentWithOnyx = withOnyx({
-//             text: {
-//                 key: ONYX_KEYS.COLLECTION.TEST_KEY,
-//             },
-//         })(ViewWithCollections);
-//         const result = render(<TestComponentWithOnyx />);
-
-//         // Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {test_1: {ID: 123}, test_2: {ID: 234}, test_3: {ID: 345}});
-//         Onyx.merge(ONYX_KEYS.COLLECTION.TEST_KEY+'1',{ID: 123});
-//         Onyx.merge(ONYX_KEYS.COLLECTION.TEST_KEY+'2',{ID: 234});
-//         Onyx.merge(ONYX_KEYS.COLLECTION.TEST_KEY+'3',{ID: 345});
-//         return waitForPromisesToResolve()
-//             .then(() => {
-//                 expect(logSpy).toHaveBeenCalledTimes(4);
-//             });
-//     });
-// });
-
 describe('withOnyx', () => {
-    it('should update withOnyx subscriber just once when mergeCollection is used', () => {
-        const logSpy2 = jest.spyOn(console, 'log');
+    it('should update withOnyx subscriber multiple times when merge is used', () => {
+        const logSpy = jest.spyOn(console, 'log');
         const TestComponentWithOnyx = withOnyx({
             text: {
                 key: ONYX_KEYS.COLLECTION.TEST_KEY,
             },
         })(ViewWithCollections);
-        const result = render(<TestComponentWithOnyx />);
+        render(<TestComponentWithOnyx />);
+
+        Onyx.merge(ONYX_KEYS.COLLECTION.TEST_KEY + '1', {ID: 123});
+        Onyx.merge(ONYX_KEYS.COLLECTION.TEST_KEY + '2', {ID: 234});
+        Onyx.merge(ONYX_KEYS.COLLECTION.TEST_KEY + '3', {ID: 345});
+        return waitForPromisesToResolve()
+            .then(() => {
+                expect(logSpy).toHaveBeenCalledTimes(4);
+                console.log.mockClear();
+            });
+    });
+});
+
+describe('withOnyx', () => {
+    it('should update withOnyx subscriber just once when mergeCollection is used', () => {
+        const logSpy = jest.spyOn(console, 'log');
+        const TestComponentWithOnyx = withOnyx({
+            text: {
+                key: ONYX_KEYS.COLLECTION.TEST_KEY,
+            },
+        })(ViewWithCollections);
+        render(<TestComponentWithOnyx />);
 
         Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {test_1: {ID: 123}, test_2: {ID: 234}, test_3: {ID: 345}});
         return waitForPromisesToResolve()
             .then(() => {
-                expect(logSpy2).toHaveBeenCalledTimes(1);
+                expect(logSpy).toHaveBeenCalledTimes(2);
+                console.log.mockClear();
             });
-    });
-});
-
-describe('withOnyx', () => {
-    it('should receive callback for each object change for mergeCollection', () => {
-        const valuesReceived = [];
-        let numberOfCallbacks = 0;
-        Onyx.connect({
-            key: ONYX_KEYS.COLLECTION.TEST_KEY,
-            initWithStoredValues: false,
-            callback: (value) => {
-                ++numberOfCallbacks;
-                valuesReceived.push(value);
-            },
-        });
-
-        Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {test_1: {ID: 123}, test_2: {ID: 234}, test_3: {ID: 345}})
-            .then(() => {
-                expect(numberOfCallbacks).toEqual(3);
-                expect(valuesReceived[0]).toEqual({ID: 123});
-                expect(valuesReceived[1]).toEqual({ID: 234});
-                expect(valuesReceived[2]).toEqual({ID: 345});
-            });
-    });
-});
-
-describe('withOnyx', () => {
-    it('should throw error when a key not belonging to collection key is present in mergeCollection', () => {
-        try {
-            Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {test_1: {ID: 123}, not_my_test: {beep: 'boop'}})
-        } catch (error) {
-            expect(error.message).toEqual(`Provided collection does not have all its data belonging to the same parent. CollectionKey: ${ONYX_KEYS.COLLECTION.TEST_KEY}, DataKey: not_my_test`);
-        }
     });
 });

--- a/tests/unit/withOnyxTest.js
+++ b/tests/unit/withOnyxTest.js
@@ -50,7 +50,7 @@ describe('withOnyx', () => {
             },
         })(ViewWithCollections);
         const onRender = jest.fn();
-        render(<TestComponentWithOnyx onRender={onRender} />); 
+        render(<TestComponentWithOnyx onRender={onRender} />);
 
         Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_KEY}1`, {ID: 123});
         Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_KEY}2`, {ID: 234});
@@ -70,7 +70,7 @@ describe('withOnyx', () => {
             },
         })(ViewWithCollections);
         const onRender = jest.fn();
-        render(<TestComponentWithOnyx onRender={onRender} />); 
+        render(<TestComponentWithOnyx onRender={onRender} />);
 
         Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {test_1: {ID: 123}, test_2: {ID: 234}, test_3: {ID: 345}});
         return waitForPromisesToResolve()

--- a/tests/unit/withOnyxTest.js
+++ b/tests/unit/withOnyxTest.js
@@ -3,17 +3,19 @@ import {render} from '@testing-library/react-native';
 import React from 'react';
 import Onyx, {withOnyx} from '../../index';
 import ViewWithText from '../components/ViewWithText';
-
+import ViewWithCollections from '../components/ViewWithCollections';
 import waitForPromisesToResolve from '../utils/waitForPromisesToResolve';
 
-const TEST_KEY = 'test';
+const ONYX_KEYS = {
+    TEST_KEY: 'test',
+    COLLECTION: {
+        TEST_KEY: 'test_',
+    }
+}
 
 Onyx.registerLogger(() => {});
 Onyx.init({
-    keys: {
-        TEST_KEY,
-        COLLECTION: {},
-    },
+    keys: ONYX_KEYS,
     registerStorageEventListener: () => {},
 });
 
@@ -21,11 +23,11 @@ describe('withOnyx', () => {
     it('should render with the test data when using withOnyx', () => {
         let result;
 
-        Onyx.set(TEST_KEY, 'test1')
+        Onyx.set(ONYX_KEYS.TEST_KEY, 'test1')
             .then(() => {
                 const TestComponentWithOnyx = withOnyx({
                     text: {
-                        key: TEST_KEY,
+                        key: ONYX_KEYS.TEST_KEY,
                     },
                 })(ViewWithText);
 
@@ -36,5 +38,54 @@ describe('withOnyx', () => {
                 const textComponent = result.getByText('test1');
                 expect(textComponent).toBeTruthy();
             });
+    });
+});
+
+describe('withOnyx', () => {
+    it('should receive callback for each object change for mergeCollection', () => {
+        const valuesReceived = [];
+        let numberOfCallbacks = 0;
+        Onyx.connect({
+            key: ONYX_KEYS.COLLECTION.TEST_KEY,
+            initWithStoredValues: false,
+            callback: (value) => {
+                ++numberOfCallbacks;
+                valuesReceived.push(value);
+            },
+        });
+
+        Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {test_1: {ID: 123}, test_2: {ID: 234}, test_3: {ID: 345}})
+            .then(() => {
+                expect(numberOfCallbacks).toEqual(3);
+                expect(valuesReceived[0]).toEqual({ID: 123});
+                expect(valuesReceived[1]).toEqual({ID: 234});
+                expect(valuesReceived[2]).toEqual({ID: 345});
+            });
+    });
+});
+
+describe('withOnyx', () => {
+    it('should throw error when a key not belonging to collection key is present in mergeCollection', () => {
+        try {
+            Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {test_1: {ID: 123}, not_my_test: {beep: 'boop'}})
+        } catch (error) {
+            expect(error.message).toEqual(`Provided collection does not have all its data belonging to the same parent. CollectionKey: ${ONYX_KEYS.COLLECTION.TEST_KEY}, DataKey: not_my_test`);
+        }
+    });
+});
+
+describe('withOnyx', () => {
+    it('should update withOnyx subscriber just once when mergeCollection is used', () => {
+        const TestComponentWithOnyx = withOnyx({
+            text: {
+                key: ONYX_KEYS.COLLECTION.TEST_KEY,
+            },
+        })(ViewWithCollections);
+        const result = render(<TestComponentWithOnyx />);
+
+        Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {test_1: {ID: 123}, test_2: {ID: 234}, test_3: {ID: 345}})
+            .then(() => {
+                expect(result).toHaveBeenCalledTimes(5);
+            })
     });
 });

--- a/tests/unit/withOnyxTest.js
+++ b/tests/unit/withOnyxTest.js
@@ -11,7 +11,7 @@ const ONYX_KEYS = {
     COLLECTION: {
         TEST_KEY: 'test_',
     }
-}
+};
 
 Onyx.registerLogger(() => {});
 Onyx.init({
@@ -52,13 +52,13 @@ describe('withOnyx', () => {
         })(ViewWithCollections);
         render(<TestComponentWithOnyx />);
 
-        Onyx.merge(ONYX_KEYS.COLLECTION.TEST_KEY + '1', {ID: 123});
-        Onyx.merge(ONYX_KEYS.COLLECTION.TEST_KEY + '2', {ID: 234});
-        Onyx.merge(ONYX_KEYS.COLLECTION.TEST_KEY + '3', {ID: 345});
+        Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_KEY}1`, {ID: 123});
+        Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_KEY}2`, {ID: 234});
+        Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_KEY}3`, {ID: 345});
         return waitForPromisesToResolve()
             .then(() => {
                 expect(logSpy).toHaveBeenCalledTimes(4);
-                console.log.mockClear();
+                console.log.mockClear(); // eslint-disable-line no-console
             });
     });
 });
@@ -77,7 +77,7 @@ describe('withOnyx', () => {
         return waitForPromisesToResolve()
             .then(() => {
                 expect(logSpy).toHaveBeenCalledTimes(2);
-                console.log.mockClear();
+                console.log.mockClear(); // eslint-disable-line no-console
             });
     });
 });

--- a/tests/unit/withOnyxTest.js
+++ b/tests/unit/withOnyxTest.js
@@ -44,40 +44,38 @@ describe('withOnyx', () => {
 
 describe('withOnyx', () => {
     it('should update withOnyx subscriber multiple times when merge is used', () => {
-        const logSpy = jest.spyOn(console, 'log');
         const TestComponentWithOnyx = withOnyx({
             text: {
                 key: ONYX_KEYS.COLLECTION.TEST_KEY,
             },
         })(ViewWithCollections);
-        render(<TestComponentWithOnyx />);
+        const onRender = jest.fn();
+        render(<TestComponentWithOnyx onRender={onRender} />); 
 
         Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_KEY}1`, {ID: 123});
         Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_KEY}2`, {ID: 234});
         Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_KEY}3`, {ID: 345});
         return waitForPromisesToResolve()
             .then(() => {
-                expect(logSpy).toHaveBeenCalledTimes(4);
-                console.log.mockClear(); // eslint-disable-line no-console
+                expect(onRender.mock.calls.length).toBe(4);
             });
     });
 });
 
 describe('withOnyx', () => {
     it('should update withOnyx subscriber just once when mergeCollection is used', () => {
-        const logSpy = jest.spyOn(console, 'log');
         const TestComponentWithOnyx = withOnyx({
             text: {
                 key: ONYX_KEYS.COLLECTION.TEST_KEY,
             },
         })(ViewWithCollections);
-        render(<TestComponentWithOnyx />);
+        const onRender = jest.fn();
+        render(<TestComponentWithOnyx onRender={onRender} />); 
 
         Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {test_1: {ID: 123}, test_2: {ID: 234}, test_3: {ID: 345}});
         return waitForPromisesToResolve()
             .then(() => {
-                expect(logSpy).toHaveBeenCalledTimes(2);
-                console.log.mockClear(); // eslint-disable-line no-console
+                expect(onRender.mock.calls.length).toBe(2);
             });
     });
 });


### PR DESCRIPTION
Helps with,
https://github.com/Expensify/Expensify/issues/152029

Rather than notifying the subscriber each time for every item within a collection now we can just notify the subscriber of the updated data once. This results in drastically less re-renders.