### PR TITLE
fix Breaking Changes for `initWithStoredValues` 🏴

### DIFF
--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -270,8 +270,9 @@ function keysChanged(collectionKey, collection) {
  *
  * @param {string} key
  * @param {mixed} data
+ * @param {boolean} [hasNewValue=true]
  */
-function keyChanged(key, data) {
+function keyChanged(key, data, hasNewValue = true) {
     // Add or remove this key from the recentlyAccessedKeys lists
     if (!_.isNull(data)) {
         addLastAccessedKey(key);
@@ -282,6 +283,9 @@ function keyChanged(key, data) {
     // Find all subscribers that were added with connect() and trigger the callback or setState() with the new data
     _.each(callbackToStateMapping, (subscriber) => {
         if (subscriber && isKeyMatch(subscriber.key, key)) {
+            if (!hasNewValue && (subscriber.initWithStoredValues !== false)) {
+                return;
+            }
             if (_.isFunction(subscriber.callback)) {
                 subscriber.callback(data, key);
             }
@@ -474,17 +478,20 @@ function evictStorageAndRetry(error, ionMethod, ...args) {
  * @param {mixed} val
  * @returns {Promise}
  */
-function set(key, val) {
-    // Skip writing to storage if the value hasn't changed
-    if (cache.hasCacheForKey(key) && _.isEqual(val, cache.getValue(key))) {
-        return Promise.resolve();
-    }
+ function set(key, val) {
+    const shouldCacheNewValue = !cache.hasCacheForKey(key) || !_.isEqual(val, cache.getValue(key));
 
     // Adds the key to cache when it's not available
-    cache.set(key, val);
+    if (shouldCacheNewValue) {
+        cache.set(key, val);
+    }
 
     // Optimistically inform subscribers on the next tick
-    Promise.resolve().then(() => keyChanged(key, val));
+    Promise.resolve().then(() => keyChanged(key, val, shouldCacheNewValue));
+
+    if (!shouldCacheNewValue) {
+        return Promise.resolve();
+    }
 
     // Write the thing to persistent storage, which will trigger a storage event for any other tabs open on this domain
     return AsyncStorage.setItem(key, JSON.stringify(val))

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -283,7 +283,8 @@ function keyChanged(key, data, hasNewValue = true) {
     // Find all subscribers that were added with connect() and trigger the callback or setState() with the new data
     _.each(callbackToStateMapping, (subscriber) => {
         if (subscriber && isKeyMatch(subscriber.key, key)) {
-            // If data is not new then only trigger the callback or setState() for subscribers which are not initialized with Stored value
+            // If data is not new then only trigger the callback or setState() for subscribers
+            // which are not initialized with Stored value
             if (!hasNewValue && (subscriber.initWithStoredValues !== false)) {
                 return;
             }
@@ -479,7 +480,7 @@ function evictStorageAndRetry(error, ionMethod, ...args) {
  * @param {mixed} val
  * @returns {Promise}
  */
- function set(key, val) {
+function set(key, val) {
     const shouldCacheNewValue = !cache.hasCacheForKey(key) || !_.isEqual(val, cache.getValue(key));
 
     // Adds the key to cache when it's not available

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -283,6 +283,7 @@ function keyChanged(key, data, hasNewValue = true) {
     // Find all subscribers that were added with connect() and trigger the callback or setState() with the new data
     _.each(callbackToStateMapping, (subscriber) => {
         if (subscriber && isKeyMatch(subscriber.key, key)) {
+            // If data is not new then only trigger the callback or setState() for subscribers which are not initialized with Stored value
             if (!hasNewValue && (subscriber.initWithStoredValues !== false)) {
                 return;
             }


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Allow trigger for the subscribers that are using `initWithStoredValues:false` even if the data is not changed.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
Fixes https://github.com/Expensify/App/issues/4500

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->
