### PR TITLE
Call setState once when handling initial withOnyx data to reduce JS scripting time

### DIFF
--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -328,9 +328,7 @@ function keyChanged(key, data, hasNewValue = true) {
  */
 function sendDataToConnection(config, val, key) {
     if (config.withOnyxInstance) {
-        config.withOnyxInstance.setState({
-            [config.statePropertyName]: val,
-        });
+        config.withOnyxInstance.setInitialState(config.statePropertyName, val);
     } else if (_.isFunction(config.callback)) {
         config.callback(val, key);
     }

--- a/lib/withOnyx.js
+++ b/lib/withOnyx.js
@@ -25,9 +25,13 @@ export default function (mapOnyxToState) {
             constructor(props) {
                 super(props);
 
+                this.setInitialData = this.setInitialData.bind(this);
+
                 // This stores all the Onyx connection IDs to be used when the component unmounts so everything can be
                 // disconnected. It is a key value store with the format {[mapping.key]: connectionID}.
                 this.activeConnectionIDs = {};
+
+                this.tempState = {};
 
                 this.state = {
                     loading: true,
@@ -39,7 +43,7 @@ export default function (mapOnyxToState) {
                 _.each(mapOnyxToState, (mapping, propertyName) => {
                     this.connectMappingToOnyx(mapping, propertyName);
                 });
-                this.checkAndUpdateLoading();
+                this.checkEvictableKeys();
             }
 
             componentDidUpdate(prevProps) {
@@ -55,7 +59,7 @@ export default function (mapOnyxToState) {
                         this.connectMappingToOnyx(mapping, propertyName);
                     }
                 });
-                this.checkAndUpdateLoading();
+                this.checkEvictableKeys();
             }
 
             componentWillUnmount() {
@@ -68,11 +72,41 @@ export default function (mapOnyxToState) {
             }
 
             /**
+             * This method is used externally by sendDataToConnection to prevent unnecessary renders while a component
+             * still in a loading state. The temporary initial state is saved to the component instance and setState()
+             * only called once all the necessary data has been collected.
+             *
+             * @param {String} statePropertyName
+             * @param {*} val
+             */
+            setInitialState(statePropertyName, val) {
+                this.tempState[statePropertyName] = val;
+
+                // Filter all keys by those which we do want to init with stored values
+                // since keys that are configured to not init with stored values will
+                // never appear on state when the component mounts - only after they update
+                // organically.
+                const requiredKeysForInit = _.chain(mapOnyxToState)
+                    .omit(config => config.initWithStoredValues === false)
+                    .keys()
+                    .value();
+
+                // All state keys should exist and at least have a value of null
+                if (!_.every(requiredKeysForInit, key => !_.isUndefined(this.tempState[key]))) {
+                    return;
+                }
+
+                this.setState({...this.tempState, loading: false}, () => {
+                    this.tempState = {};
+                });
+            }
+
+            /**
              * Makes sure each Onyx key we requested has been set to state with a value of some kind.
              * We are doing this so that the wrapped component will only render when all the data
              * it needs is available to it.
              */
-            checkAndUpdateLoading() {
+            checkEvictableKeys() {
                 // We will add this key to our list of recently accessed keys
                 // if the canEvict function returns true. This is necessary criteria
                 // we MUST use to specify if a key can be removed or not.
@@ -95,24 +129,6 @@ export default function (mapOnyxToState) {
                         Onyx.addToEvictionBlockList(key, mapping.connectionID);
                     }
                 });
-
-                if (!this.state.loading) {
-                    return;
-                }
-
-                // Filter all keys by those which we do want to init with stored values
-                // since keys that are configured to not init with stored values will
-                // never appear on state when the component mounts - only after they update
-                // organically.
-                const requiredKeysForInit = _.chain(mapOnyxToState)
-                    .omit(config => config.initWithStoredValues === false)
-                    .keys()
-                    .value();
-
-                // All state keys should exist and at least have a value of null
-                if (_.every(requiredKeysForInit, key => !_.isUndefined(this.state[key]))) {
-                    this.setState({loading: false});
-                }
             }
 
             /**

--- a/lib/withOnyx.js
+++ b/lib/withOnyx.js
@@ -25,7 +25,7 @@ export default function (mapOnyxToState) {
             constructor(props) {
                 super(props);
 
-                this.setInitialData = this.setInitialData.bind(this);
+                this.setInitialState = this.setInitialState.bind(this);
 
                 // This stores all the Onyx connection IDs to be used when the component unmounts so everything can be
                 // disconnected. It is a key value store with the format {[mapping.key]: connectionID}.

--- a/lib/withOnyx.js
+++ b/lib/withOnyx.js
@@ -20,6 +20,12 @@ function getDisplayName(component) {
 }
 
 export default function (mapOnyxToState) {
+    // A list of keys that must be present in tempState before we can render the WrappedComponent
+    const requiredKeysForInit = _.chain(mapOnyxToState)
+        .omit(config => config.initWithStoredValues === false)
+        .keys()
+        .value();
+
     return (WrappedComponent) => {
         class withOnyx extends React.Component {
             constructor(props) {
@@ -31,6 +37,7 @@ export default function (mapOnyxToState) {
                 // disconnected. It is a key value store with the format {[mapping.key]: connectionID}.
                 this.activeConnectionIDs = {};
 
+                // Object holding the temporary initial state for the component while we load the various Onyx keys
                 this.tempState = {};
 
                 this.state = {
@@ -81,15 +88,6 @@ export default function (mapOnyxToState) {
              */
             setInitialState(statePropertyName, val) {
                 this.tempState[statePropertyName] = val;
-
-                // Filter all keys by those which we do want to init with stored values
-                // since keys that are configured to not init with stored values will
-                // never appear on state when the component mounts - only after they update
-                // organically.
-                const requiredKeysForInit = _.chain(mapOnyxToState)
-                    .omit(config => config.initWithStoredValues === false)
-                    .keys()
-                    .value();
 
                 // All state keys should exist and at least have a value of null
                 if (!_.every(requiredKeysForInit, key => !_.isUndefined(this.tempState[key]))) {

--- a/lib/withOnyx.js
+++ b/lib/withOnyx.js
@@ -87,16 +87,20 @@ export default function (mapOnyxToState) {
              * @param {*} val
              */
             setInitialState(statePropertyName, val) {
-                this.tempState[statePropertyName] = val;
-
-                // All state keys should exist and at least have a value of null
-                if (!_.every(requiredKeysForInit, key => !_.isUndefined(this.tempState[key]))) {
+                if (!this.state.loading) {
+                    console.error('withOnyx.setInitialState() called after loading: false');
                     return;
                 }
 
-                this.setState({...this.tempState, loading: false}, () => {
-                    this.tempState = {};
-                });
+                this.tempState[statePropertyName] = val;
+
+                // All state keys should exist and at least have a value of null
+                if (_.some(requiredKeysForInit, key => _.isUndefined(this.tempState[key]))) {
+                    return;
+                }
+
+                this.setState({...this.tempState, loading: false});
+                delete this.tempState;
             }
 
             /**

--- a/tests/unit/withOnyxTest.js
+++ b/tests/unit/withOnyxTest.js
@@ -68,7 +68,7 @@ describe('withOnyx', () => {
         })(ViewWithCollections);
         const onRender = jest.fn();
         render(<TestComponentWithOnyx onRender={onRender} />);
-        waitForPromisesToResolve()
+        return waitForPromisesToResolve()
             .then(() => {
                 Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
                     test_1: {ID: 123}, test_2: {ID: 234}, test_3: {ID: 345},
@@ -89,7 +89,7 @@ describe('withOnyx', () => {
         })(ViewWithCollections);
         const onRender = jest.fn();
         render(<TestComponentWithOnyx onRender={onRender} />);
-        waitForPromisesToResolve()
+        return waitForPromisesToResolve()
             .then(() => {
                 Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
                     test_1: {ID: 123}, test_2: {ID: 234}, test_3: {ID: 345},
@@ -110,7 +110,7 @@ describe('withOnyx', () => {
         })(ViewWithCollections);
         const onRender = jest.fn();
         render(<TestComponentWithOnyx onRender={onRender} />);
-        waitForPromisesToResolve()
+        return waitForPromisesToResolve()
             .then(() => {
                 Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {test_4: {ID: 456}, test_5: {ID: 567}});
                 Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {

--- a/tests/unit/withOnyxTest.js
+++ b/tests/unit/withOnyxTest.js
@@ -68,9 +68,13 @@ describe('withOnyx', () => {
         })(ViewWithCollections);
         const onRender = jest.fn();
         render(<TestComponentWithOnyx onRender={onRender} />);
-
-        Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {test_1: {ID: 123}, test_2: {ID: 234}, test_3: {ID: 345}});
-        return waitForPromisesToResolve()
+        waitForPromisesToResolve()
+            .then(() => {
+                Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
+                    test_1: {ID: 123}, test_2: {ID: 234}, test_3: {ID: 345},
+                });
+                return waitForPromisesToResolve();
+            })
             .then(() => {
                 expect(onRender.mock.calls.length).toBe(2);
             });
@@ -85,9 +89,13 @@ describe('withOnyx', () => {
         })(ViewWithCollections);
         const onRender = jest.fn();
         render(<TestComponentWithOnyx onRender={onRender} />);
-
-        Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {test_1: {ID: 123}, test_2: {ID: 234}, test_3: {ID: 345}});
-        return waitForPromisesToResolve()
+        waitForPromisesToResolve()
+            .then(() => {
+                Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
+                    test_1: {ID: 123}, test_2: {ID: 234}, test_3: {ID: 345},
+                });
+                return waitForPromisesToResolve();
+            })
             .then(() => {
                 expect(onRender.mock.calls.length).toBe(2);
             });
@@ -102,13 +110,16 @@ describe('withOnyx', () => {
         })(ViewWithCollections);
         const onRender = jest.fn();
         render(<TestComponentWithOnyx onRender={onRender} />);
-        Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {test_4: {ID: 456}, test_5: {ID: 567}});
-        Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
-            test_4: {Name: 'Test4'},
-            test_5: {Name: 'Test5'},
-            test_6: {ID: 678, Name: 'Test6'},
-        });
-        return waitForPromisesToResolve()
+        waitForPromisesToResolve()
+            .then(() => {
+                Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {test_4: {ID: 456}, test_5: {ID: 567}});
+                Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
+                    test_4: {Name: 'Test4'},
+                    test_5: {Name: 'Test5'},
+                    test_6: {ID: 678, Name: 'Test6'},
+                });
+                return waitForPromisesToResolve();
+            })
             .then(() => {
                 expect(onRender.mock.calls.length).toBe(3);
                 expect(onRender.mock.instances[2].text).toEqual({ID: 456, Name: 'Test4'});


### PR DESCRIPTION
### Details

Implements the idea discussed in the link below cc @kidroca 

**Before change**
![2021-08-12_06-53-51](https://user-images.githubusercontent.com/32969087/129237140-dec32f80-c86d-4bff-9e11-9732a46987ad.png)

**After change:**
![2021-08-12_06-51-51](https://user-images.githubusercontent.com/32969087/129237124-70473b20-4a87-49de-8a49-3e4c8a875f54.png)

Small difference of about 81ms here to total scripting time when the app first becomes active. But this should have positive affects in all other places where a `withOnyx` connection is set up.

### Related Issues
https://github.com/Expensify/App/issues/4592#issuecomment-897672983

### Automated Tests

### Linked PRs
