### PR TITLE
Create a test case for mergecollection value check

### DIFF
--- a/tests/unit/withOnyxTest.js
+++ b/tests/unit/withOnyxTest.js
@@ -108,11 +108,11 @@ describe('withOnyx', () => {
         const onRender = jest.fn();
         render(<TestComponentWithOnyx onRender={onRender} />);
         Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {test_4: {ID: 456}, test_5: {ID: 567}});
-        Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {test_4: {Name: "Test4"}, test_5: {Name: "Test5"}, test_6: {ID: 678, Name: "Test6"}});
+        Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {test_4: {Name: 'Test4'}, test_5: {Name: 'Test5'}, test_6: {ID: 678, Name: 'Test6'}});
         return waitForPromisesToResolve()
             .then(() => {
                 expect(onRender.mock.calls.length).toBe(3);
-                expect(onRender.mock.instances[2].text).toEqual({ID: 456, Name: "Test4"});
+                expect(onRender.mock.instances[2].text).toEqual({ID: 456, Name: 'Test4'});
             });
     });
 });

--- a/tests/unit/withOnyxTest.js
+++ b/tests/unit/withOnyxTest.js
@@ -96,3 +96,23 @@ describe('withOnyx', () => {
             });
     });
 });
+
+describe('withOnyx', () => {
+    it('should update withOnyx subscribing to individual key with merged value if mergeCollection is used', () => {
+        const collectionItemID = 4;
+        const TestComponentWithOnyx = withOnyx({
+            text: {
+                key: `${ONYX_KEYS.COLLECTION.TEST_KEY}${collectionItemID}`,
+            },
+        })(ViewWithCollections);
+        const onRender = jest.fn();
+        render(<TestComponentWithOnyx onRender={onRender} />);
+        Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {test_4: {ID: 456}, test_5: {ID: 567}});
+        Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {test_4: {Name: "Test4"}, test_5: {Name: "Test5"}, test_6: {ID: 678, Name: "Test6"}});
+        return waitForPromisesToResolve()
+            .then(() => {
+                expect(onRender.mock.calls.length).toBe(3);
+                expect(onRender.mock.instances[2].text).toEqual({ID: 456, Name: "Test4"});
+            });
+    });
+});


### PR DESCRIPTION
Related issue: https://github.com/Expensify/Expensify.cash/issues/2225

Created a new test case for mergeCollection function to see if it merges values as expected. This test will fail.