### PR TITLE
[No QA] Update expensify-common hash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5548,8 +5548,8 @@
       }
     },
     "expensify-common": {
-      "version": "git+https://github.com/Expensify/expensify-common.git#758b46bc0b50320a006c7892faec56c2d3952135",
-      "from": "git+https://github.com/Expensify/expensify-common.git#758b46bc0b50320a006c7892faec56c2d3952135",
+      "version": "git+https://github.com/Expensify/expensify-common.git#2e5cff552cf132da90a3fb9756e6b4fb6ae7b40c",
+      "from": "git+https://github.com/Expensify/expensify-common.git#2e5cff552cf132da90a3fb9756e6b4fb6ae7b40c",
       "requires": {
         "classnames": "2.2.5",
         "clipboard": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@react-native-community/async-storage": "^1.12.1",
-    "expensify-common": "git+https://github.com/Expensify/expensify-common.git#758b46bc0b50320a006c7892faec56c2d3952135",
+    "expensify-common": "git+https://github.com/Expensify/expensify-common.git#2e5cff552cf132da90a3fb9756e6b4fb6ae7b40c",
     "lodash": "4.17.21",
     "react": "^16.13.1",
     "underscore": "^1.11.0"


### PR DESCRIPTION
Hash update for https://github.com/Expensify/expensify-common/pull/366

@nickmurray47 since you have the big one for e.cash