### PR TITLE
Defer initialization and wait for defaultKeyStates

### DIFF
--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -28,6 +28,13 @@ const evictionBlocklist = {};
 // Optional user-provided key value states set when Onyx initializes or clears
 let defaultKeyStates = {};
 
+// Connections can be made before `Onyx.init`. They would wait for this promise before resolving
+const deferredInit = {};
+deferredInit.promise = new Promise((res, rej) => {
+    deferredInit.resolve = res;
+    deferredInit.reject = rej;
+});
+
 /**
  * Get some data from the store
  *
@@ -359,18 +366,20 @@ function connect(mapping) {
         return connectionID;
     }
 
-    // Check to see if this key is flagged as a safe eviction key and add it to the recentlyAccessedKeys list
-    if (mapping.withOnyxInstance && !isCollectionKey(mapping.key) && isSafeEvictionKey(mapping.key)) {
+    // Commit connection only after init passes
+    deferredInit.promise.then(() => {
+        // Check to see if this key is flagged as a safe eviction key and add it to the recentlyAccessedKeys list
+        if (mapping.withOnyxInstance && !isCollectionKey(mapping.key) && isSafeEvictionKey(mapping.key)) {
         // All React components subscribing to a key flagged as a safe eviction
         // key must implement the canEvict property.
-        if (_.isUndefined(mapping.canEvict)) {
+            if (_.isUndefined(mapping.canEvict)) {
             // eslint-disable-next-line max-len
-            throw new Error(`Cannot subscribe to safe eviction key '${mapping.key}' without providing a canEvict value.`);
+                throw new Error(`Cannot subscribe to safe eviction key '${mapping.key}' without providing a canEvict value.`);
+            }
+            addLastAccessedKey(mapping.key);
         }
-        addLastAccessedKey(mapping.key);
-    }
-
-    getAllKeys()
+    })
+        .then(getAllKeys)
         .then((keys) => {
             // Find all the keys matched by the config key
             const matchingKeys = _.filter(keys, key => isKeyMatch(mapping.key, key));
@@ -742,6 +751,9 @@ function init({
         cache.set(key, newValue);
         keyChanged(key, newValue);
     });
+
+    // Give green light to any pending connections
+    deferredInit.resolve();
 }
 
 const Onyx = {

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -4,6 +4,7 @@ import Str from 'expensify-common/lib/str';
 import lodashMerge from 'lodash/merge';
 import {registerLogger, logInfo, logAlert} from './Logger';
 import cache from './OnyxCache';
+import createDeferredTask from './createDeferredTask';
 
 // Keeps track of the last connectionID that was used so we can keep incrementing it
 let lastConnectionID = 0;
@@ -29,11 +30,7 @@ const evictionBlocklist = {};
 let defaultKeyStates = {};
 
 // Connections can be made before `Onyx.init`. They would wait for this promise before resolving
-const deferredInit = {};
-deferredInit.promise = new Promise((res, rej) => {
-    deferredInit.resolve = res;
-    deferredInit.reject = rej;
-});
+const deferredInit = createDeferredTask();
 
 /**
  * Get some data from the store

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -203,9 +203,11 @@ function addToEvictionBlockList(key, connectionID) {
  * the recently accessed list when initializing the app. This
  * enables keys that have not recently been accessed to be
  * removed.
+ *
+ * @returns {Promise}
  */
 function addAllSafeEvictionKeysToRecentlyAccessedList() {
-    getAllKeys()
+    return getAllKeys()
         .then((keys) => {
             _.each(evictionAllowList, (safeEvictionKey) => {
                 _.each(keys, (key) => {
@@ -636,7 +638,7 @@ function merge(key, val) {
 /**
  * Merge user provided default key value pairs.
  *
- * @returns {Promise<void>}
+ * @returns {Promise}
  */
 function initializeWithDefaultKeyStates() {
     return AsyncStorage.multiGet(_.keys(defaultKeyStates))
@@ -757,11 +759,13 @@ function init({
 
     // Let Onyx know about which keys are safe to evict
     evictionAllowList = safeEvictionKeys;
-    addAllSafeEvictionKeysToRecentlyAccessedList();
 
     // Initialize all of our keys with data provided then give green light to any pending connections
-    initializeWithDefaultKeyStates()
-        .finally(deferredInit.resolve); // Proceed even if the above task fails
+    Promise.all([
+        addAllSafeEvictionKeysToRecentlyAccessedList(),
+        initializeWithDefaultKeyStates()
+    ])
+        .then(deferredInit.resolve);
 
     // Update any key whose value changes in storage
     registerStorageEventListener((key, newValue) => {

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -414,6 +414,11 @@ function connect(mapping) {
  * @param {string} key
  */
 function cleanCache(key) {
+    // Don't remove default keys from cache, they don't take much memory and are accessed frequently
+    if (_.has(defaultKeyStates, key)) {
+        return;
+    }
+
     const hasRemainingConnections = _.some(callbackToStateMapping, {key});
 
     // When the key is still used in other places don't remove it from cache

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -630,9 +630,21 @@ function merge(key, val) {
 
 /**
  * Merge user provided default key value pairs.
+ *
+ * @returns {Promise<void>}
  */
 function initializeWithDefaultKeyStates() {
-    _.each(defaultKeyStates, (state, key) => merge(key, state));
+    return AsyncStorage.multiGet(_.keys(defaultKeyStates))
+        .then((pairs) => {
+            const asObject = _.chain(pairs)
+                .map(([key, val]) => [key, val && JSON.parse(val)])
+                .object()
+                .value();
+
+            const merged = lodashMerge(asObject, defaultKeyStates);
+            cache.merge(merged);
+            _.each(merged, (val, key) => keyChanged(key, val));
+        });
 }
 
 /**
@@ -707,7 +719,9 @@ function mergeCollection(collectionKey, collection) {
 /**
  * Initialize the store with actions and listening for storage events
  *
- * @param {Object} [options]
+ * @param {Object} options
+ * @param {Object} [options.keys]
+ * @param {Object} [options.initialKeyStates]
  * @param {String[]} [options.safeEvictionKeys] This is an array of keys
  * (individual or collection patterns) that when provided to Onyx are flagged
  * as "safe" for removal. Any components subscribing to these keys must also
@@ -740,17 +754,15 @@ function init({
     evictionAllowList = safeEvictionKeys;
     addAllSafeEvictionKeysToRecentlyAccessedList();
 
-    // Initialize all of our keys with data provided
-    initializeWithDefaultKeyStates();
+    // Initialize all of our keys with data provided then give green light to any pending connections
+    initializeWithDefaultKeyStates()
+        .finally(deferredInit.resolve); // Proceed even if the above task fails
 
     // Update any key whose value changes in storage
     registerStorageEventListener((key, newValue) => {
         cache.set(key, newValue);
         keyChanged(key, newValue);
     });
-
-    // Give green light to any pending connections
-    deferredInit.resolve();
 }
 
 const Onyx = {
@@ -784,6 +796,7 @@ function applyDecorators() {
     merge = decorate.decorateWithMetrics(merge, 'Onyx:merge');
     mergeCollection = decorate.decorateWithMetrics(mergeCollection, 'Onyx:mergeCollection');
     getAllKeys = decorate.decorateWithMetrics(getAllKeys, 'Onyx:getAllKeys');
+    initializeWithDefaultKeyStates = decorate.decorateWithMetrics(initializeWithDefaultKeyStates, 'Onyx:defaults');
     /* eslint-enable */
 
     // Re-expose decorated methods

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -29,8 +29,8 @@ const evictionBlocklist = {};
 // Optional user-provided key value states set when Onyx initializes or clears
 let defaultKeyStates = {};
 
-// Connections can be made before `Onyx.init`. They would wait for this promise before resolving
-const deferredInit = createDeferredTask();
+// Connections can be made before `Onyx.init`. They would wait for this task before resolving
+const deferredInitTask = createDeferredTask();
 
 /**
  * Get some data from the store
@@ -366,18 +366,19 @@ function connect(mapping) {
     }
 
     // Commit connection only after init passes
-    deferredInit.promise.then(() => {
-        // Check to see if this key is flagged as a safe eviction key and add it to the recentlyAccessedKeys list
-        if (mapping.withOnyxInstance && !isCollectionKey(mapping.key) && isSafeEvictionKey(mapping.key)) {
-        // All React components subscribing to a key flagged as a safe eviction
-        // key must implement the canEvict property.
-            if (_.isUndefined(mapping.canEvict)) {
-            // eslint-disable-next-line max-len
-                throw new Error(`Cannot subscribe to safe eviction key '${mapping.key}' without providing a canEvict value.`);
+    deferredInitTask.promise
+        .then(() => {
+            // Check to see if this key is flagged as a safe eviction key and add it to the recentlyAccessedKeys list
+            if (mapping.withOnyxInstance && !isCollectionKey(mapping.key) && isSafeEvictionKey(mapping.key)) {
+                // All React components subscribing to a key flagged as a safe eviction
+                // key must implement the canEvict property.
+                if (_.isUndefined(mapping.canEvict)) {
+                    // eslint-disable-next-line max-len
+                    throw new Error(`Cannot subscribe to safe eviction key '${mapping.key}' without providing a canEvict value.`);
+                }
+                addLastAccessedKey(mapping.key);
             }
-            addLastAccessedKey(mapping.key);
-        }
-    })
+        })
         .then(getAllKeys)
         .then((keys) => {
             // Find all the keys matched by the config key
@@ -765,7 +766,7 @@ function init({
         addAllSafeEvictionKeysToRecentlyAccessedList(),
         initializeWithDefaultKeyStates()
     ])
-        .then(deferredInit.resolve);
+        .then(deferredInitTask.resolve);
 
     // Update any key whose value changes in storage
     registerStorageEventListener((key, newValue) => {

--- a/lib/createDeferredTask.js
+++ b/lib/createDeferredTask.js
@@ -1,16 +1,15 @@
 /**
  * Create a deferred task that can be resolved when we call `resolve()`
- * The returned promise will complete only when we call `resolve` or `reject`
+ * The returned promise will complete when we call `resolve`
  * Useful when we want to wait for a tasks that is resolved from an external action
  *
  * @template T
- * @returns {{ resolve: function(*), reject: function(Error), promise: Promise<T|void> }}
+ * @returns {{ resolve: function(*), promise: Promise<T|void> }}
  */
 export default function createDeferredTask() {
     const deferred = {};
-    deferred.promise = new Promise((res, rej) => {
+    deferred.promise = new Promise((res) => {
         deferred.resolve = res;
-        deferred.reject = rej;
     });
 
     return deferred;

--- a/lib/createDeferredTask.js
+++ b/lib/createDeferredTask.js
@@ -1,0 +1,17 @@
+/**
+ * Create a deferred task that can be resolved when we call `resolve()`
+ * The returned promise will complete only when we call `resolve` or `reject`
+ * Useful when we want to wait for a tasks that is resolved from an external action
+ *
+ * @template T
+ * @returns {{ resolve: function(*), reject: function(Error), promise: Promise<T|void> }}
+ */
+export default function createDeferredTask() {
+    const deferred = {};
+    deferred.promise = new Promise((res, rej) => {
+        deferred.resolve = res;
+        deferred.reject = rej;
+    });
+
+    return deferred;
+}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->
@marcaaron 

### Details
<!-- Explanation of the change or anything fishy that is going on -->
##### Make connections wait for Onyx.init
Some connections start really early before Onyx.init is even called
They should wait as Onyx.init adds some initial values that might be needed
Also waiting helps as every call uses `getAllKeys` and the keys are retrieved during init - if connections wait, every following connection would instantly retrieve them from cache, otherwise even though they hook to the same storage read they still create a new promise

##### Read defaults in one go and keep them in cache
Instead of reading default keys, then merging default values to them and then writing them back in storage
We read the default keys in one go, and then write the merged result to cache
We also make sure to never remove the default keys from cache - they don't take much space and are used often

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/App/issues/2667

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
Covered by existing tests

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->

### Benchmarks

##### Android Before 
|                    |     Run 1 |     Run 2 |     Run 3 |     Run 4 |     Run 5 |
|--------------------|----------:|----------:|----------:|----------:|----------:|
| Total              | 124.06sec | 118.71sec | 118.43sec | 116.57sec | 114.24sec |
| Last call ended at |   8.26sec |   7.83sec |   7.25sec |   7.13sec |   7.89sec |
- Full data: https://docs.google.com/spreadsheets/d/1lEZ1dZD77D6zUQgB5A6-QTlX3JdVcyARThKh7-dru_4/edit?usp=sharing

##### Android After
|                    |    Run 1 |    Run 2 |    Run 3 |    Run 4 |    Run 5 |
|--------------------|---------:|---------:|---------:|---------:|---------:|
| Total              | 92.22sec | 92.44sec | 92.15sec | 89.81sec | 91.98sec |
| Last call ended at |  7.77sec |  7.41sec |  7.03sec |  7.71sec |  7.55sec |
- Full data: https://docs.google.com/spreadsheets/d/1USrACRs5grnnBZwL9y2eU-QNLr8y1tWzacMCd9hFSWo/edit?usp=sharing

##### iOS Before
|                    |    Run 1 |    Run 2 |    Run 3 |    Run 4 |    Run 5 |
|--------------------|---------:|---------:|---------:|---------:|---------:|
| Total              | 87.91sec | 87.41sec | 87.21sec | 86.29sec | 86.18sec |
| Last call ended at |  4.96sec |  4.47sec |  4.47sec |  4.77sec |  4.71sec |
- Full data: https://docs.google.com/spreadsheets/d/1quU0R5xhRWmH3xsatU-uUMOIPqSy7v7rlZobjwtJk38/edit?usp=sharing

##### iOS After
|                    |    Run 1 |    Run 2 |    Run 3 |    Run 4 |    Run 5 |
|--------------------|---------:|---------:|---------:|---------:|---------:|
| Total              | 66.36sec | 61.48sec | 58.39sec | 67.08sec | 65.94sec |
| Last call ended at |  4.63sec |  4.76sec |  4.72sec |  4.78sec |  4.90sec |
- Full data: https://docs.google.com/spreadsheets/d/1B4k4lidFnIZgngKmjI5EW7MTZ8ORqEUqpdG8taoZtJU/edit?usp=sharing

#### Benchmark info: 
Add `global.Onyx = Onyx` in Eexpensify.js 
Open the dev menu and make sure dev=false 
Disable all breakpoints in the debugger 
Wait for any syncing (top right corner) to end before starting any tests

##### Test   
1. Reload the app 
2. Wait processes to settle 
3. Run `Onyx.printMetrics({ format: 'csv', raw: true })`  
4. Copy the results to file 
5. Import file as new sheet in excel 
 
Run 7 times
Remove the fastest and the slowest runs 

All benchmarks were performed against this hash in Expensify/App: https://github.com/Expensify/App/commit/fc965f68d308167d19d00a29b91e85ca33707882