### PR TITLE
Add test and fix enable-payments page issue

### DIFF
--- a/lib/withOnyx.js
+++ b/lib/withOnyx.js
@@ -41,7 +41,8 @@ export default function (mapOnyxToState) {
                 this.tempState = {};
 
                 this.state = {
-                    loading: true,
+                    // If there are no required keys for init then we can render the wrapped component immediately
+                    loading: requiredKeysForInit.length > 0,
                 };
             }
 

--- a/tests/unit/withOnyxTest.js
+++ b/tests/unit/withOnyxTest.js
@@ -156,6 +156,25 @@ describe('withOnyx', () => {
             });
     });
 
+    it('should render the WrappedComponent if no keys are required for init', () => {
+        const INITIAL_VALUE = 'initial_value';
+        const TestComponentWithOnyx = withOnyx({
+            text: {
+                key: 'test',
+                initWithStoredValues: false,
+            },
+        })(ViewWithText);
+        TestComponentWithOnyx.defaultProps = {
+            text: INITIAL_VALUE,
+        };
+        Onyx.set('test_key', 'test_text');
+        return waitForPromisesToResolve()
+            .then(() => {
+                const {getByTestId} = render(<TestComponentWithOnyx collectionID="1" />);
+                expect(getByTestId('text-element').props.children).toEqual(INITIAL_VALUE);
+            });
+    });
+
     it('should pass a prop from one connected component to another', () => {
         const collectionItemID = 1;
         const onRender = jest.fn();


### PR DESCRIPTION
### Details
If we have no `requiredKeysForInit` `withOnyx` will never render the wrapped component. This will affect any components that have one or more keys flagged as `initWithStoredValues: false`.

### Related Issues
https://github.com/Expensify/App/issues/4719

### Automated Tests

Added an automated test to protect against similar mistakes in the future.

### Linked PRs
https://github.com/Expensify/App/pull/4721