### PR TITLE
Perf: Lru cache

### DIFF
--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -683,8 +683,8 @@ function mergeCollection(collectionKey, collection) {
  * @param {function} registerStorageEventListener a callback when a storage event happens.
  * This applies to web platforms where the local storage emits storage events
  * across all open tabs and allows Onyx to stay in sync across all open tabs.
- * @param {Number} [options.maxCachedKeysCount=150] Sets how many recent keys should we try to keep in cache
- * Setting this to 0 would only keep active connections in cache
+ * @param {Number} [options.maxCachedKeysCount=55] Sets how many recent keys should we try to keep in cache
+ * Setting this to 0 would keep cache forever
  * @param {Boolean} [options.captureMetrics]
  */
 function init({
@@ -692,7 +692,7 @@ function init({
     initialKeyStates,
     safeEvictionKeys,
     registerStorageEventListener,
-    maxCachedKeysCount = 150,
+    maxCachedKeysCount = 55,
     captureMetrics = false,
 }) {
     if (captureMetrics) {
@@ -701,7 +701,7 @@ function init({
         applyDecorators();
     }
 
-    if (_.isNumber(maxCachedKeysCount)) {
+    if (maxCachedKeysCount > 0) {
         setInterval(() => {
             // Try to free anything dated from cache
             cache.removeLeastRecentUsedKeys(maxCachedKeysCount);

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -356,14 +356,21 @@ function connect(mapping) {
     deferredInitTask.promise
         .then(() => {
             // Check to see if this key is flagged as a safe eviction key and add it to the recentlyAccessedKeys list
-            if (mapping.withOnyxInstance && !isCollectionKey(mapping.key) && isSafeEvictionKey(mapping.key)) {
-                // All React components subscribing to a key flagged as a safe eviction
-                // key must implement the canEvict property.
-                if (_.isUndefined(mapping.canEvict)) {
-                    // eslint-disable-next-line max-len
-                    throw new Error(`Cannot subscribe to safe eviction key '${mapping.key}' without providing a canEvict value.`);
+            if (isSafeEvictionKey(mapping.key)) {
+                // Try to free some cache whenever we connect to a safe eviction key
+                cache.removeLeastRecentlyUsedKeys();
+
+                if (mapping.withOnyxInstance && !isCollectionKey(mapping.key)) {
+                    // All React components subscribing to a key flagged as a safe eviction
+                    // key must implement the canEvict property.
+                    if (_.isUndefined(mapping.canEvict)) {
+                        throw new Error(
+                            `Cannot subscribe to safe eviction key '${mapping.key}' without providing a canEvict value.`
+                        );
+                    }
+
+                    addLastAccessedKey(mapping.key);
                 }
-                addLastAccessedKey(mapping.key);
             }
         })
         .then(getAllKeys)
@@ -684,8 +691,9 @@ function mergeCollection(collectionKey, collection) {
  * This applies to web platforms where the local storage emits storage events
  * across all open tabs and allows Onyx to stay in sync across all open tabs.
  * @param {Number} [options.maxCachedKeysCount=55] Sets how many recent keys should we try to keep in cache
- * Setting this to 0 would keep cache forever
- * @param {Boolean} [options.captureMetrics]
+ * Setting this to 0 would practically mean no cache
+ * We try to free cache when we connect to a safe eviction key
+ * @param {Boolean} [options.captureMetrics] Enables Onyx benchmarking and exposes the get/print/reset functions
  */
 function init({
     keys,
@@ -702,10 +710,7 @@ function init({
     }
 
     if (maxCachedKeysCount > 0) {
-        setInterval(() => {
-            // Try to free anything dated from cache
-            cache.removeLeastRecentUsedKeys(maxCachedKeysCount);
-        }, 10 * 1000);
+        cache.setRecentKeysLimit(maxCachedKeysCount);
     }
 
     // Let Onyx know about all of our keys

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -29,6 +29,9 @@ const evictionBlocklist = {};
 // Optional user-provided key value states set when Onyx initializes or clears
 let defaultKeyStates = {};
 
+// Cache cleaning uses this to remove least recently accessed keys
+let MAX_CACHED_KEYS = 150;
+
 // Connections can be made before `Onyx.init`. They would wait for this task before resolving
 const deferredInitTask = createDeferredTask();
 
@@ -100,19 +103,6 @@ function getAllKeys() {
  */
 function isCollectionKey(key) {
     return _.contains(_.values(onyxKeys.COLLECTION), key);
-}
-
-/**
- * Find the collection a collection item belongs to
- * or return null if them item is not a part of a collection
- * @param {string} key
- * @returns {string|null}
- */
-function getCollectionKeyForItem(key) {
-    return _.chain(onyxKeys.COLLECTION)
-        .values()
-        .find(name => key.startsWith(name))
-        .value();
 }
 
 /**
@@ -413,48 +403,6 @@ function connect(mapping) {
 }
 
 /**
- * Remove cache items that are no longer connected through Onyx
- * @param {string} key
- */
-function cleanCache(key) {
-    // Don't remove default keys from cache, they don't take much memory and are accessed frequently
-    if (_.has(defaultKeyStates, key)) {
-        return;
-    }
-
-    const hasRemainingConnections = _.some(callbackToStateMapping, {key});
-
-    // When the key is still used in other places don't remove it from cache
-    if (hasRemainingConnections) {
-        return;
-    }
-
-    // When this is a collection - also recursively remove any unused individual items
-    if (isCollectionKey(key)) {
-        cache.drop(key);
-
-        getAllKeys().then(cachedKeys => _.chain(cachedKeys)
-            .filter(name => name.startsWith(key))
-            .forEach(cleanCache));
-
-        return;
-    }
-
-    // When this is a collection item - check if the collection is still used
-    const collectionKey = getCollectionKeyForItem(key);
-    if (collectionKey) {
-        // When there's an active subscription for a collection don't remove the item
-        const hasRemainingConnectionsForCollection = _.some(callbackToStateMapping, {key: collectionKey});
-        if (hasRemainingConnectionsForCollection) {
-            return;
-        }
-    }
-
-    // Otherwise remove the value from cache
-    cache.drop(key);
-}
-
-/**
  * Remove the listener for a react component
  *
  * @param {Number} connectionID
@@ -471,11 +419,10 @@ function disconnect(connectionID, keyToRemoveFromEvictionBlocklist) {
         removeFromEvictionBlockList(keyToRemoveFromEvictionBlocklist, connectionID);
     }
 
-    const key = callbackToStateMapping[connectionID].key;
     delete callbackToStateMapping[connectionID];
 
-    // When the last subscriber disconnects, drop cache as well
-    cleanCache(key);
+    // Try to free anything dated from cache
+    cache.removeLeastRecentUsedKeys(MAX_CACHED_KEYS);
 }
 
 /**
@@ -742,6 +689,8 @@ function mergeCollection(collectionKey, collection) {
  * @param {function} registerStorageEventListener a callback when a storage event happens.
  * This applies to web platforms where the local storage emits storage events
  * across all open tabs and allows Onyx to stay in sync across all open tabs.
+ * @param {Number} [options.maxCachedKeysCount=150] Sets how many recent keys should we try to keep in cache
+ * Setting this to 0 would only keep active connections in cache
  * @param {Boolean} [options.captureMetrics]
  */
 function init({
@@ -749,12 +698,17 @@ function init({
     initialKeyStates,
     safeEvictionKeys,
     registerStorageEventListener,
+    maxCachedKeysCount,
     captureMetrics = false,
 }) {
     if (captureMetrics) {
         // The code here is only bundled and applied when the captureMetrics is set
         // eslint-disable-next-line no-use-before-define
         applyDecorators();
+    }
+
+    if (_.isNumber(maxCachedKeysCount)) {
+        MAX_CACHED_KEYS = maxCachedKeysCount;
     }
 
     // Let Onyx know about all of our keys

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -29,9 +29,6 @@ const evictionBlocklist = {};
 // Optional user-provided key value states set when Onyx initializes or clears
 let defaultKeyStates = {};
 
-// Cache cleaning uses this to remove least recently accessed keys
-let MAX_CACHED_KEYS = 150;
-
 // Connections can be made before `Onyx.init`. They would wait for this task before resolving
 const deferredInitTask = createDeferredTask();
 
@@ -420,9 +417,6 @@ function disconnect(connectionID, keyToRemoveFromEvictionBlocklist) {
     }
 
     delete callbackToStateMapping[connectionID];
-
-    // Try to free anything dated from cache
-    cache.removeLeastRecentUsedKeys(MAX_CACHED_KEYS);
 }
 
 /**
@@ -698,7 +692,7 @@ function init({
     initialKeyStates,
     safeEvictionKeys,
     registerStorageEventListener,
-    maxCachedKeysCount,
+    maxCachedKeysCount = 150,
     captureMetrics = false,
 }) {
     if (captureMetrics) {
@@ -708,7 +702,10 @@ function init({
     }
 
     if (_.isNumber(maxCachedKeysCount)) {
-        MAX_CACHED_KEYS = maxCachedKeysCount;
+        setInterval(() => {
+            // Try to free anything dated from cache
+            cache.removeLeastRecentUsedKeys(maxCachedKeysCount);
+        }, 10 * 1000);
     }
 
     // Let Onyx know about all of our keys

--- a/lib/OnyxCache.js
+++ b/lib/OnyxCache.js
@@ -171,16 +171,14 @@ class OnyxCache {
      * @param {number} recentKeysSize - a list of most recent keys from this size will remain in cache.
      */
     removeLeastRecentUsedKeys(recentKeysSize) {
-        // Get the last N keys by doing a negative slice
-        const recentlyAccessed = new Set([...this.recentKeys].slice(-recentKeysSize));
+        if (this.recentKeys.size > recentKeysSize) {
+            // Get the last N keys by doing a negative slice
+            const recentlyAccessed = [...this.recentKeys].slice(-recentKeysSize);
+            const storageKeys = _.keys(this.storageMap);
+            const keysToRemove = _.difference(storageKeys, recentlyAccessed);
 
-        _.chain(this.storageMap)
-            .keys()
-            .each((key) => {
-                if (!recentlyAccessed.has(key)) {
-                    this.drop(key);
-                }
-            });
+            _.each(keysToRemove, this.drop);
+        }
     }
 }
 

--- a/lib/OnyxCache.js
+++ b/lib/OnyxCache.js
@@ -168,17 +168,24 @@ class OnyxCache {
 
     /**
      * Remove keys that don't fall into the range of recently used keys
-     * @param {number} recentKeysSize - a list of most recent keys from this size will remain in cache.
      */
-    removeLeastRecentUsedKeys(recentKeysSize) {
-        if (this.recentKeys.size > recentKeysSize) {
+    removeLeastRecentlyUsedKeys() {
+        if (this.recentKeys.size > this.maxRecentKeysSize) {
             // Get the last N keys by doing a negative slice
-            const recentlyAccessed = [...this.recentKeys].slice(-recentKeysSize);
+            const recentlyAccessed = [...this.recentKeys].slice(-this.maxRecentKeysSize);
             const storageKeys = _.keys(this.storageMap);
             const keysToRemove = _.difference(storageKeys, recentlyAccessed);
 
             _.each(keysToRemove, this.drop);
         }
+    }
+
+    /**
+     * Set the recent keys list size
+     * @param {number} limit
+     */
+    setRecentKeysLimit(limit) {
+        this.maxRecentKeysSize = limit;
     }
 }
 

--- a/lib/OnyxCache.js
+++ b/lib/OnyxCache.js
@@ -38,11 +38,12 @@ class OnyxCache {
          */
         this.pendingPromises = {};
 
-        // bind all methods to prevent problems with `this`
+        // bind all public methods to prevent problems with `this`
         _.bindAll(
             this,
             'getAllKeys', 'getValue', 'hasCacheForKey', 'addKey', 'set', 'drop', 'merge',
-            'hasPendingTask', 'getTaskPromise', 'captureTask',
+            'hasPendingTask', 'getTaskPromise', 'captureTask', 'removeLeastRecentlyUsedKeys',
+            'setRecentKeysLimit'
         );
     }
 

--- a/lib/OnyxCache.js
+++ b/lib/OnyxCache.js
@@ -19,6 +19,13 @@ class OnyxCache {
 
         /**
          * @private
+         * Unique list of keys maintained in access order (most recent at the end)
+         * @type {Set<string>}
+         */
+        this.recentKeys = new Set();
+
+        /**
+         * @private
          * A map of cached values
          * @type {Record<string, *>}
          */
@@ -53,6 +60,7 @@ class OnyxCache {
      * @returns {*}
      */
     getValue(key) {
+        this.addToAccessedKeys(key);
         return this.storageMap[key];
     }
 
@@ -83,6 +91,7 @@ class OnyxCache {
      */
     set(key, value) {
         this.addKey(key);
+        this.addToAccessedKeys(key);
         this.storageMap[key] = value;
 
         return value;
@@ -106,6 +115,7 @@ class OnyxCache {
         const storageKeys = this.getAllKeys();
         const mergedKeys = _.keys(data);
         this.storageKeys = new Set([...storageKeys, ...mergedKeys]);
+        _.each(mergedKeys, key => this.addToAccessedKeys(key));
     }
 
     /**
@@ -143,6 +153,34 @@ class OnyxCache {
         });
 
         return this.pendingPromises[taskName];
+    }
+
+    /**
+     * @private
+     * Adds a key to the top of the recently accessed keys
+     * @param {string} key
+     */
+    addToAccessedKeys(key) {
+        // Removing and re-adding a key ensures it's at the end of the list
+        this.recentKeys.delete(key);
+        this.recentKeys.add(key);
+    }
+
+    /**
+     * Remove keys that don't fall into the range of recently used keys
+     * @param {number} recentKeysSize - a list of most recent keys from this size will remain in cache.
+     */
+    removeLeastRecentUsedKeys(recentKeysSize) {
+        // Get the last N keys by doing a negative slice
+        const recentlyAccessed = new Set([...this.recentKeys].slice(-recentKeysSize));
+
+        _.chain(this.storageMap)
+            .keys()
+            .each((key) => {
+                if (!recentlyAccessed.has(key)) {
+                    this.drop(key);
+                }
+            });
     }
 }
 

--- a/lib/decorateWithMetrics.js
+++ b/lib/decorateWithMetrics.js
@@ -48,6 +48,7 @@ function decorateWithMetrics(func, alias = func.name) {
                     methodName: alias,
                     startTime,
                     endTime,
+                    duration: endTime - startTime,
                     args,
                 });
             });
@@ -78,8 +79,7 @@ function sum(list, prop) {
  */
 function getMetrics() {
     const summaries = _.chain(stats)
-        .map((data, methodName) => {
-            const calls = _.map(data, call => ({...call, duration: call.endTime - call.startTime}));
+        .map((calls, methodName) => {
             const total = sum(calls, 'duration');
             const avg = (total / calls.length) || 0;
             const max = _.max(calls, 'duration').duration || 0;
@@ -144,9 +144,10 @@ function toDuration(millis, raw = false) {
  * @param {'console'|'csv'|'json'|'string'} [options.format=console] The output format of this function
  * `string` is useful when __DEV__ is set to `false` as writing to the console is disabled, but the result of this
  * method would still get printed as output
+ * @param {string[]} [options.methods] Print stats only for these method names
  * @returns {string|undefined}
  */
-function printMetrics({raw = false, format = 'console'} = {}) {
+function printMetrics({raw = false, format = 'console', methods} = {}) {
     const {totalTime, summaries, lastCompleteCall} = getMetrics();
 
     const tableSummary = MDTable.factory({
@@ -154,11 +155,11 @@ function printMetrics({raw = false, format = 'console'} = {}) {
         leftAlignedCols: [0],
     });
 
-    const methodCallTables = _.chain(summaries)
-        .filter(method => method.avg > 0)
-        .sortBy('avg')
-        .reverse()
-        .map(({methodName, calls, ...methodStats}) => {
+    const methodNames = _.isArray(methods) ? methods : _.keys(summaries);
+
+    const methodCallTables = _.chain(methodNames)
+        .map((methodName) => {
+            const {calls, ...methodStats} = summaries[methodName];
             tableSummary.addRow(
                 methodName,
                 toDuration(methodStats.total, raw),

--- a/lib/decorateWithMetrics.js
+++ b/lib/decorateWithMetrics.js
@@ -24,6 +24,8 @@ function decorateWithMetrics(func, alias = func.name) {
         throw new Error(`"${alias}" is already decorated`);
     }
 
+    stats[alias] = [];
+
     function decorated(...args) {
         const startTime = performance.now() - PERFORMANCE_OFFSET;
 

--- a/lib/decorateWithMetrics.js
+++ b/lib/decorateWithMetrics.js
@@ -24,8 +24,6 @@ function decorateWithMetrics(func, alias = func.name) {
         throw new Error(`"${alias}" is already decorated`);
     }
 
-    stats[alias] = [];
-
     function decorated(...args) {
         const startTime = performance.now() - PERFORMANCE_OFFSET;
 

--- a/lib/decorateWithMetrics.js
+++ b/lib/decorateWithMetrics.js
@@ -158,6 +158,7 @@ function printMetrics({raw = false, format = 'console', methods} = {}) {
     const methodNames = _.isArray(methods) ? methods : _.keys(summaries);
 
     const methodCallTables = _.chain(methodNames)
+        .filter(methodName => summaries[methodName] && summaries[methodName].avg > 0)
         .map((methodName) => {
             const {calls, ...methodStats} = summaries[methodName];
             tableSummary.addRow(


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->
cc @marcaaron 

### Details
<!-- Explanation of the change or anything fishy that is going on -->
PR4. Of the changes planned here: https://github.com/Expensify/react-native-onyx/pull/88#issuecomment-880916315

Keep a list of recently accessed keys in `OnyxCache` - `recentKeys`
This serves to clean "Least Recently Used" keys from cache

Keys are added to `recentKeys` for any cache access operation - get/set/merge

Added a configurable limit of 150 keys in cache
This looks like a sane value from observations during chat browsing

#### Note on print/benchmark updates:
This helps with extracting information to excel in a consistent matter

Add an optional `methods` list parameter
When such a list is provided only the methods from this list will be printed

Removed any sorting
Tables order varies and makes it harder to deal with in Excel

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
Expensify/App#2667

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
Added test covering that recent keys are available in cache 
and that older keys past the LRU limit are cleared from cache when safe eviction connection happens

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->
