### PR TITLE
Fix: `Onyx.cleanCache` 

### DIFF
--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -471,8 +471,8 @@ function disconnect(connectionID, keyToRemoveFromEvictionBlocklist) {
  * @return {Promise}
  */
 function remove(key) {
-    // Remove from cache
-    cache.drop(key);
+    // Cache the fact that the value was removed
+    cache.set(key, null);
 
     // Optimistically inform subscribers
     keyChanged(key, null);
@@ -639,7 +639,7 @@ function clear() {
         .then((keys) => {
             _.each(keys, (key) => {
                 keyChanged(key, null);
-                cache.drop(key);
+                cache.set(key, null);
             });
         })
         .then(AsyncStorage.clear)

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -417,7 +417,7 @@ function cleanCache(key) {
 
     // When this is a collection - also recursively remove any unused individual items
     if (isCollectionKey(key)) {
-        cache.remove(key);
+        cache.drop(key);
 
         getAllKeys().then(cachedKeys => _.chain(cachedKeys)
             .filter(name => name.startsWith(key))
@@ -436,8 +436,8 @@ function cleanCache(key) {
         }
     }
 
-    // Otherwise remove the item from cache
-    cache.remove(key);
+    // Otherwise remove the value from cache
+    cache.drop(key);
 }
 
 /**
@@ -472,7 +472,7 @@ function disconnect(connectionID, keyToRemoveFromEvictionBlocklist) {
  */
 function remove(key) {
     // Remove from cache
-    cache.remove(key);
+    cache.drop(key);
 
     // Optimistically inform subscribers
     keyChanged(key, null);
@@ -639,7 +639,7 @@ function clear() {
         .then((keys) => {
             _.each(keys, (key) => {
                 keyChanged(key, null);
-                cache.remove(key);
+                cache.drop(key);
             });
         })
         .then(AsyncStorage.clear)

--- a/lib/OnyxCache.js
+++ b/lib/OnyxCache.js
@@ -34,7 +34,7 @@ class OnyxCache {
         // bind all methods to prevent problems with `this`
         _.bindAll(
             this,
-            'getAllKeys', 'getValue', 'hasCacheForKey', 'addKey', 'set', 'remove', 'merge',
+            'getAllKeys', 'getValue', 'hasCacheForKey', 'addKey', 'set', 'drop', 'merge',
             'hasPendingTask', 'getTaskPromise', 'captureTask',
         );
     }
@@ -89,11 +89,10 @@ class OnyxCache {
     }
 
     /**
-     * Remove data from cache
+     * Forget the cached value for the given key
      * @param {string} key
      */
-    remove(key) {
-        this.storageKeys.delete(key);
+    drop(key) {
         delete this.storageMap[key];
     }
 

--- a/tests/unit/onyxCacheTest.js
+++ b/tests/unit/onyxCacheTest.js
@@ -172,19 +172,19 @@ describe('Onyx', () => {
             });
         });
 
-        describe('remove', () => {
-            it('Should remove the key from all keys', () => {
+        describe('drop', () => {
+            it('Should NOT remove the key from all keys', () => {
                 // GIVEN cache with some items
                 cache.set('mockKey', 'mockValue');
                 cache.set('mockKey2', 'mockValue');
                 cache.set('mockKey3', 'mockValue');
 
                 // WHEN an key is removed
-                cache.remove('mockKey2');
+                cache.drop('mockKey2');
 
-                // THEN getAllKeys should not include the removed value
+                // THEN getAllKeys should still include the key
                 const allKeys = cache.getAllKeys();
-                expect(allKeys).toEqual(['mockKey', 'mockKey3']);
+                expect(allKeys).toEqual(expect.arrayContaining(['mockKey2']));
             });
 
             it('Should remove the key from cache', () => {
@@ -193,7 +193,7 @@ describe('Onyx', () => {
                 cache.set('mockKey2', 'mockValue3');
 
                 // WHEN a key is removed
-                cache.remove('mockKey');
+                cache.drop('mockKey');
 
                 // THEN a value should not be available in cache
                 expect(cache.hasCacheForKey('mockKey')).toBe(false);


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->
@Julesssss @marcaaron 

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Renamed `Cache.remove` to `Cache.drop` this method should not remove the key from `getAllKeys`'s result
Updated `Onyx.remove` and `Onyx.clear` they `set` the cached value to `null` this way 
the next connection does not have to wait to read `null` from storage

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/react-native-onyx/pull/76#issuecomment-857609265
https://github.com/Expensify/Expensify.cash/issues/3482

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
Updated the tests for `cache.drop` 

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->
