### PR TITLE
[No QA] Update expensify-common hash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5548,15 +5548,14 @@
       }
     },
     "expensify-common": {
-      "version": "git+https://github.com/Expensify/expensify-common.git#09e7a7014537b4fec527ea12039eb227a72133fd",
-      "from": "git+https://github.com/Expensify/expensify-common.git#09e7a7014537b4fec527ea12039eb227a72133fd",
+      "version": "git+https://github.com/Expensify/expensify-common.git#c7becaa79e10c10da521261ebb83dd3871847e84",
+      "from": "git+https://github.com/Expensify/expensify-common.git#c7becaa79e10c10da521261ebb83dd3871847e84",
       "requires": {
         "classnames": "2.2.5",
         "clipboard": "2.0.4",
         "html-entities": "^1.3.1",
         "jquery": "3.3.1",
-        "lodash.get": "4.4.2",
-        "lodash.has": "4.5.2",
+        "lodash": "4.17.21",
         "prop-types": "15.7.2",
         "react": "16.12.0",
         "react-dom": "16.12.0",
@@ -5565,6 +5564,11 @@
         "underscore": "1.9.1"
       },
       "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        },
         "lru-cache": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -8856,16 +8860,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
       "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
       "dev": true
-    },
-    "lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
-    },
-    "lodash.has": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/lodash.has/-/lodash.has-4.5.2.tgz",
-      "integrity": "sha1-0Z9NwQlQWMzL4rDN9O4P5Ko3yGI="
     },
     "lodash.merge": {
       "version": "4.6.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@react-native-community/async-storage": "^1.12.1",
-    "expensify-common": "git+https://github.com/Expensify/expensify-common.git#09e7a7014537b4fec527ea12039eb227a72133fd",
+    "expensify-common": "git+https://github.com/Expensify/expensify-common.git#c7becaa79e10c10da521261ebb83dd3871847e84",
     "lodash.merge": "^4.6.2",
     "react": "^16.13.1",
     "underscore": "^1.11.0"


### PR DESCRIPTION
Hash update for https://github.com/Expensify/expensify-common/pull/353.

@nickmurray47 assigning you since you have the expensify.cash one