### PR TITLE
Add setState style callback to Onyx.merge()

### DIFF
--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -466,24 +466,6 @@ function evictStorageAndRetry(error, ionMethod, ...args) {
 }
 
 /**
- * @param {String} key
- * @param {*} finalValue
- * @returns {Promise}
- */
-function cacheAndSet(key, finalValue) {
-    // Adds the key to cache when it's not available
-    cache.set(key, finalValue);
-
-    // Optimistically inform subscribers on the next tick
-    Promise.resolve().then(() => keyChanged(key, finalValue));
-
-    // Write the thing to persistent storage, which will trigger a storage event for any other tabs open on this
-    // domain
-    return AsyncStorage.setItem(key, JSON.stringify(finalValue))
-        .catch(error => evictStorageAndRetry(error, cacheAndSet, key, finalValue));
-}
-
-/**
  * Write a value to our store with the given key
  *
  * @param {string} key
@@ -491,11 +473,15 @@ function cacheAndSet(key, finalValue) {
  * @returns {Promise}
  */
 function set(key, val) {
-    if (_.isFunction(val)) {
-        return get(key).then(previousValue => cacheAndSet(key, val(previousValue)));
-    }
+    // Adds the key to cache when it's not available
+    cache.set(key, val);
 
-    return cacheAndSet(key, val);
+    // Optimistically inform subscribers on the next tick
+    Promise.resolve().then(() => keyChanged(key, val));
+
+    // Write the thing to persistent storage, which will trigger a storage event for any other tabs open on this domain
+    return AsyncStorage.setItem(key, JSON.stringify(val))
+        .catch(error => evictStorageAndRetry(error, set, key, val));
 }
 
 /**

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -466,6 +466,24 @@ function evictStorageAndRetry(error, ionMethod, ...args) {
 }
 
 /**
+ * @param {String} key
+ * @param {*} finalValue
+ * @returns {Promise}
+ */
+function cacheAndWrite(key, finalValue) {
+    // Adds the key to cache when it's not available
+    cache.set(key, finalValue);
+
+    // Optimistically inform subscribers on the next tick
+    Promise.resolve().then(() => keyChanged(key, finalValue));
+
+    // Write the thing to persistent storage, which will trigger a storage event for any other tabs open on this
+    // domain
+    return AsyncStorage.setItem(key, JSON.stringify(finalValue))
+        .catch(error => evictStorageAndRetry(error, cacheAndWrite, key, finalValue));
+}
+
+/**
  * Write a value to our store with the given key
  *
  * @param {string} key
@@ -473,24 +491,11 @@ function evictStorageAndRetry(error, ionMethod, ...args) {
  * @returns {Promise}
  */
 function set(key, val) {
-    const cacheAndWrite = (finalValue) => {
-        // Adds the key to cache when it's not available
-        cache.set(key, finalValue);
-
-        // Optimistically inform subscribers on the next tick
-        Promise.resolve().then(() => keyChanged(key, finalValue));
-
-        // Write the thing to persistent storage, which will trigger a storage event for any other tabs open on this
-        // domain
-        return AsyncStorage.setItem(key, JSON.stringify(finalValue))
-            .catch(error => evictStorageAndRetry(error, set, key, finalValue));
-    };
-
     if (_.isFunction(val)) {
-        return get(key).then(previousValue => cacheAndWrite(val(previousValue)));
+        return get(key).then(previousValue => cacheAndWrite(key, val(previousValue)));
     }
 
-    return cacheAndWrite(val);
+    return cacheAndWrite(key, val);
 }
 
 /**

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -472,10 +472,8 @@ function evictStorageAndRetry(error, ionMethod, ...args) {
  * @param {mixed} val
  * @returns {Promise}
  */
