### PR TITLE
Switch async-storage repository

### DIFF
--- a/__mocks__/@react-native-async-storage/async-storage.js
+++ b/__mocks__/@react-native-async-storage/async-storage.js
@@ -1,0 +1,1 @@
+export {default} from '@react-native-async-storage/async-storage/jest/async-storage-mock';

--- a/__mocks__/@react-native-community/async-storage.js
+++ b/__mocks__/@react-native-community/async-storage.js
@@ -1,1 +1,0 @@
-export {default} from '@react-native-community/async-storage/jest/async-storage-mock';

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -675,10 +675,17 @@ function mergeCollection(collectionKey, collection) {
             const keyValuePairsForExistingCollection = prepareKeyValuePairsForStorage(existingKeyCollection);
             const keyValuePairsForNewCollection = prepareKeyValuePairsForStorage(newCollection);
 
+            const promises = [];
+
             // New keys will be added via multiSet while existing keys will be updated using multiMerge
             // This is because setting a key that doesn't exist yet with multiMerge will throw errors
-            const existingCollectionPromise = AsyncStorage.multiMerge(keyValuePairsForExistingCollection);
-            const newCollectionPromise = AsyncStorage.multiSet(keyValuePairsForNewCollection);
+            if (keyValuePairsForExistingCollection.length > 0) {
+                promises.push(AsyncStorage.multiMerge(keyValuePairsForExistingCollection));
+            }
+
+            if (keyValuePairsForNewCollection.length > 0) {
+                promises.push(AsyncStorage.multiSet(keyValuePairsForNewCollection));
+            }
 
             // Merge original data to cache
             cache.merge(collection);
@@ -686,7 +693,7 @@ function mergeCollection(collectionKey, collection) {
             // Optimistically inform collection subscribers
             keysChanged(collectionKey, collection);
 
-            return Promise.all([existingCollectionPromise, newCollectionPromise])
+            return Promise.all(promises)
                 .catch(error => evictStorageAndRetry(error, mergeCollection, collection));
         });
 }

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -1,5 +1,5 @@
 import _ from 'underscore';
-import AsyncStorage from '@react-native-community/async-storage';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import Str from 'expensify-common/lib/str';
 import lodashMerge from 'lodash/merge';
 import {registerLogger, logInfo, logAlert} from './Logger';

--- a/package-lock.json
+++ b/package-lock.json
@@ -2216,6 +2216,15 @@
         "@types/yargs": "^13.0.0"
       }
     },
+    "@react-native-async-storage/async-storage": {
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.15.5.tgz",
+      "integrity": "sha512-4AYehLH39B9a8UXCMf3ieOK+G61wGMP72ikx6/XSMA0DUnvx0PgaeaT2Wyt06kTrDTy8edewKnbrbeqwaM50TQ==",
+      "dev": true,
+      "requires": {
+        "deep-assign": "^3.0.0"
+      }
+    },
     "@react-native-community/cli-debugger-ui": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-5.0.1.tgz",
@@ -4607,6 +4616,15 @@
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
+    "deep-assign": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/deep-assign/-/deep-assign-3.0.0.tgz",
+      "integrity": "sha512-YX2i9XjJ7h5q/aQ/IM9PEwEnDqETAIYbggmdDB3HLTlSgo1CxPsj6pvhPG68rq6SVE0+p+6Ywsm5fTYNrYtBWw==",
+      "dev": true,
+      "requires": {
+        "is-obj": "^1.0.0"
+      }
+    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -6943,6 +6961,12 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true
+    },
+    "is-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
     "is-plain-object": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2216,10 +2216,10 @@
         "@types/yargs": "^13.0.0"
       }
     },
-    "@react-native-community/async-storage": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@react-native-community/async-storage/-/async-storage-1.12.1.tgz",
-      "integrity": "sha512-70WGaH3PKYASi4BThuEEKMkyAgE9k7VytBqmgPRx3MzJx9/MkspwqJGmn3QLCgHLIFUgF1pit2mWICbRJ3T3lg==",
+    "@react-native-async-storage/async-storage": {
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.15.5.tgz",
+      "integrity": "sha512-4AYehLH39B9a8UXCMf3ieOK+G61wGMP72ikx6/XSMA0DUnvx0PgaeaT2Wyt06kTrDTy8edewKnbrbeqwaM50TQ==",
       "requires": {
         "deep-assign": "^3.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2216,14 +2216,6 @@
         "@types/yargs": "^13.0.0"
       }
     },
