### PR TITLE
Make Onyx.getAllKeys public

### DIFF
--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -730,35 +730,6 @@ function mergeCollection(collectionKey, collection) {
 }
 
 /**
- * Sets a collection based on their keys. Any existing elements in the collection that are not in the passed collection
- * will be set to null
- *
- * @param {String} collectionKey
- * @param {Object} collection
- * @returns {Promise}
- */
-function setCollection(collectionKey, collection) {
-    return getAllKeys()
-        .then((persistedKeys) => {
-            const promises = [];
-            promises.push(mergeCollection(collectionKey, collection));
-
-            const keysToClear = _.filter(persistedKeys, persistedKey => isKeyMatch(collectionKey, persistedKey)
-                && !_.keys(collection).includes(persistedKey));
-            const keyValuePairsForClearing = _.map(keysToClear, key => [key, 'null']);
-            if (keyValuePairsForClearing.length > 0) {
-                promises.push(AsyncStorage.multiSet(keyValuePairsForClearing));
-
-                // Clear them in cache
-                _.each(keysToClear, key => cache.set(key, null));
-            }
-
-            return Promise.all(promises)
-                .catch(error => evictStorageAndRetry(error, setCollection, collection));
-        });
-}
-
-/**
  * Initialize the store with actions and listening for storage events
  *
  * @param {Object} options
@@ -812,11 +783,11 @@ function init({
 const Onyx = {
     connect,
     disconnect,
+    getAllKeys,
     set,
     multiSet,
     merge,
     mergeCollection,
-    setCollection,
     clear,
     init,
     registerLogger,
@@ -840,7 +811,6 @@ function applyDecorators() {
     clear = decorate.decorateWithMetrics(clear, 'Onyx:clear');
     merge = decorate.decorateWithMetrics(merge, 'Onyx:merge');
     mergeCollection = decorate.decorateWithMetrics(mergeCollection, 'Onyx:mergeCollection');
-    setCollection = decorate.decorateWithMetrics(setCollection, 'Onyx:setCollection');
     getAllKeys = decorate.decorateWithMetrics(getAllKeys, 'Onyx:getAllKeys');
     initializeWithDefaultKeyStates = decorate.decorateWithMetrics(initializeWithDefaultKeyStates, 'Onyx:defaults');
     /* eslint-enable */

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -721,8 +721,8 @@ function mergeCollection(collectionKey, collection, clearRemoved = false) {
 
             // If the flag is set, clear any removed keys in the collection
             if (clearRemoved) {
-                const keysToClear = _.filter(persistedKeys, persistedKey => isKeyMatch(collectionKey, persistedKey) &&
-                    !_.keys(collection).includes(persistedKey));
+                const keysToClear = _.filter(persistedKeys, persistedKey => isKeyMatch(collectionKey, persistedKey)
+                    && !_.keys(collection).includes(persistedKey));
                 const keyValuePairsForClearing = _.map(keysToClear, key => [key, 'null']);
                 if (keyValuePairsForClearing.length > 0) {
                     promises.push(AsyncStorage.multiSet(keyValuePairsForClearing));

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -685,7 +685,36 @@ function clear() {
  * @param {Boolean} [clearRemoved]
  * @returns {Promise}
  */
-function mergeCollection(collectionKey, collection, clearRemoved = false) {
+function setCollection(collectionKey, collection) {
+    return getAllKeys()
+        .then((persistedKeys) => {
+            const promises = [];
+            promises.push(mergeCollection(collectionKey, collection));
+
+            const keysToClear = _.filter(persistedKeys, persistedKey => isKeyMatch(collectionKey, persistedKey)
+                && !_.keys(collection).includes(persistedKey));
+            const keyValuePairsForClearing = _.map(keysToClear, key => [key, 'null']);
+            if (keyValuePairsForClearing.length > 0) {
+                promises.push(AsyncStorage.multiSet(keyValuePairsForClearing));
+
+                // Clear them in cache
+                _.each(keysToClear, key => cache.set(key, null));
+            }
+
+            return Promise.all(promises)
+                .catch(error => evictStorageAndRetry(error, setCollection, collection));
+        });
+}
+
+/**
+ * Merges a collection based on their keys
+ *
+ * @param {String} collectionKey
+ * @param {Object} collection
+ * @param {Boolean} [clearRemoved]
+ * @returns {Promise}
+ */
+function mergeCollection(collectionKey, collection) {
     // Confirm all the collection keys belong to the same parent
     _.each(collection, (data, dataKey) => {
         if (!isKeyMatch(collectionKey, dataKey)) {
@@ -717,19 +746,6 @@ function mergeCollection(collectionKey, collection, clearRemoved = false) {
 
             if (keyValuePairsForNewCollection.length > 0) {
                 promises.push(AsyncStorage.multiSet(keyValuePairsForNewCollection));
-            }
-
-            // If the flag is set, clear any removed keys in the collection
-            if (clearRemoved) {
-                const keysToClear = _.filter(persistedKeys, persistedKey => isKeyMatch(collectionKey, persistedKey)
-                    && !_.keys(collection).includes(persistedKey));
-                const keyValuePairsForClearing = _.map(keysToClear, key => [key, 'null']);
-                if (keyValuePairsForClearing.length > 0) {
-                    promises.push(AsyncStorage.multiSet(keyValuePairsForClearing));
-
-                    // Clear them in cache
-                    _.each(keysToClear, key => cache.set(key, null));
-                }
             }
 
             // Merge original data to cache
@@ -801,6 +817,7 @@ const Onyx = {
     multiSet,
     merge,
     mergeCollection,
+    setCollection,
     clear,
     init,
     registerLogger,
@@ -824,6 +841,7 @@ function applyDecorators() {
     clear = decorate.decorateWithMetrics(clear, 'Onyx:clear');
     merge = decorate.decorateWithMetrics(merge, 'Onyx:merge');
     mergeCollection = decorate.decorateWithMetrics(mergeCollection, 'Onyx:mergeCollection');
+    setCollection = decorate.decorateWithMetrics(setCollection, 'Onyx:mergeCollection');
     getAllKeys = decorate.decorateWithMetrics(getAllKeys, 'Onyx:getAllKeys');
     initializeWithDefaultKeyStates = decorate.decorateWithMetrics(initializeWithDefaultKeyStates, 'Onyx:defaults');
     /* eslint-enable */

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -682,36 +682,6 @@ function clear() {
  *
  * @param {String} collectionKey
  * @param {Object} collection
- * @param {Boolean} [clearRemoved]
- * @returns {Promise}
- */
-function setCollection(collectionKey, collection) {
-    return getAllKeys()
-        .then((persistedKeys) => {
-            const promises = [];
-            promises.push(mergeCollection(collectionKey, collection));
-
-            const keysToClear = _.filter(persistedKeys, persistedKey => isKeyMatch(collectionKey, persistedKey)
-                && !_.keys(collection).includes(persistedKey));
-            const keyValuePairsForClearing = _.map(keysToClear, key => [key, 'null']);
-            if (keyValuePairsForClearing.length > 0) {
-                promises.push(AsyncStorage.multiSet(keyValuePairsForClearing));
-
-                // Clear them in cache
-                _.each(keysToClear, key => cache.set(key, null));
-            }
-
-            return Promise.all(promises)
-                .catch(error => evictStorageAndRetry(error, setCollection, collection));
-        });
-}
-
-/**
- * Merges a collection based on their keys
- *
- * @param {String} collectionKey
- * @param {Object} collection
- * @param {Boolean} [clearRemoved]
  * @returns {Promise}
  */
 function mergeCollection(collectionKey, collection) {
@@ -756,6 +726,35 @@ function mergeCollection(collectionKey, collection) {
 
             return Promise.all(promises)
                 .catch(error => evictStorageAndRetry(error, mergeCollection, collection));
+        });
+}
+
+/**
+ * Sets a collection based on their keys. Any existing elements in the collection that are not in the passed collection
+ * will be set to null
+ *
+ * @param {String} collectionKey
+ * @param {Object} collection
+ * @returns {Promise}
+ */
+function setCollection(collectionKey, collection) {
+    return getAllKeys()
+        .then((persistedKeys) => {
+            const promises = [];
+            promises.push(mergeCollection(collectionKey, collection));
+
+            const keysToClear = _.filter(persistedKeys, persistedKey => isKeyMatch(collectionKey, persistedKey)
+                && !_.keys(collection).includes(persistedKey));
+            const keyValuePairsForClearing = _.map(keysToClear, key => [key, 'null']);
+            if (keyValuePairsForClearing.length > 0) {
+                promises.push(AsyncStorage.multiSet(keyValuePairsForClearing));
+
+                // Clear them in cache
+                _.each(keysToClear, key => cache.set(key, null));
+            }
+
+            return Promise.all(promises)
+                .catch(error => evictStorageAndRetry(error, setCollection, collection));
         });
 }
 

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -682,9 +682,10 @@ function clear() {
  *
  * @param {String} collectionKey
  * @param {Object} collection
+ * @param {Boolean} [clearRemoved]
  * @returns {Promise}
  */
-function mergeCollection(collectionKey, collection) {
+function mergeCollection(collectionKey, collection, clearRemoved = false) {
     // Confirm all the collection keys belong to the same parent
     _.each(collection, (data, dataKey) => {
         if (!isKeyMatch(collectionKey, dataKey)) {
@@ -716,6 +717,21 @@ function mergeCollection(collectionKey, collection) {
 
             if (keyValuePairsForNewCollection.length > 0) {
                 promises.push(AsyncStorage.multiSet(keyValuePairsForNewCollection));
+            }
+
+            // If the flag is set, clear any removed keys in the collection
+            if (clearRemoved) {
+                console.log(collection);
+                const keysToClear = _.filter(persistedKeys, (persistedKey) => {
+                    return (isKeyMatch(collectionKey, persistedKey) && !_.keys(collection).includes(persistedKey));
+                });
+                const keyValuePairsForClearing = _.map(keysToClear, key => [key, 'null']);
+                if (keyValuePairsForClearing.length > 0) {
+                    promises.push(AsyncStorage.multiSet(keyValuePairsForClearing));
+
+                    // Clear them in cache
+                    _.each(keysToClear, (key) => cache.set(key, null));
+                }
             }
 
             // Merge original data to cache

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -721,8 +721,8 @@ function mergeCollection(collectionKey, collection, clearRemoved = false) {
 
             // If the flag is set, clear any removed keys in the collection
             if (clearRemoved) {
-                const keysToClear = _.filter(persistedKeys, persistedKey =>
-                    (isKeyMatch(collectionKey, persistedKey) && !_.keys(collection).includes(persistedKey)));
+                const keysToClear = _.filter(persistedKeys, persistedKey => isKeyMatch(collectionKey, persistedKey) &&
+                    !_.keys(collection).includes(persistedKey));
                 const keyValuePairsForClearing = _.map(keysToClear, key => [key, 'null']);
                 if (keyValuePairsForClearing.length > 0) {
                     promises.push(AsyncStorage.multiSet(keyValuePairsForClearing));

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -840,7 +840,7 @@ function applyDecorators() {
     clear = decorate.decorateWithMetrics(clear, 'Onyx:clear');
     merge = decorate.decorateWithMetrics(merge, 'Onyx:merge');
     mergeCollection = decorate.decorateWithMetrics(mergeCollection, 'Onyx:mergeCollection');
-    setCollection = decorate.decorateWithMetrics(setCollection, 'Onyx:mergeCollection');
+    setCollection = decorate.decorateWithMetrics(setCollection, 'Onyx:setCollection');
     getAllKeys = decorate.decorateWithMetrics(getAllKeys, 'Onyx:getAllKeys');
     initializeWithDefaultKeyStates = decorate.decorateWithMetrics(initializeWithDefaultKeyStates, 'Onyx:defaults');
     /* eslint-enable */

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -721,16 +721,14 @@ function mergeCollection(collectionKey, collection, clearRemoved = false) {
 
             // If the flag is set, clear any removed keys in the collection
             if (clearRemoved) {
-                console.log(collection);
-                const keysToClear = _.filter(persistedKeys, (persistedKey) => {
-                    return (isKeyMatch(collectionKey, persistedKey) && !_.keys(collection).includes(persistedKey));
-                });
+                const keysToClear = _.filter(persistedKeys, persistedKey =>
+                    (isKeyMatch(collectionKey, persistedKey) && !_.keys(collection).includes(persistedKey)));
                 const keyValuePairsForClearing = _.map(keysToClear, key => [key, 'null']);
                 if (keyValuePairsForClearing.length > 0) {
                     promises.push(AsyncStorage.multiSet(keyValuePairsForClearing));
 
                     // Clear them in cache
-                    _.each(keysToClear, (key) => cache.set(key, null));
+                    _.each(keysToClear, key => cache.set(key, null));
                 }
             }
 

--- a/tests/unit/onyxTest.js
+++ b/tests/unit/onyxTest.js
@@ -202,7 +202,7 @@ describe('Onyx', () => {
         })
             .then(() => (
 
-                // 2 key values to update and 2 new keys to add.
+                // 2 key values to update and 3 new keys to add.
                 // MergeCollection will perform a mix of multiSet and multiMerge
                 Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
                     test_1: {
@@ -220,8 +220,40 @@ describe('Onyx', () => {
                     test_5: {
                         ID: 567,
                         value: 'one'
+                    },
+                    test_6: {
+                        ID: 678,
+                        value: 'zero'
                     }
                 })
+            ))
+            .then(() => (
+
+                // Everything is the same, but a key is missing
+                // MergeCollection will use multiMerge to reset the existing keys
+                // and will set the missing key to null, since clearRemoved is set
+                Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
+                    test_1: {
+                        ID: 123,
+                        value: 'five'
+                    },
+                    test_2: {
+                        ID: 234,
+                        value: 'four'
+                    },
+                    test_3: {
+                        ID: 345,
+                        value: 'three'
+                    },
+                    test_4: {
+                        ID: 456,
+                        value: 'two'
+                    },
+                    test_5: {
+                        ID: 567,
+                        value: 'one'
+                    }
+                }, true)
             ))
             .then(() => {
                 // 3 items on the first mergeCollection + 4 items the next mergeCollection

--- a/tests/unit/onyxTest.js
+++ b/tests/unit/onyxTest.js
@@ -257,7 +257,7 @@ describe('Onyx', () => {
             ))
             .then(() => {
                 // 3 items on the first mergeCollection + 4 items the next mergeCollection
-                expect(mockCallback.mock.calls.length).toBe(7);
+                expect(mockCallback.mock.calls.length).toBe(8);
 
                 expect(mockCallback.mock.calls[0][0]).toEqual({ID: 123, value: 'one'});
                 expect(mockCallback.mock.calls[0][1]).toEqual('test_1');
@@ -280,11 +280,15 @@ describe('Onyx', () => {
                 expect(mockCallback.mock.calls[6][0]).toEqual({ID: 567, value: 'one'});
                 expect(mockCallback.mock.calls[6][1]).toEqual('test_5');
 
+                expect(mockCallback.mock.calls[6][0]).toEqual({ID: 678, value: null});
+                expect(mockCallback.mock.calls[6][1]).toEqual('test_6');
+
                 expect(valuesReceived[123]).toEqual('five');
                 expect(valuesReceived[234]).toEqual('four');
                 expect(valuesReceived[345]).toEqual('three');
                 expect(valuesReceived[456]).toEqual('two');
                 expect(valuesReceived[567]).toEqual('one');
+                expect(valuesReceived[678]).toEqual(null);
             });
     });
 

--- a/tests/unit/onyxTest.js
+++ b/tests/unit/onyxTest.js
@@ -202,7 +202,7 @@ describe('Onyx', () => {
         })
             .then(() => (
 
-                // 2 key values to update and 2 new keys to add (and one will be removed).
+                // 2 key values to update and 2 new keys to add.
                 // MergeCollection will perform a mix of multiSet and multiMerge
                 Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
                     test_1: {
@@ -221,7 +221,7 @@ describe('Onyx', () => {
                         ID: 567,
                         value: 'one'
                     }
-                }, true)
+                })
             ))
             .then(() => {
                 // 3 items on the first mergeCollection + 4 items the next mergeCollection

--- a/tests/unit/onyxTest.js
+++ b/tests/unit/onyxTest.js
@@ -250,7 +250,7 @@ describe('Onyx', () => {
 
                 expect(valuesReceived[123]).toEqual('five');
                 expect(valuesReceived[234]).toEqual('four');
-                expect(valuesReceived[345]).toEqual(null);
+                expect(valuesReceived[345]).toEqual('three');
                 expect(valuesReceived[456]).toEqual('two');
                 expect(valuesReceived[567]).toEqual('one');
             });

--- a/tests/unit/onyxTest.js
+++ b/tests/unit/onyxTest.js
@@ -220,38 +220,6 @@ describe('Onyx', () => {
                     test_5: {
                         ID: 567,
                         value: 'one'
-                    },
-                    test_6: {
-                        ID: 678,
-                        value: 'zero'
-                    }
-                })
-            ))
-            .then(() => (
-
-                // Everything is the same, but a key is missing
-                // MergeCollection will use multiMerge to reset the existing keys
-                // and will set the missing key to null, since clearRemoved is set
-                Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
-                    test_1: {
-                        ID: 123,
-                        value: 'five'
-                    },
-                    test_2: {
-                        ID: 234,
-                        value: 'four'
-                    },
-                    test_3: {
-                        ID: 345,
-                        value: 'three'
-                    },
-                    test_4: {
-                        ID: 456,
-                        value: 'two'
-                    },
-                    test_5: {
-                        ID: 567,
-                        value: 'one'
                     }
                 }, true)
             ))
@@ -282,7 +250,7 @@ describe('Onyx', () => {
 
                 expect(valuesReceived[123]).toEqual('five');
                 expect(valuesReceived[234]).toEqual('four');
-                expect(valuesReceived[345]).toEqual('three');
+                expect(valuesReceived[345]).toEqual(null);
                 expect(valuesReceived[456]).toEqual('two');
                 expect(valuesReceived[567]).toEqual('one');
             });

--- a/tests/unit/onyxTest.js
+++ b/tests/unit/onyxTest.js
@@ -202,7 +202,7 @@ describe('Onyx', () => {
         })
             .then(() => (
 
-                // 2 key values to update and 3 new keys to add.
+                // 2 key values to update and 2 new keys to add (and one will be removed).
                 // MergeCollection will perform a mix of multiSet and multiMerge
                 Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
                     test_1: {

--- a/tests/unit/onyxTest.js
+++ b/tests/unit/onyxTest.js
@@ -257,7 +257,7 @@ describe('Onyx', () => {
             ))
             .then(() => {
                 // 3 items on the first mergeCollection + 4 items the next mergeCollection
-                expect(mockCallback.mock.calls.length).toBe(8);
+                expect(mockCallback.mock.calls.length).toBe(7);
 
                 expect(mockCallback.mock.calls[0][0]).toEqual({ID: 123, value: 'one'});
                 expect(mockCallback.mock.calls[0][1]).toEqual('test_1');
@@ -280,15 +280,11 @@ describe('Onyx', () => {
                 expect(mockCallback.mock.calls[6][0]).toEqual({ID: 567, value: 'one'});
                 expect(mockCallback.mock.calls[6][1]).toEqual('test_5');
 
-                expect(mockCallback.mock.calls[6][0]).toEqual({ID: 678, value: null});
-                expect(mockCallback.mock.calls[6][1]).toEqual('test_6');
-
                 expect(valuesReceived[123]).toEqual('five');
                 expect(valuesReceived[234]).toEqual('four');
                 expect(valuesReceived[345]).toEqual('three');
                 expect(valuesReceived[456]).toEqual('two');
                 expect(valuesReceived[567]).toEqual('one');
-                expect(valuesReceived[678]).toEqual(null);
             });
     });
 


### PR DESCRIPTION
@alex-mechler 🐻 

cc @marcaaron to make sure I'm not doing anything that goes against our standards.

### Details
For https://github.com/Expensify/App/pull/4453, I needed the ability to, basically, replace a whole collection with a new one. Since we currently don't have an easy way of doing so, I need to retrieve all existing keys so I can decide which ones to clear.

### Related Issues
https://github.com/Expensify/Expensify/issues/173112

### Automated Tests
None

### Linked PRs
https://github.com/Expensify/App/pull/4453
