### PR TITLE
Onyx optimizations

### DIFF
--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -36,69 +36,37 @@ let MAX_CACHED_KEYS = 150;
 const deferredInit = createDeferredTask();
 
 /**
- * Get multiple keys in a single batch
- *
- * @param {string[]} keys
- * @returns {Promise<Record<string, *>>} - an object of key -> value mapping
- */
-function multiGet(keys) {
-    const [fromCache, hardReads] = _.partition(
-        keys,
-        key => cache.hasCacheForKey(key) || cache.hasPendingTask(`get:${key}`)
-    );
-
-    // Init a list of tasks containing any pending reads from storage
-    const tasks = fromCache
-        .filter(key => cache.hasPendingTask(`get:${key}`))
-        .map(key => Promise.resolve(cache.getTaskPromise(`get:${key}`)));
-
-    // Append a task for any remaining "hard reads" the current list
-    if (hardReads.length > 0) {
-        const readKeysFromStorage = AsyncStorage.multiGet(hardReads)
-            .then(pairs => pairs.forEach(([key, val]) => {
-                const parsed = val && JSON.parse(val);
-                cache.set(key, parsed || null);
-            }));
-
-        tasks.push(readKeysFromStorage);
-
-        /* Capture a resolver for potential multiGet calls that happen while we retrieve keys
-        * example one one call retrieves keys A,B,C another call retrieves B,C,D
-        * we don't need to start a new read for B,C we'll hook them from the first call
-        */
-        hardReads.forEach((key) => {
-            cache.captureTask(`get:${key}`, readKeysFromStorage.then(() => cache.getValue(key)));
-        });
-    }
-
-    // Return a grouped result
-    return Promise.all(tasks)
-        .then(() => {
-            /* At this point we have everything in cache
-            * Instead of searching for the value inside the result, we can retrieved it by key from cache */
-            const result = _.chain(keys)
-                .map((key) => {
-                    // eslint-disable-next-line no-use-before-define
-                    addLastAccessedKey(key);
-                    return [key, cache.getValue(key)];
-                })
-                .object()
-                .value();
-
-            return result;
-        });
-}
-
-/**
  * Get some data from the store
  *
  * @param {string} key
  * @returns {Promise<*>}
  */
 function get(key) {
-    /* We use multiGet as it will batch multiple calls and flush them on the next iteration of
-    * the event loop. AsyncStorage uses `setImmediate` to do this internally */
-    return multiGet([key]).then(result => result[key]);
+    // eslint-disable-next-line no-use-before-define
+    addLastAccessedKey(key);
+
+    // When we already have the value in cache - resolve right away
+    if (cache.hasCacheForKey(key)) {
+        return Promise.resolve(cache.getValue(key));
+    }
+
+    const taskName = `get:${key}`;
+
+    // When a value retrieving task for this key is still running hook to it
+    if (cache.hasPendingTask(taskName)) {
+        return cache.getTaskPromise(taskName);
+    }
+
+    // Otherwise retrieve the value from storage and capture a promise to aid concurrent usages
+    const promise = AsyncStorage.getItem(key)
+        .then((val) => {
+            const parsed = val && JSON.parse(val);
+            cache.set(key, parsed);
+            return parsed;
+        })
+        .catch(err => logInfo(`Unable to get item from persistent storage. Key: ${key} Error: ${err}`));
+
+    return cache.captureTask(taskName, promise);
 }
 
 /**
@@ -367,24 +335,6 @@ function sendDataToConnection(config, val, key) {
 }
 
 /**
- *  Retrieve all the connections that should be made for a given mapping
- * @param {object} mapping
- * @param {string} mapping.key
- *
- * @returns {Promise<string[]>}
- */
-function getKeysToConnectTo(mapping) {
-    if (isCollectionKey(mapping.key)) {
-        // Find all collection items keys matching this mapping
-        return getAllKeys()
-            .then(keys => _.filter(keys, key => isKeyMatch(mapping.key, key)));
-    }
-
-    // Otherwise it's just a single item, wrap it in a list
-    return Promise.resolve([mapping.key]);
-}
-
-/**
  * Subscribes a react component's state directly to a store key
  *
  * @param {object} mapping the mapping information to connect Onyx to the components state
@@ -417,27 +367,34 @@ function connect(mapping) {
             }
         }
     })
-        .then(() => getKeysToConnectTo(mapping))
-        .then((matchingKeys) => {
-            // When there are no matching keys, initialize the value with null
+        .then(getAllKeys)
+        .then((keys) => {
+            // Find all the keys matched by the config key
+            const matchingKeys = _.filter(keys, key => isKeyMatch(mapping.key, key));
+
+            // If the key being connected to does not exist, initialize the value with null
             if (matchingKeys.length === 0) {
                 sendDataToConnection(mapping, null);
-                return [];
+                return;
             }
 
-            return multiGet(matchingKeys);
-        })
-        .then((result) => {
-            /* For React components subscribed to collections we want to send the data
-            *  as a single object and trigger setState just once */
+            // When using a callback subscriber we will trigger the callback
+            // for each key we find. It's up to the subscriber to know whether
+            // to expect a single key or multiple keys in the case of a collection.
+            // React components are an exception since we'll want to send their
+            // initial data as a single object when using collection keys.
             if (mapping.withOnyxInstance && isCollectionKey(mapping.key)) {
-                return sendDataToConnection(mapping, result);
+                Promise.all(_.map(matchingKeys, key => get(key)))
+                    .then(values => _.reduce(values, (finalObject, value, i) => ({
+                        ...finalObject,
+                        [matchingKeys[i]]: value,
+                    }), {}))
+                    .then(val => sendDataToConnection(mapping, val));
+            } else {
+                _.each(matchingKeys, (key) => {
+                    get(key).then(val => sendDataToConnection(mapping, val, key));
+                });
             }