-    "@react-native-async-storage/async-storage": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.15.5.tgz",
-      "integrity": "sha512-4AYehLH39B9a8UXCMf3ieOK+G61wGMP72ikx6/XSMA0DUnvx0PgaeaT2Wyt06kTrDTy8edewKnbrbeqwaM50TQ==",
-      "requires": {
-        "deep-assign": "^3.0.0"
-      }
-    },
     "@react-native-community/cli-debugger-ui": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-5.0.1.tgz",
@@ -4615,14 +4607,6 @@
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
-    "deep-assign": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/deep-assign/-/deep-assign-3.0.0.tgz",
-      "integrity": "sha512-YX2i9XjJ7h5q/aQ/IM9PEwEnDqETAIYbggmdDB3HLTlSgo1CxPsj6pvhPG68rq6SVE0+p+6Ywsm5fTYNrYtBWw==",
-      "requires": {
-        "is-obj": "^1.0.0"
-      }
-    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -6960,11 +6944,6 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true
-    },
-    "is-obj": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
     },
     "is-plain-object": {
       "version": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "test": "jest"
   },
   "dependencies": {
-    "@react-native-async-storage/async-storage": "^1.15.5",
     "expensify-common": "git+https://github.com/Expensify/expensify-common.git#2e5cff552cf132da90a3fb9756e6b4fb6ae7b40c",
     "lodash": "4.17.21",
     "react": "^16.13.1",
@@ -40,6 +39,9 @@
     "react-native": "0.64.1",
     "react-test-renderer": "16.13.1",
     "metro-react-native-babel-preset": "^0.61.0"
+  },
+  "peerDependencies": {
+    "@react-native-async-storage/async-storage": "^1.15.5"
   },
   "jest": {
     "preset": "react-native",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@react-native-community/async-storage": "^1.12.1",
+    "@react-native-async-storage/async-storage": "^1.15.5",
     "expensify-common": "git+https://github.com/Expensify/expensify-common.git#2e5cff552cf132da90a3fb9756e6b4fb6ae7b40c",
     "lodash": "4.17.21",
     "react": "^16.13.1",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@babel/preset-env": "^7.11.0",
     "@babel/preset-react": "^7.10.4",
     "@babel/runtime": "^7.11.2",
+    "@react-native-async-storage/async-storage": "^1.15.5",
     "@react-native-community/eslint-config": "^2.0.0",
     "@testing-library/jest-native": "^3.4.2",
     "@testing-library/react-native": "^7.0.2",

--- a/tests/unit/cacheEvictionTest.js
+++ b/tests/unit/cacheEvictionTest.js
@@ -1,4 +1,4 @@
-import AsyncStorage from '@react-native-community/async-storage';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import Onyx from '../../index';
 import waitForPromisesToResolve from '../utils/waitForPromisesToResolve';
 

--- a/tests/unit/onyxCacheTest.js
+++ b/tests/unit/onyxCacheTest.js
@@ -410,7 +410,7 @@ describe('Onyx', () => {
             const OnyxModule = require('../../index');
             Onyx = OnyxModule.default;
             withOnyx = OnyxModule.withOnyx;
-            AsyncStorageMock = require('@react-native-community/async-storage').default;
+            AsyncStorageMock = require('@react-native-async-storage/async-storage').default;
             cache = require('../../lib/OnyxCache').default;
 
             Onyx.init({


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->
@tgolen 

### Details
<!-- Explanation of the change or anything fishy that is going on -->
The package `@react-native-community/async-storage` is deprecated from `@react-native-community` repo 
It's moved and maintained as `@react-native-async-storage/async-storage` 
There are some improvements that have happened since then
There are no breaking changes listed

#### The package is listed in `peerDependencies` now 
Libraries that are managed by the parent project should be listed as `peerDependencies`
There are some gradle settings that are tweaked from E.cash
a peer dependency ensures the app is using the same module in both Onyx and E.cash

#### The package is listed as a `devDependency` as well 
- npm 6 would not install `peerDependencies` during `npm install` 
- it's added as `devDependency` so that it is installed and used in tests
- while when `react-native-onyx` is installed in a project - onyx will use the version of AsyncStorage that E.cash provides

#### This update need to go hand in hand with E.cash
- E.cash needs to install the new `@react-native-async-storage/async-storage` (as a regular dependency)
- And also update Onyx's hash to the current repository

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
- https://github.com/Expensify/Expensify.cash/issues/2667#issuecomment-874274118
- https://github.com/Expensify/Expensify.cash/issues/2667#issuecomment-875062880

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
Updated tests to use the newer library mock

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->
https://github.com/Expensify/Expensify.cash/pull/3898