### PR TITLE
Add cache eviction test. Clean up some other tests.

### DIFF
--- a/lib/Logger.js
+++ b/lib/Logger.js
@@ -1,5 +1,5 @@
 // Logging callback
-let logger;
+let logger = () => {};
 
 /**
  * Register the logging callback

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -240,14 +240,15 @@ function keyChanged(key, data) {
  * @param {string} [config.statePropertyName]
  * @param {function} [config.callback]
  * @param {*|null} val
+ * @param {String} key
  */
-function sendDataToConnection(config, val) {
+function sendDataToConnection(config, val, key) {
     if (config.withOnyxInstance) {
         config.withOnyxInstance.setState({
             [config.statePropertyName]: val,
         });
     } else if (_.isFunction(config.callback)) {
-        config.callback(val);
+        config.callback(val, key);
     }
 }
 
@@ -309,7 +310,7 @@ function connect(mapping) {
                     .then(val => sendDataToConnection(mapping, val));
             } else {
                 _.each(matchingKeys, (key) => {
-                    get(key).then(val => sendDataToConnection(mapping, val));
+                    get(key).then(val => sendDataToConnection(mapping, val, key));
                 });
             }
         });
@@ -384,7 +385,9 @@ function set(key, val) {
     // Write the thing to persistent storage, which will trigger a storage event for any other tabs open on this domain
     return AsyncStorage.setItem(key, JSON.stringify(val))
         .then(() => keyChanged(key, val))
-        .catch(error => evictStorageAndRetry(error, set, key, val));
+        .catch(error => {
+            return evictStorageAndRetry(error, set, key, val);
+        });
 }
 
 /**

--- a/tests/unit/cacheEvictionTest.js
+++ b/tests/unit/cacheEvictionTest.js
@@ -1,0 +1,58 @@
+import Onyx from '../../index';
+import AsyncStorage from '@react-native-community/async-storage';
+import waitForPromisesToResolve from '../utils/waitForPromisesToResolve';
+
+const ONYX_KEYS = {
+    COLLECTION: {
+        TEST_KEY: 'test_',
+    },
+};
+
+test('Cache eviction', () => {
+    const RECORD_TO_EVICT = 'evict';
+    const RECORD_TO_ADD = 'add';
+    const collection = {};
+
+    // Given an evictable key previously set in storage
+    return AsyncStorage.setItem(`${ONYX_KEYS.COLLECTION.TEST_KEY}${RECORD_TO_EVICT}`, JSON.stringify({test: 'evict'}))
+        .then(() => {
+
+            // When we initialize Onyx and mark the set collection key as a safeEvictionKey
+            Onyx.init({
+                keys: ONYX_KEYS,
+                registerStorageEventListener: () => {},
+                safeEvictionKeys: [ONYX_KEYS.COLLECTION.TEST_KEY],
+            });
+
+            // And connect to this key
+            Onyx.connect({
+                key: ONYX_KEYS.COLLECTION.TEST_KEY,
+                callback: (val, key) => {
+                    if (!val) {
+                        delete collection[key]
+                    } else {
+                        collection[key] = val;
+                    }
+                },
+            });
+
+            return waitForPromisesToResolve();
+        })
+        .then(() => {
+            // Then it should populate our data with the key we will soon evict
+            expect(collection[`${ONYX_KEYS.COLLECTION.TEST_KEY}${RECORD_TO_EVICT}`]).toStrictEqual({test: 'evict'});
+
+            // When we set a new key we want to add and force the first attempt to fail
+            const originalSetItem = AsyncStorage.setItem;
+            const setItemMock = jest.fn(originalSetItem)
+                .mockImplementationOnce(() => new Promise((_resolve, reject) => reject()));
+            AsyncStorage.setItem = setItemMock;
+
+            return Onyx.set(`${ONYX_KEYS.COLLECTION.TEST_KEY}${RECORD_TO_ADD}`, {test: 'add'})
+                .then(() => {
+                    // Then our collection should no longer contain the evictable key
+                    expect(collection[`${ONYX_KEYS.COLLECTION.TEST_KEY}${RECORD_TO_EVICT}`]).toBe(undefined);
+                    expect(collection[`${ONYX_KEYS.COLLECTION.TEST_KEY}${RECORD_TO_ADD}`]).toStrictEqual({test: 'add'});
+                });
+        });
+});

--- a/tests/unit/onyxTest.js
+++ b/tests/unit/onyxTest.js
@@ -1,4 +1,3 @@
-import 'react-native';
 import Onyx from '../../index';
 import waitForPromisesToResolve from '../utils/waitForPromisesToResolve';
 
@@ -9,7 +8,6 @@ const ONYX_KEYS = {
     }
 };
 
-Onyx.registerLogger(() => {});
 Onyx.init({
     keys: ONYX_KEYS,
     registerStorageEventListener: () => {},

--- a/tests/unit/withOnyxTest.js
+++ b/tests/unit/withOnyxTest.js
@@ -1,6 +1,5 @@
-import 'react-native';
-import {render} from '@testing-library/react-native';
 import React from 'react';
+import {render} from '@testing-library/react-native';
 import Onyx, {withOnyx} from '../../index';
 import ViewWithText from '../components/ViewWithText';
 import ViewWithCollections from '../components/ViewWithCollections';
@@ -13,7 +12,6 @@ const ONYX_KEYS = {
     }
 };
 
-Onyx.registerLogger(() => {});
 Onyx.init({
     keys: ONYX_KEYS,
     registerStorageEventListener: () => {},


### PR DESCRIPTION
cc @chiragsalian @madmax330 might be interested in the conversation [here](https://expensify.slack.com/archives/C01GTK53T8Q/p1609359194296700)

Doesn't seem like there is a very clear consensus yet on whether we **need** to fix the existing cache eviction strategy. But the concerns in the Slack thread above make a lot of sense. I have also started to see storage errors popping up more and more frequently while testing Expensify.cash via the web proxy instead of local development. I expect that other engineers will see the same if they switch to testing via the proxy.

For now, this PR just adds tests for the existing cache eviction system since none were written when it was conceived. Eventually if/when we re-work cache eviction it will be good to have a test set up to build off of. Additionally, it seems like a good idea to get some of this stuff under test.