-
-            /* When using a callback subscriber we will trigger the callback
-            *  for each key we find. It's up to the subscriber to know whether
-            *  to expect a single key or multiple keys in the case of a collection. */
-            _.each(result, (val, key) => sendDataToConnection(mapping, val, key));
         });
 
     return connectionID;
@@ -814,7 +771,6 @@ function applyDecorators() {
     // Re-assign with decorated functions
     /* eslint-disable no-func-assign */
     get = decorate.decorateWithMetrics(get, 'Onyx:get');
-    multiGet = decorate.decorateWithMetrics(multiGet, 'Onyx:multiGet');
     set = decorate.decorateWithMetrics(set, 'Onyx:set');
     multiSet = decorate.decorateWithMetrics(multiSet, 'Onyx:multiSet');
     clear = decorate.decorateWithMetrics(clear, 'Onyx:clear');

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -28,6 +28,13 @@ const evictionBlocklist = {};
 // Optional user-provided key value states set when Onyx initializes or clears
 let defaultKeyStates = {};
 
+// Connections can be made before `Onyx.init`. They would wait for this promise before resolving
+const deferredInit = {};
+deferredInit.promise = new Promise((res, rej) => {
+    deferredInit.resolve = res;
+    deferredInit.reject = rej;
+});
+
 /**
  * Get some data from the store
  *
@@ -359,18 +366,20 @@ function connect(mapping) {
         return connectionID;
     }
 
-    // Check to see if this key is flagged as a safe eviction key and add it to the recentlyAccessedKeys list
-    if (mapping.withOnyxInstance && !isCollectionKey(mapping.key) && isSafeEvictionKey(mapping.key)) {
+    // Commit connection only after init passes
+    deferredInit.promise.then(() => {
+        // Check to see if this key is flagged as a safe eviction key and add it to the recentlyAccessedKeys list
+        if (mapping.withOnyxInstance && !isCollectionKey(mapping.key) && isSafeEvictionKey(mapping.key)) {
         // All React components subscribing to a key flagged as a safe eviction
         // key must implement the canEvict property.
-        if (_.isUndefined(mapping.canEvict)) {
+            if (_.isUndefined(mapping.canEvict)) {
             // eslint-disable-next-line max-len
-            throw new Error(`Cannot subscribe to safe eviction key '${mapping.key}' without providing a canEvict value.`);
+                throw new Error(`Cannot subscribe to safe eviction key '${mapping.key}' without providing a canEvict value.`);
+            }
+            addLastAccessedKey(mapping.key);
         }
-        addLastAccessedKey(mapping.key);
-    }
-
-    getAllKeys()
+    })
+        .then(getAllKeys)
         .then((keys) => {
             // Find all the keys matched by the config key
             const matchingKeys = _.filter(keys, key => isKeyMatch(mapping.key, key));
@@ -742,6 +751,9 @@ function init({
         cache.set(key, newValue);
         keyChanged(key, newValue);
     });
+
+    // Give green light to any pending connections
+    deferredInit.resolve();
 }
 
 const Onyx = {

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -411,12 +411,14 @@ function cleanCache() {
         /* Keep any other items with active connections
         * Note: after `splice` the array no longer contains the `mostRecent` */
         const stillConnected = recentlyAccessedKeys.filter((key) => {
-            const hasRemainingConnections = _.some(callbackToStateMapping, mapping => key.startsWith(mapping.key));
-            if (!hasRemainingConnections) {
+            const shouldKeep = _.has(defaultKeyStates, key)
+                || _.some(callbackToStateMapping, mapping => key.startsWith(mapping.key));
+
+            if (!shouldKeep) {
                 cache.drop(key);
             }
 
-            return hasRemainingConnections;
+            return shouldKeep;
         });
 
         recentlyAccessedKeys = stillConnected.concat(mostRecent);
@@ -616,7 +618,7 @@ function merge(key, val) {
 }
 
 /**
- * Merge user provided default key value pairs.
+ * Merge stored data and user provided default key value pairs to cache
  *
  * @returns {Promise<void>}
  */
@@ -643,12 +645,13 @@ function clear() {
     return getAllKeys()
         .then((keys) => {
             _.each(keys, (key) => {
-                keyChanged(key, null);
-                cache.set(key, null);
+                if (!_.has(defaultKeyStates, key)) {
+                    keyChanged(key, null);
+                    cache.set(key, null);
+                }
             });
         })
-        .then(AsyncStorage.clear)
-        .then(initializeWithDefaultKeyStates);
+        .then(AsyncStorage.clear);
 }
 
 /**

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -561,6 +561,11 @@ function evictStorageAndRetry(error, ionMethod, ...args) {
  * @returns {Promise}
  */
 function set(key, val) {
+    // Skip writing to storage if the value hasn't changed
+    if (cache.hasCacheForKey(key) && _.isEqual(val, cache.getValue(key))) {
+        return Promise.resolve();
+    }
+
     // Adds the key to cache when it's not available
     cache.set(key, val);
 

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -597,11 +597,12 @@ function applyMerge(key, data) {
 function merge(key, val) {
     if (mergeQueue[key]) {
         mergeQueue[key].push(val);
-        return Promise.resolve();
+        return merge.lastPromise;
     }
 
+    // Capture a promise that will resolve when this queue is written
     mergeQueue[key] = [val];
-    return get(key)
+    merge.lastPromise = get(key)
         .then((data) => {
             const modifiedData = applyMerge(key, data);
 
@@ -610,6 +611,8 @@ function merge(key, val) {
             delete mergeQueue[key];
             return set(key, modifiedData);
         });
+
+    return merge.lastPromise;
 }
 
 /**

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -36,34 +36,65 @@ deferredInit.promise = new Promise((res, rej) => {
 });
 
 /**
+ * Get multiple keys in a single batch
+ *
+ * @param {string[]} keys
+ * @returns {Promise<Record<string, *>>} - an object of key -> value mapping
+ */
+function multiGet(keys) {
+    const [fromCache, hardReads] = _.partition(
+        keys,
+        key => cache.hasCacheForKey(key) || cache.hasPendingTask(`get:${key}`)
+    );
+
+    // Init a list of tasks containing any pending reads from storage
+    const tasks = fromCache
+        .filter(key => cache.hasPendingTask(`get:${key}`))
+        .map(key => Promise.resolve(cache.getTaskPromise(`get:${key}`)));
+
+    // Append a task for any remaining "hard reads" the current list
+    if (hardReads.length > 0) {
+        const readKeysFromStorage = AsyncStorage.multiGet(hardReads)
+            .then(pairs => pairs.forEach(([key, val]) => {
+                const parsed = val && JSON.parse(val);
+                cache.set(key, parsed || null);
+            }));
+
+        tasks.push(readKeysFromStorage);
+
+        /* Capture a resolver for potential multiGet calls that happen while we retrieve keys
+        * example one one call retrieves keys A,B,C another call retrieves B,C,D
+        * we don't need to start a new read for B,C we'll hook them from the first call
+        */
+        hardReads.forEach((key) => {
+            cache.captureTask(`get:${key}`, readKeysFromStorage.then(() => cache.getValue(key)));
+        });
+    }
+
+    // Return a grouped result
+    return Promise.all(tasks)
+        .then(() => {
+            /* At this point we have everything in cache
+            * Instead of searching for the value inside the result, we can retrieved it by key from cache */
+            const result = _.chain(keys)
+                .map(key => [key, cache.getValue(key)])
+                .object()
+                .value();
+
+            return result;
+        });
+}
+
+/**
  * Get some data from the store
  *
  * @param {string} key
  * @returns {Promise<*>}
  */
 function get(key) {
-    // When we already have the value in cache - resolve right away
-    if (cache.hasCacheForKey(key)) {
-        return Promise.resolve(cache.getValue(key));
-    }
-
-    const taskName = `get:${key}`;
-
-    // When a value retrieving task for this key is still running hook to it
-    if (cache.hasPendingTask(taskName)) {
-        return cache.getTaskPromise(taskName);
-    }
-
-    // Otherwise retrieve the value from storage and capture a promise to aid concurrent usages
-    const promise = AsyncStorage.getItem(key)
-        .then((val) => {
-            const parsed = val && JSON.parse(val);
-            cache.set(key, parsed);
-            return parsed;
-        })
-        .catch(err => logInfo(`Unable to get item from persistent storage. Key: ${key} Error: ${err}`));
-
-    return cache.captureTask(taskName, promise);
+    /* We use multiGet as it will batch multiple calls and flush them on the next iteration of
+    * the event loop. AsyncStorage uses `setImmediate` to do this internally */
+    return multiGet([key]).then(result => result[key]);
 }
 
 /**
@@ -781,6 +812,7 @@ function applyDecorators() {
     // Re-assign with decorated functions
     /* eslint-disable no-func-assign */
     get = decorate.decorateWithMetrics(get, 'Onyx:get');
+    multiGet = decorate.decorateWithMetrics(multiGet, 'Onyx:multiGet');
     set = decorate.decorateWithMetrics(set, 'Onyx:set');
     multiSet = decorate.decorateWithMetrics(multiSet, 'Onyx:multiSet');
     clear = decorate.decorateWithMetrics(clear, 'Onyx:clear');

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -4,6 +4,7 @@ import Str from 'expensify-common/lib/str';
 import lodashMerge from 'lodash/merge';
 import {registerLogger, logInfo, logAlert} from './Logger';
 import cache from './OnyxCache';
+import createDeferredTask from './createDeferredTask';
 
 // Keeps track of the last connectionID that was used so we can keep incrementing it
 let lastConnectionID = 0;
@@ -29,11 +30,7 @@ const evictionBlocklist = {};
 let defaultKeyStates = {};
 
 // Connections can be made before `Onyx.init`. They would wait for this promise before resolving
-const deferredInit = {};
-deferredInit.promise = new Promise((res, rej) => {
-    deferredInit.resolve = res;
-    deferredInit.reject = rej;
-});
+const deferredInit = createDeferredTask();
 
 /**
  * Get multiple keys in a single batch

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -29,6 +29,9 @@ const evictionBlocklist = {};
 // Optional user-provided key value states set when Onyx initializes or clears
 let defaultKeyStates = {};
 
+// Cache cleaning uses this to remove least recently accessed keys
+let MAX_CACHED_KEYS = 150;
+
 // Connections can be made before `Onyx.init`. They would wait for this promise before resolving
 const deferredInit = createDeferredTask();
 
@@ -74,7 +77,11 @@ function multiGet(keys) {
             /* At this point we have everything in cache
             * Instead of searching for the value inside the result, we can retrieved it by key from cache */
             const result = _.chain(keys)
-                .map(key => [key, cache.getValue(key)])
+                .map((key) => {
+                    // eslint-disable-next-line no-use-before-define
+                    addLastAccessedKey(key);
+                    return [key, cache.getValue(key)];
+                })
                 .object()
                 .value();
 
@@ -134,19 +141,6 @@ function isCollectionKey(key) {
 }
 
 /**
- * Find the collection a collection item belongs to
- * or return null if them item is not a part of a collection
- * @param {string} key
- * @returns {string|null}
- */
-function getCollectionKeyForItem(key) {
-    return _.chain(onyxKeys.COLLECTION)
-        .values()
-        .find(name => key.startsWith(name))
-        .value();
-}
-
-/**
  * Checks to see if a given key matches with the
  * configured key of our connected subscriber
  *
@@ -189,7 +183,7 @@ function removeLastAccessedKey(key) {
  */
 function addLastAccessedKey(key) {
     // Only specific keys belong in this list since we cannot remove an entire collection.
-    if (isCollectionKey(key) || !isSafeEvictionKey(key)) {
+    if (isCollectionKey(key)) {
         return;
     }
 
@@ -414,15 +408,13 @@ function connect(mapping) {
 
     // Commit connection only after init passes
     deferredInit.promise.then(() => {
-        // Check to see if this key is flagged as a safe eviction key and add it to the recentlyAccessedKeys list
-        if (mapping.withOnyxInstance && !isCollectionKey(mapping.key) && isSafeEvictionKey(mapping.key)) {
         // All React components subscribing to a key flagged as a safe eviction
         // key must implement the canEvict property.
+        if (mapping.withOnyxInstance && !isCollectionKey(mapping.key) && isSafeEvictionKey(mapping.key)) {
             if (_.isUndefined(mapping.canEvict)) {
-            // eslint-disable-next-line max-len
+                // eslint-disable-next-line max-len
                 throw new Error(`Cannot subscribe to safe eviction key '${mapping.key}' without providing a canEvict value.`);
             }
-            addLastAccessedKey(mapping.key);
         }
     })
         .then(() => getKeysToConnectTo(mapping))
@@ -452,40 +444,26 @@ function connect(mapping) {
 }
 
 /**
- * Remove cache items that are no longer connected through Onyx
- * @param {string} key
+ * Used to periodically clean least recently accessed items from cache
  */
-function cleanCache(key) {
-    const hasRemainingConnections = _.some(callbackToStateMapping, {key});
+function cleanCache() {
+    if (recentlyAccessedKeys.length > MAX_CACHED_KEYS) {
+        // Keep the most recent
+        const mostRecent = recentlyAccessedKeys.splice(recentlyAccessedKeys.length - MAX_CACHED_KEYS, MAX_CACHED_KEYS);
 
-    // When the key is still used in other places don't remove it from cache
-    if (hasRemainingConnections) {
-        return;
+        /* Keep any other items with active connections
+        * Note: after `splice` the array no longer contains the `mostRecent` */
+        const stillConnected = recentlyAccessedKeys.filter((key) => {
+            const hasRemainingConnections = _.some(callbackToStateMapping, mapping => key.startsWith(mapping.key));
+            if (!hasRemainingConnections) {
+                cache.drop(key);
+            }
+
+            return hasRemainingConnections;
+        });
+
+        recentlyAccessedKeys = stillConnected.concat(mostRecent);
     }
-
-    // When this is a collection - also recursively remove any unused individual items
-    if (isCollectionKey(key)) {
-        cache.drop(key);
-
-        getAllKeys().then(cachedKeys => _.chain(cachedKeys)
-            .filter(name => name.startsWith(key))
-            .forEach(cleanCache));
-
-        return;
-    }
-
-    // When this is a collection item - check if the collection is still used
-    const collectionKey = getCollectionKeyForItem(key);
-    if (collectionKey) {
-        // When there's an active subscription for a collection don't remove the item
-        const hasRemainingConnectionsForCollection = _.some(callbackToStateMapping, {key: collectionKey});
-        if (hasRemainingConnectionsForCollection) {
-            return;
-        }
-    }
-
-    // Otherwise remove the value from cache
-    cache.drop(key);
 }
 
 /**
@@ -505,11 +483,10 @@ function disconnect(connectionID, keyToRemoveFromEvictionBlocklist) {
         removeFromEvictionBlockList(keyToRemoveFromEvictionBlocklist, connectionID);
     }
 
-    const key = callbackToStateMapping[connectionID].key;
     delete callbackToStateMapping[connectionID];
 
-    // When the last subscriber disconnects, drop cache as well
-    cleanCache(key);
+    // Check if anything can be removed from cache
+    cleanCache();
 }
 
 /**
@@ -540,7 +517,10 @@ function remove(key) {
  */
 function evictStorageAndRetry(error, ionMethod, ...args) {
     // Find the first key that we can remove that has no subscribers in our blocklist
-    const keyForRemoval = _.find(recentlyAccessedKeys, key => !evictionBlocklist[key]);
+    const keyForRemoval = _.find(
+        recentlyAccessedKeys,
+        key => !evictionBlocklist[key] && isSafeEvictionKey(key),
+    );
 
     if (!keyForRemoval) {
         logAlert('Out of storage. But found no acceptable keys to remove.');
@@ -754,7 +734,9 @@ function mergeCollection(collectionKey, collection) {
 /**
  * Initialize the store with actions and listening for storage events
  *
- * @param {Object} [options]
+ * @param {Object} options
+ * @param {Object} [options.keys]
+ * @param {Object} [options.initialKeyStates]
  * @param {String[]} [options.safeEvictionKeys] This is an array of keys
  * (individual or collection patterns) that when provided to Onyx are flagged
  * as "safe" for removal. Any components subscribing to these keys must also
@@ -762,6 +744,8 @@ function mergeCollection(collectionKey, collection) {
  * @param {function} registerStorageEventListener a callback when a storage event happens.
  * This applies to web platforms where the local storage emits storage events
  * across all open tabs and allows Onyx to stay in sync across all open tabs.
+ * @param {Number} [options.maxCachedKeysCount=150] Sets how many recent keys should we try to keep in cache
+ * Setting this to 0 would only keep active connections in cache
  * @param {Boolean} [options.captureMetrics]
  */
 function init({
@@ -769,12 +753,17 @@ function init({
     initialKeyStates,
     safeEvictionKeys,
     registerStorageEventListener,
+    maxCachedKeysCount,
     captureMetrics = false,
 }) {
     if (captureMetrics) {
         // The code here is only bundled and applied when the captureMetrics is set
         // eslint-disable-next-line no-use-before-define
         applyDecorators();
+    }
+
+    if (_.isNumber(maxCachedKeysCount)) {
+        MAX_CACHED_KEYS = maxCachedKeysCount;
     }
 
     // Let Onyx know about all of our keys

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -621,8 +621,17 @@ function merge(key, val) {
  * @returns {Promise<void>}
  */
 function initializeWithDefaultKeyStates() {
-    const prepared = prepareKeyValuePairsForStorage(defaultKeyStates);
-    return AsyncStorage.multiMerge(prepared);
+    return AsyncStorage.multiGet(_.keys(defaultKeyStates))
+        .then((pairs) => {
+            const asObject = _.chain(pairs)
+                .map(([key, val]) => [key, val && JSON.parse(val)])
+                .object()
+                .value();
+
+            const merged = lodashMerge(asObject, defaultKeyStates);
+            cache.merge(merged);
+            _.each(merged, (val, key) => keyChanged(key, val));
+        });
 }
 
 /**
@@ -781,7 +790,7 @@ function applyDecorators() {
     merge = decorate.decorateWithMetrics(merge, 'Onyx:merge');
     mergeCollection = decorate.decorateWithMetrics(mergeCollection, 'Onyx:mergeCollection');
     getAllKeys = decorate.decorateWithMetrics(getAllKeys, 'Onyx:getAllKeys');
-    AsyncStorage.multiMerge = decorate.decorateWithMetrics(AsyncStorage.multiMerge, 'Async:multiMerge');
+    initializeWithDefaultKeyStates = decorate.decorateWithMetrics(initializeWithDefaultKeyStates, 'Onyx:defaults');
     /* eslint-enable */
 
     // Re-expose decorated methods

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -617,9 +617,12 @@ function merge(key, val) {
 
 /**
  * Merge user provided default key value pairs.
+ *
+ * @returns {Promise<void>}
  */
 function initializeWithDefaultKeyStates() {
-    _.each(defaultKeyStates, (state, key) => merge(key, state));
+    const prepared = prepareKeyValuePairsForStorage(defaultKeyStates);
+    return AsyncStorage.multiMerge(prepared);
 }
 
 /**
@@ -736,17 +739,15 @@ function init({
     evictionAllowList = safeEvictionKeys;
     addAllSafeEvictionKeysToRecentlyAccessedList();
 
-    // Initialize all of our keys with data provided
-    initializeWithDefaultKeyStates();
+    // Initialize all of our keys with data provided then give green light to any pending connections
+    initializeWithDefaultKeyStates()
+        .finally(deferredInit.resolve); // Proceed even if the above task fails
 
     // Update any key whose value changes in storage
     registerStorageEventListener((key, newValue) => {
         cache.set(key, newValue);
         keyChanged(key, newValue);
     });
-
-    // Give green light to any pending connections
-    deferredInit.resolve();
 }
 
 const Onyx = {
@@ -780,6 +781,7 @@ function applyDecorators() {
     merge = decorate.decorateWithMetrics(merge, 'Onyx:merge');
     mergeCollection = decorate.decorateWithMetrics(mergeCollection, 'Onyx:mergeCollection');
     getAllKeys = decorate.decorateWithMetrics(getAllKeys, 'Onyx:getAllKeys');
+    AsyncStorage.multiMerge = decorate.decorateWithMetrics(AsyncStorage.multiMerge, 'Async:multiMerge');
     /* eslint-enable */
 
     // Re-expose decorated methods

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -373,6 +373,24 @@ function sendDataToConnection(config, val, key) {
 }
 
 /**
+ *  Retrieve all the connections that should be made for a given mapping
+ * @param {object} mapping
+ * @param {string} mapping.key
+ *
+ * @returns {Promise<string[]>}
+ */
+function getKeysToConnectTo(mapping) {
+    if (isCollectionKey(mapping.key)) {
+        // Find all collection items keys matching this mapping
+        return getAllKeys()
+            .then(keys => _.filter(keys, key => isKeyMatch(mapping.key, key)));
+    }
+
+    // Otherwise it's just a single item, wrap it in a list
+    return Promise.resolve([mapping.key]);
+}
+
+/**
  * Subscribes a react component's state directly to a store key
  *
  * @param {object} mapping the mapping information to connect Onyx to the components state
@@ -407,34 +425,27 @@ function connect(mapping) {
             addLastAccessedKey(mapping.key);
         }
     })
-        .then(getAllKeys)
-        .then((keys) => {
-            // Find all the keys matched by the config key
-            const matchingKeys = _.filter(keys, key => isKeyMatch(mapping.key, key));
-
-            // If the key being connected to does not exist, initialize the value with null
+        .then(() => getKeysToConnectTo(mapping))
+        .then((matchingKeys) => {
+            // When there are no matching keys, initialize the value with null
             if (matchingKeys.length === 0) {
                 sendDataToConnection(mapping, null);
-                return;
+                return [];
             }
 
-            // When using a callback subscriber we will trigger the callback
-            // for each key we find. It's up to the subscriber to know whether
-            // to expect a single key or multiple keys in the case of a collection.
-            // React components are an exception since we'll want to send their
-            // initial data as a single object when using collection keys.
+            return multiGet(matchingKeys);
+        })
+        .then((result) => {
+            /* For React components subscribed to collections we want to send the data
+            *  as a single object and trigger setState just once */
             if (mapping.withOnyxInstance && isCollectionKey(mapping.key)) {
-                Promise.all(_.map(matchingKeys, key => get(key)))
-                    .then(values => _.reduce(values, (finalObject, value, i) => ({
-                        ...finalObject,
-                        [matchingKeys[i]]: value,
-                    }), {}))
-                    .then(val => sendDataToConnection(mapping, val));
-            } else {
-                _.each(matchingKeys, (key) => {
-                    get(key).then(val => sendDataToConnection(mapping, val, key));
-                });
+                return sendDataToConnection(mapping, result);
             }
+
+            /* When using a callback subscriber we will trigger the callback
+            *  for each key we find. It's up to the subscriber to know whether
+            *  to expect a single key or multiple keys in the case of a collection. */
+            _.each(result, (val, key) => sendDataToConnection(mapping, val, key));
         });
 
     return connectionID;

--- a/lib/createDeferredTask.js
+++ b/lib/createDeferredTask.js
@@ -1,0 +1,17 @@
+/**
+ * Create a deferred task that can be resolved when we call `resolve()`
+ * The returned promise will complete only when we call `resolve` or `reject`
+ * Useful when we want to wait for a tasks that is resolved from an external action
+ *
+ * @template T
+ * @returns {{ resolve: function(*), reject: function(Error), promise: Promise<T|void> }}
+ */
+export default function createDeferredTask() {
+    const deferred = {};
+    deferred.promise = new Promise((res, rej) => {
+        deferred.resolve = res;
+        deferred.reject = rej;
+    });
+
+    return deferred;
+}

--- a/lib/decorateWithMetrics.js
+++ b/lib/decorateWithMetrics.js
@@ -119,26 +119,45 @@ function toHumanReadableDuration(millis) {
 function printMetrics() {
     const {totalTime, averageTime, summaries} = getMetrics();
 
+    const prettyData = _.chain(summaries)
+        .filter(method => method.avg > 0)
+        .sortBy('avg')
+        .reverse()
+        .map(({calls, methodName, ...summary}) => {
+            const prettyTimes = _.chain(summary)
+                .map((value, key) => ([key, toHumanReadableDuration(value)]))
+                .object()
+                .value();
+
+            const prettyCalls = calls.map(call => ({
+                startTime: toHumanReadableDuration(call.startTime),
+                endTime: toHumanReadableDuration(call.endTime),
+                duration: toHumanReadableDuration(call.duration),
+                args: JSON.stringify(call.args)
+            }));
+
+            return {
+                methodName,
+                ...prettyTimes,
+                calls: calls.length,
+                prettyCalls,
+            };
+        })
+        .value();
+
     /* eslint-disable no-console */
     console.group('Onyx Benchmark');
     console.info('  Total: ', toHumanReadableDuration(totalTime));
     console.info('  Average: ', toHumanReadableDuration(averageTime));
 
-    _.chain(summaries)
-        .sortBy('avg')
-        .reverse()
-        .forEach(({calls, methodName, ...summary}) => {
-            const times = _.map(summary, (value, key) => `${key}: ${toHumanReadableDuration(value)}`);
+    console.table(prettyData.map(({prettyCalls, ...summary}) => summary));
 
-            console.groupCollapsed(`${methodName}\n  ${times.join('\n  ')} \n  calls: ${calls.length}`);
-            console.table(calls.map(call => ({
-                startTime: toHumanReadableDuration(call.startTime),
-                endTime: toHumanReadableDuration(call.endTime),
-                duration: toHumanReadableDuration(call.duration),
-                args: JSON.stringify(call.args)
-            })));
-            console.groupEnd();
-        });
+    prettyData.forEach((method) => {
+        console.groupCollapsed(`[${method.methodName}] individual calls: `);
+        console.table(method.prettyCalls);
+        console.groupEnd();
+    });
+
     console.groupEnd();
     /* eslint-enable */
 }


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->
cc @marcaaron @tgolen 

### Details
This PR contains a few optimizations and refactors
1. The first commit has and updated `Onyx.printMetrics` function. You can use it as a base to compare before/after results. It prints a general table on the console which is easy to copy and put in excel. 
2. Fix: some connections happen even before `Onyx.init` is called. This should not be allowed as the `initialKeyStates` are applied during init. Added a deferred tasks that would queue incoming connections and only make them after init, this also gives the rest of the app init some breathing space
3. Perf: Update `set` to check with cache and skip writing to storage. Cache reflects what's already on disc, if we have the exact value in cache it means it didn't change and we don't need to make a write
4. Perf: Updated cache clearing strategy. It's a mix of LRU and active connections. The cache works in the following way: each time a connection is terminated we run a `cleanCache` function. The function removes dated items from cache, if the item is still being used by a component it's kept in cache. By default it will try to keep up to ~150 keys in cache, can be a bit more due to active connections to old items
5. Refactor: `merge` was refactored so that it's promises are resolved when a queue for a key is done. This helps with measuring the function more accurately
6. Perf: Updated `defaultKeyStates` handling. Merging these keys one by one was taking a significant amount of time, even though they are only 4. Instead of writing them to storage, we read data from storage and merge it along with the defaults to the cache. Then we never allow for the `defaultKeys` to be removed from cache 

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/Expensify.cash/issues/2667

### Automated Tests
Added and updated tests related to changes in cache handling.
The rest of the changes are covered by the existing tests

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->
TBD

### Benchmark results 
There are overall improvements that can be seen in the stats here
https://docs.google.com/spreadsheets/d/1kHRvFL1ITbr4p9TzT_nsmtvCY4KoPwKCXp84FTCsGzk/edit?usp=sharing

##### Android
|                       | Before Updates | After Updates |
|-----------------------|---------------:|--------------:|
| Total Onyx Time       |       55.06sec |      19.67sec |
| Heavy reading ends at |        8.27sec |       5.44sec |

##### iOS
|                       | Before Updates | After Updates |
|-----------------------|---------------:|--------------:|
| Total Onyx Time       |       16.37sec |       8.74sec |
| Heavy reading ends at |        2.96sec |       2.98sec |

- Total: the total time spent by Onyx functions data fetching/writing
- Heavy reading: the point since app launch at which hard reads from disk are over
- The link above contains device information and how the tests were performed
