### PR TITLE
Make sure Onyx re-sets with default values when logging out and back in

### DIFF
--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -435,32 +435,6 @@ function multiSet(data) {
         .catch(error => evictStorageAndRetry(error, multiSet, data));
 }
 
-/**
- * Merge user provided default key value pairs.
- */
-function initializeWithDefaultKeyStates() {
-    _.each(defaultKeyStates, (state, key) => merge(key, state));
-}
-
-/**
- * Clear out all the data in the store
- *
- * @returns {Promise<void>}
- */
-function clear() {
-    let allKeys;
-    return AsyncStorage.getAllKeys()
-        .then(keys => allKeys = keys)
-        .then(() => AsyncStorage.clear())
-        .then(() => {
-            _.each(allKeys, (key) => {
-                keyChanged(key, null);
-            });
-
-            initializeWithDefaultKeyStates();
-        });
-}
-
 // Key/value store of Onyx key and arrays of values to merge
 const mergeQueue = {};
 
@@ -524,6 +498,32 @@ function merge(key, val) {
             // don't apply these changes again
             delete mergeQueue[key];
             set(key, modifiedData);
+        });
+}
+
+/**
+ * Merge user provided default key value pairs.
+ */
+function initializeWithDefaultKeyStates() {
+    _.each(defaultKeyStates, (state, key) => merge(key, state));
+}
+
+/**
+ * Clear out all the data in the store
+ *
+ * @returns {Promise<void>}
+ */
+function clear() {
+    let allKeys;
+    return AsyncStorage.getAllKeys()
+        .then(keys => allKeys = keys)
+        .then(() => AsyncStorage.clear())
+        .then(() => {
+            _.each(allKeys, (key) => {
+                keyChanged(key, null);
+            });
+
+            initializeWithDefaultKeyStates();
         });
 }
 

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -24,6 +24,9 @@ let evictionAllowList = [];
 // long as we have at least one subscriber that returns false for the canEvict property.
 const evictionBlocklist = {};
 
+// Optional user-provided key value states set when Onyx initializes or clears
+let defaultKeyStates = {};
+
 /**
  * When a key change happens, search for any callbacks matching the regex pattern and trigger those callbacks
  * Get some data from the store
@@ -433,6 +436,13 @@ function multiSet(data) {
 }
 
 /**
+ * Merge user provided default key value pairs.
+ */
+function initializeWithDefaultKeyStates() {
+    _.each(defaultKeyStates, (state, key) => merge(key, state));
+}
+
+/**
  * Clear out all the data in the store
  *
  * @returns {Promise<void>}
@@ -446,6 +456,8 @@ function clear() {
             _.each(allKeys, (key) => {
                 keyChanged(key, null);
             });
+
+            initializeWithDefaultKeyStates();
         });
 }
 
@@ -584,12 +596,15 @@ function init({
     // Let Onyx know about all of our keys
     onyxKeys = keys;
 
+    // Set our default key states to use when initializing and clearing Onyx data
+    defaultKeyStates = initialKeyStates;
+
     // Let Onyx know about which keys are safe to evict
     evictionAllowList = safeEvictionKeys;
     addAllSafeEvictionKeysToRecentlyAccessedList();
 
     // Initialize all of our keys with data provided
-    _.each(initialKeyStates, (state, key) => merge(key, state));
+    initializeWithDefaultKeyStates();
 
     // Update any key whose value changes in storage
     registerStorageEventListener((key, newValue) => keyChanged(key, newValue));


### PR DESCRIPTION
### Details
cc @Julesssss 

We have the ability to initialize Onyx with a set of keys + values, but those values are not reset when Onyx is cleared leading to unexpected things in the cases where this might happen e.g. when a user "logs out" of an application. This PR will make sure we re-initialize Onyx with any default values.

### Related Issues
https://github.com/Expensify/Expensify/issues/164467

### Automated Tests
Added test

### Linked PRs
https://github.com/Expensify/Expensify.cash/pull/2979
