### PR TITLE
Kidroca/onyx cache cleanup

### DIFF
--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -731,7 +731,10 @@ function init({
     initializeWithDefaultKeyStates();
 
     // Update any key whose value changes in storage
-    registerStorageEventListener((key, newValue) => keyChanged(key, newValue));
+    registerStorageEventListener((key, newValue) => {
+        cache.set(key, newValue);
+        keyChanged(key, newValue);
+    });
 }
 
 const Onyx = {

--- a/lib/OnyxCache.js
+++ b/lib/OnyxCache.js
@@ -103,6 +103,10 @@ class OnyxCache {
      */
     merge(data) {
         this.storageMap = lodashMerge({}, this.storageMap, data);
+
+        const storageKeys = this.getAllKeys();
+        const mergedKeys = _.keys(data);
+        this.storageKeys = new Set([...storageKeys, ...mergedKeys]);
     }
 
     /**

--- a/lib/OnyxCache.js
+++ b/lib/OnyxCache.js
@@ -98,7 +98,7 @@ class OnyxCache {
     }
 
     /**
-     * Deep merge data to cache, any non existing keys will be crated
+     * Deep merge data to cache, any non existing keys will be created
      * @param {Record<string, *>} data - a map of (cache) key - values
      */
     merge(data) {

--- a/lib/decorateWithMetrics.js
+++ b/lib/decorateWithMetrics.js
@@ -26,7 +26,7 @@ function decorateWithMetrics(func, alias = func.name) {
 
         /*
         * Then handlers added here are not affecting the original promise
-        * They crate a separate chain that's not exposed (returned) to the original caller
+        * They create a separate chain that's not exposed (returned) to the original caller
         * */
         originalPromise
             .finally(() => {

--- a/tests/unit/onyxCacheTest.js
+++ b/tests/unit/onyxCacheTest.js
@@ -377,6 +377,7 @@ describe('Onyx', () => {
     describe('Onyx with Cache', () => {
         let Onyx;
         let withOnyx;
+        let AsyncStorageMock;
 
         /** @type OnyxCache */
         let cache;
@@ -393,6 +394,7 @@ describe('Onyx', () => {
             const OnyxModule = require('../../index');
             Onyx = OnyxModule.default;
             withOnyx = OnyxModule.withOnyx;
+            AsyncStorageMock = require('@react-native-community/async-storage').default;
             cache = require('../../lib/OnyxCache').default;
 
             Onyx.init({
@@ -413,8 +415,6 @@ describe('Onyx', () => {
         });
 
         it('Expect a single call to getItem when multiple components use the same key', () => {
-            const AsyncStorageMock = require('@react-native-community/async-storage/jest/async-storage-mock');
-
             // GIVEN a component connected to Onyx
             const TestComponentWithOnyx = withOnyx({
                 text: {
@@ -444,8 +444,6 @@ describe('Onyx', () => {
         });
 
         it('Expect a single call to getAllKeys when multiple components use the same key', () => {
-            const AsyncStorageMock = require('@react-native-community/async-storage/jest/async-storage-mock');
-
             // GIVEN a component connected to Onyx
             const TestComponentWithOnyx = withOnyx({
                 text: {
@@ -476,8 +474,6 @@ describe('Onyx', () => {
         });
 
         it('Expect multiple calls to getItem when no existing component is using a key', () => {
-            const AsyncStorageMock = require('@react-native-community/async-storage/jest/async-storage-mock');
-
             // GIVEN a component connected to Onyx
             const TestComponentWithOnyx = withOnyx({
                 text: {
@@ -509,8 +505,6 @@ describe('Onyx', () => {
         });
 
         it('Expect multiple calls to getItem when multiple keys are used', () => {
-            const AsyncStorageMock = require('@react-native-community/async-storage/jest/async-storage-mock');
-
             // GIVEN two component
             const TestComponentWithOnyx = withOnyx({
                 testObject: {
@@ -550,8 +544,6 @@ describe('Onyx', () => {
         });
 
         it('Expect a single call to getItem when at least one component is still subscribed to a key', () => {
-            const AsyncStorageMock = require('@react-native-community/async-storage/jest/async-storage-mock');
-
             // GIVEN a component connected to Onyx
             const TestComponentWithOnyx = withOnyx({
                 text: {
@@ -589,8 +581,6 @@ describe('Onyx', () => {
         });
 
         it('Should remove collection items from cache when collection is disconnected', () => {
-            const AsyncStorageMock = require('@react-native-community/async-storage/jest/async-storage-mock');
-
             // GIVEN a component subscribing to a collection
             const TestComponentWithOnyx = withOnyx({
                 collections: {
@@ -638,8 +628,6 @@ describe('Onyx', () => {
         });
 
         it('Should not remove item from cache when it still used in a collection', () => {
-            const AsyncStorageMock = require('@react-native-community/async-storage/jest/async-storage-mock');
-
             // GIVEN component that uses a collection and a component that uses a collection item
             const COLLECTION_ITEM_KEY = `${ONYX_KEYS.COLLECTION.MOCK_COLLECTION}10`;
             const TestComponentWithOnyx = withOnyx({

--- a/tests/unit/onyxCacheTest.js
+++ b/tests/unit/onyxCacheTest.js
@@ -318,6 +318,22 @@ describe('Onyx', () => {
                 expect(cache.hasCacheForKey('mockKey')).toBe(true);
                 expect(cache.getValue('mockKey')).toEqual({ID: 5});
             });
+
+            it('Should update storageKeys when new keys are created', () => {
+                // GIVEN cache with some items
+                cache.set('mockKey', {value: 'mockValue'});
+                cache.set('mockKey2', {other: 'otherMockValue', mock: 'mock', items: [3, 4, 5]});
+
+                // WHEN merge is called with existing key value pairs
+                cache.merge({
+                    mockKey: {mockItems: []},
+                    mockKey3: {ID: 3},
+                    mockKey4: {ID: 4},
+                });
+
+                // THEN getAllStorage keys should return updated storage keys
+                expect(cache.getAllKeys()).toEqual(['mockKey', 'mockKey2', 'mockKey3', 'mockKey4']);
+            });
         });
 
         describe('hasPendingTask', () => {

--- a/tests/unit/withOnyxTest.js
+++ b/tests/unit/withOnyxTest.js
@@ -43,7 +43,6 @@ describe('withOnyx', () => {
     });
 
     it('should update withOnyx subscriber multiple times when merge is used', () => {
-        // Todo: ViewWithCollections does not expect a `text` prop
         const TestComponentWithOnyx = withOnyx({
             text: {
                 key: ONYX_KEYS.COLLECTION.TEST_KEY,
@@ -62,7 +61,6 @@ describe('withOnyx', () => {
     });
 
     it('should update withOnyx subscriber just once when mergeCollection is used', () => {
-        // Todo: ViewWithCollections does not expect a `text` prop
         const TestComponentWithOnyx = withOnyx({
             text: {
                 key: ONYX_KEYS.COLLECTION.TEST_KEY,
@@ -79,7 +77,6 @@ describe('withOnyx', () => {
     });
 
     it('should update withOnyx subscribing to individual key if mergeCollection is used', () => {
-        // Todo: ViewWithCollections does not expect a `text` prop
         const collectionItemID = 1;
         const TestComponentWithOnyx = withOnyx({
             text: {
@@ -97,7 +94,6 @@ describe('withOnyx', () => {
     });
 
     it('should update withOnyx subscribing to individual key with merged value if mergeCollection is used', () => {
-        // Todo: ViewWithCollections does not expect a `text` prop
         const collectionItemID = 4;
         const TestComponentWithOnyx = withOnyx({
             text: {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->
@marcaaron @Jag96 @roryabraham

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Address some NAB leftovers from #76

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
#63, Expensify/Expensify.cash#2762

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
Cache tests were updated to require AsyncStorage in the before each block

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->
https://github.com/Expensify/Expensify.cash/pull/3423