### PR TITLE
Update CLA to remove botify allowlist

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -35,4 +35,3 @@ jobs:
                   branch: 'master'
                   remote-organization-name: 'Expensify'
                   remote-repository-name: 'CLA'
-                  allowlist: botify


### PR DESCRIPTION
We no longer need to whitelist @botify as it does not commit or merge pull requests in this repo anymore, so I've removed it to make sure we are compliant!