### PR TITLE
Fix Onyx.mergeCollection doesn't update subscribers

### DIFF
--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -159,10 +159,15 @@ function addAllSafeEvictionKeysToRecentlyAccessedList() {
 function keysChanged(collectionKey, collection) {
     // Find all subscribers that were added with connect() and trigger the callback or setState() with the new data
     _.each(callbackToStateMapping, (subscriber) => {
-        if (subscriber
-            && isKeyMatch(subscriber.key, collectionKey)
-            && isCollectionKey(subscriber.key)
-        ) {
+        if (!subscriber) {
+            return;
+        }
+
+        const isSubscribedToCollectionKey = isKeyMatch(subscriber.key, collectionKey)
+            && isCollectionKey(subscriber.key);
+        const isSubscribedToCollectionMemberKey = subscriber.key.startsWith(collectionKey);
+
+        if (isSubscribedToCollectionKey) {
             if (_.isFunction(subscriber.callback)) {
                 _.each(collection, (data, dataKey) => {
                     subscriber.callback(data, dataKey);
@@ -181,6 +186,15 @@ function keysChanged(collectionKey, collection) {
                     return {
                         [subscriber.statePropertyName]: finalCollection,
                     };
+                });
+            }
+        } else if (isSubscribedToCollectionMemberKey) {
+            const dataForKey = collection[subscriber.key];
+            if (_.isFunction(subscriber.callback)) {
+                subscriber.callback(dataForKey, subscriber.key);
+            } else if (subscriber.withOnyxInstance) {
+                subscriber.withOnyxInstance.setState({
+                    [subscriber.statePropertyName]: dataForKey,
                 });
             }
         }

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -151,6 +151,38 @@ function addAllSafeEvictionKeysToRecentlyAccessedList() {
 }
 
 /**
+ * Update an individual subscriber with new data.
+ *
+ * @param {Object} subscriber
+ * @param {*} data
+ * @param {String} key
+ */
+function updateIndividualSubscriber(subscriber, data, key) {
+    if (_.isFunction(subscriber.callback)) {
+        subscriber.callback(data, key);
+    }
+
+    if (!subscriber.withOnyxInstance) {
+        return;
+    }
+
+    // Check if we are subscribing to a collection key and add this item as a collection
+    if (isCollectionKey(subscriber.key)) {
+        subscriber.withOnyxInstance.setState((prevState) => {
+            const collection = _.clone(prevState[subscriber.statePropertyName] || {});
+            collection[key] = data;
+            return {
+                [subscriber.statePropertyName]: collection,
+            };
+        });
+    } else {
+        subscriber.withOnyxInstance.setState({
+            [subscriber.statePropertyName]: data,
+        });
+    }
+}
+
+/**
  * When a collection of keys change, search for any callbacks matching the collection key and trigger those callbacks
  *
  * @param {String} collectionKey
@@ -193,38 +225,6 @@ function keysChanged(collectionKey, collection) {
             updateIndividualSubscriber(subscriber, dataForKey, subscriber.key);
         }
     });
-}
-
-/**
- * Update an individual subscriber with new data.
- *
- * @param {Object} subscriber
- * @param {*} data
- * @param {String} key
- */
-function updateIndividualSubscriber(subscriber, data, key) {
-    if (_.isFunction(subscriber.callback)) {
-        subscriber.callback(data, key);
-    }
-
-    if (!subscriber.withOnyxInstance) {
-        return;
-    }
-
-    // Check if we are subscribing to a collection key and add this item as a collection
-    if (isCollectionKey(subscriber.key)) {
-        subscriber.withOnyxInstance.setState((prevState) => {
-            const collection = _.clone(prevState[subscriber.statePropertyName] || {});
-            collection[key] = data;
-            return {
-                [subscriber.statePropertyName]: collection,
-            };
-        });
-    } else {
-        subscriber.withOnyxInstance.setState({
-            [subscriber.statePropertyName]: data,
-        });
-    }
 }
 
 /**
@@ -523,6 +523,7 @@ function mergeCollection(collectionKey, collection) {
     // Confirm all the collection keys belong to the same parent
     _.each(collection, (data, dataKey) => {
         if (!isKeyMatch(collectionKey, dataKey)) {
+            // eslint-disable-next-line max-len
             throw new Error(`Provided collection does not have all its data belonging to the same parent. CollectionKey: ${collectionKey}, DataKey: ${dataKey}`);
         }
     });

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -190,15 +190,41 @@ function keysChanged(collectionKey, collection) {
             }
         } else if (isSubscribedToCollectionMemberKey) {
             const dataForKey = collection[subscriber.key];
-            if (_.isFunction(subscriber.callback)) {
-                subscriber.callback(dataForKey, subscriber.key);
-            } else if (subscriber.withOnyxInstance) {
-                subscriber.withOnyxInstance.setState({
-                    [subscriber.statePropertyName]: dataForKey,
-                });
-            }
+            updateIndividualSubscriber(subscriber, dataForKey, subscriber.key);
         }
     });
+}
+
+/**
+ * Update an individual subscriber with new data.
+ *
+ * @param {Object} subscriber
+ * @param {*} data
+ * @param {String} key
+ */
+function updateIndividualSubscriber(subscriber, data, key) {
+    if (_.isFunction(subscriber.callback)) {
+        subscriber.callback(data, key);
+    }
+
+    if (!subscriber.withOnyxInstance) {
+        return;
+    }
+
+    // Check if we are subscribing to a collection key and add this item as a collection
+    if (isCollectionKey(subscriber.key)) {
+        subscriber.withOnyxInstance.setState((prevState) => {
+            const collection = _.clone(prevState[subscriber.statePropertyName] || {});
+            collection[key] = data;
+            return {
+                [subscriber.statePropertyName]: collection,
+            };
+        });
+    } else {
+        subscriber.withOnyxInstance.setState({
+            [subscriber.statePropertyName]: data,
+        });
+    }
 }
 
 /**
@@ -218,28 +244,7 @@ function keyChanged(key, data) {
     // Find all subscribers that were added with connect() and trigger the callback or setState() with the new data
     _.each(callbackToStateMapping, (subscriber) => {
         if (subscriber && isKeyMatch(subscriber.key, key)) {
-            if (_.isFunction(subscriber.callback)) {
-                subscriber.callback(data, key);
-            }
-
-            if (!subscriber.withOnyxInstance) {
-                return;
-            }
-
-            // Check if we are subscribing to a collection key and add this item as a collection
-            if (isCollectionKey(subscriber.key)) {
-                subscriber.withOnyxInstance.setState((prevState) => {
-                    const collection = _.clone(prevState[subscriber.statePropertyName] || {});
-                    collection[key] = data;
-                    return {
-                        [subscriber.statePropertyName]: collection,
-                    };
-                });
-            } else {
-                subscriber.withOnyxInstance.setState({
-                    [subscriber.statePropertyName]: data,
-                });
-            }
+            updateIndividualSubscriber(subscriber, data, key);
         }
     });
 }

--- a/tests/unit/onyxTest.js
+++ b/tests/unit/onyxTest.js
@@ -244,6 +244,7 @@ describe('Onyx', () => {
         try {
             Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {test_1: {ID: 123}, not_my_test: {beep: 'boop'}});
         } catch (error) {
+            // eslint-disable-next-line max-len
             expect(error.message).toEqual(`Provided collection does not have all its data belonging to the same parent. CollectionKey: ${ONYX_KEYS.COLLECTION.TEST_KEY}, DataKey: not_my_test`);
         }
     });

--- a/tests/unit/withOnyxTest.js
+++ b/tests/unit/withOnyxTest.js
@@ -77,3 +77,22 @@ describe('withOnyx', () => {
             });
     });
 });
+
+describe('withOnyx', () => {
+    it('should update withOnyx subscribing to individual key if mergeCollection is used', () => {
+        const collectionItemID = 1;
+        const TestComponentWithOnyx = withOnyx({
+            text: {
+                key: `${ONYX_KEYS.COLLECTION.TEST_KEY}${collectionItemID}`,
+            },
+        })(ViewWithCollections);
+        const onRender = jest.fn();
+        render(<TestComponentWithOnyx onRender={onRender} />);
+
+        Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {test_1: {ID: 123}, test_2: {ID: 234}, test_3: {ID: 345}});
+        return waitForPromisesToResolve()
+            .then(() => {
+                expect(onRender.mock.calls.length).toBe(2);
+            });
+    });
+});


### PR DESCRIPTION
## Details

When we implemented the `mergeCollection()` feature we only set it up so that it would update subscribers of the collection key and not any individual subscribers. This prevents any components that are subscribing to an individual key from updating when `mergeCollection()` is called. So e.g. a component subscribing to `report_` would have gotten an update but a component subscribing to `report_123` would not.

cc @Julesssss 

## Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/159086

## Tests
Added a unit test to verify this is working and also updates individual subscribers to collection keys when we call `mergeCollection()`.