### PR TITLE
Update react to v17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10602,13 +10602,13 @@
       "dev": true
     },
     "react": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
+        "object-assign": "^4.1.1"
       }
     },
     "react-devtools-core": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   "dependencies": {
     "expensify-common": "git+https://github.com/Expensify/expensify-common.git#2e5cff552cf132da90a3fb9756e6b4fb6ae7b40c",
     "lodash": "4.17.21",
-    "react": "^16.13.1",
     "underscore": "^1.13.1"
   },
   "devDependencies": {
@@ -37,12 +36,14 @@
     "jest": "^26.5.2",
     "jest-cli": "^26.5.2",
     "prop-types": "^15.7.2",
+    "react": "^17.0.2",
     "react-native": "0.64.1",
     "react-test-renderer": "16.13.1",
     "metro-react-native-babel-preset": "^0.61.0"
   },
   "peerDependencies": {
-    "@react-native-async-storage/async-storage": "^1.15.5"
+    "@react-native-async-storage/async-storage": "^1.15.5",
+    "react": "^17.0.2"
   },
   "jest": {
     "preset": "react-native",


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
E.cash is using react v17 while onyx is using v16
Moved React to peer dependencies as this makes sure E.cash and Onyx are using the same instance of React - the one installed by the parent project.
More details are available here: https://github.com/Expensify/react-native-onyx/pull/85 and here https://github.com/Expensify/react-native-onyx/pull/85#discussion_r665679997

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
No related tickets

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->