-function set(...args) {
-    const [key, val] = args;
-
-    const setWithValue = (finalValue) => {
+function set(key, val) {
+    const cacheAndWrite = (finalValue) => {
         // Adds the key to cache when it's not available
         cache.set(key, finalValue);
 
@@ -489,10 +487,10 @@ function set(...args) {
     };
 
     if (_.isFunction(val)) {
-        return get(key).then(previousValue => setWithValue(val(previousValue)));
+        return get(key).then(previousValue => cacheAndWrite(val(previousValue)));
     }
 
-    return setWithValue(val);
+    return cacheAndWrite(val);
 }
 
 /**

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -472,16 +472,27 @@ function evictStorageAndRetry(error, ionMethod, ...args) {
  * @param {mixed} val
  * @returns {Promise}
  */
-function set(key, val) {
-    // Adds the key to cache when it's not available
-    cache.set(key, val);
+function set(...args) {
+    const [key, val] = args;
 
-    // Optimistically inform subscribers on the next tick
-    Promise.resolve().then(() => keyChanged(key, val));
+    const setWithValue = (finalValue) => {
+        // Adds the key to cache when it's not available
+        cache.set(key, finalValue);
 
-    // Write the thing to persistent storage, which will trigger a storage event for any other tabs open on this domain
-    return AsyncStorage.setItem(key, JSON.stringify(val))
-        .catch(error => evictStorageAndRetry(error, set, key, val));
+        // Optimistically inform subscribers on the next tick
+        Promise.resolve().then(() => keyChanged(key, finalValue));
+
+        // Write the thing to persistent storage, which will trigger a storage event for any other tabs open on this
+        // domain
+        return AsyncStorage.setItem(key, JSON.stringify(finalValue))
+            .catch(error => evictStorageAndRetry(error, set, key, finalValue));
+    };
+
+    if (_.isFunction(val)) {
+        return get(key).then(previousValue => setWithValue(val(previousValue)));
+    }
+
+    return setWithValue(val);
 }
 
 /**

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -470,7 +470,7 @@ function evictStorageAndRetry(error, ionMethod, ...args) {
  * @param {*} finalValue
  * @returns {Promise}
  */
-function cacheAndWrite(key, finalValue) {
+function cacheAndSet(key, finalValue) {
     // Adds the key to cache when it's not available
     cache.set(key, finalValue);
 
@@ -480,7 +480,7 @@ function cacheAndWrite(key, finalValue) {
     // Write the thing to persistent storage, which will trigger a storage event for any other tabs open on this
     // domain
     return AsyncStorage.setItem(key, JSON.stringify(finalValue))
-        .catch(error => evictStorageAndRetry(error, cacheAndWrite, key, finalValue));
+        .catch(error => evictStorageAndRetry(error, cacheAndSet, key, finalValue));
 }
 
 /**
@@ -492,10 +492,10 @@ function cacheAndWrite(key, finalValue) {
  */
 function set(key, val) {
     if (_.isFunction(val)) {
-        return get(key).then(previousValue => cacheAndWrite(key, val(previousValue)));
+        return get(key).then(previousValue => cacheAndSet(key, val(previousValue)));
     }
 
-    return cacheAndWrite(key, val);
+    return cacheAndSet(key, val);
 }
 
 /**

--- a/tests/unit/onyxTest.js
+++ b/tests/unit/onyxTest.js
@@ -264,4 +264,29 @@ describe('Onyx', () => {
             expect(error.message).toEqual(`Provided collection does not have all its data belonging to the same parent. CollectionKey: ${ONYX_KEYS.COLLECTION.TEST_KEY}, DataKey: not_my_test`);
         }
     });
+
+    it('should allowing calling set() with a function as a value similar to React.Component.setState()', () => {
+        let testKeyValue;
+        connectionID = Onyx.connect({
+            key: ONYX_KEYS.TEST_KEY,
+            initWithStoredValues: false,
+            callback: (value) => {
+                testKeyValue = value;
+            },
+        });
+        const errors = {otherProperty: 'test', errors: {fieldOne: true, fieldTwo: true}};
+        return Onyx.set(ONYX_KEYS.TEST_KEY, errors)
+            .then(() => Onyx.set(ONYX_KEYS.TEST_KEY, (previousValue = {}) => ({
+                ...previousValue,
+                errors: {fieldOne: true},
+            })))
+            .then(() => {
+                expect(testKeyValue).toEqual({
+                    otherProperty: 'test',
+                    errors: {
+                        fieldOne: true,
+                    }
+                });
+            });
+    });
 });

--- a/tests/unit/onyxTest.js
+++ b/tests/unit/onyxTest.js
@@ -265,7 +265,7 @@ describe('Onyx', () => {
         }
     });
 
-    it('should allowing calling set() with a function as a value similar to React.Component.setState()', () => {
+    it('should allowing calling merge() with a function as a value similar to React.Component.setState()', () => {
         let testKeyValue;
         connectionID = Onyx.connect({
             key: ONYX_KEYS.TEST_KEY,
@@ -276,7 +276,7 @@ describe('Onyx', () => {
         });
         const errors = {otherProperty: 'test', errors: {fieldOne: true, fieldTwo: true}};
         return Onyx.set(ONYX_KEYS.TEST_KEY, errors)
-            .then(() => Onyx.set(ONYX_KEYS.TEST_KEY, (previousValue = {}) => ({
+            .then(() => Onyx.merge(ONYX_KEYS.TEST_KEY, (previousValue = {}) => ({
                 ...previousValue,
                 errors: {fieldOne: true},
             })))


### PR DESCRIPTION
### Details

cc @roryabraham @aldo-expensify 

This adds a `setState()` style callback to `Onyx.get()` so that we can remove or overwrite object properties without storing local copies. For now, it is up to whoever uses this feature to make sure they are handling a value that doesn't exist and the type. We won't assume what the value should be only that if you pass a function instead of a value you are handling the possibility that there might not be any value to use at all.

### Related Issues
https://github.com/Expensify/Expensify/issues/176419

### Automated Tests
Added a small test to verify the change should work

### Linked PRs
To Do