### PR TITLE
Add log alert for calling set() after merge()

### DIFF
--- a/tests/unit/onyxTest.js
+++ b/tests/unit/onyxTest.js
@@ -264,22 +264,4 @@ describe('Onyx', () => {
             expect(error.message).toEqual(`Provided collection does not have all its data belonging to the same parent. CollectionKey: ${ONYX_KEYS.COLLECTION.TEST_KEY}, DataKey: not_my_test`);
         }
     });
-
-    it('should run set and merge in the order they are called', () => {
-        let methodCalled;
-        Onyx.connect({
-            key: ONYX_KEYS.TEST_KEY,
-            callback: val => methodCalled = val ? val.methodCalled : null,
-        });
-
-        expect(methodCalled).not.toBeDefined();
-
-        const SET_METHOD = 'set';
-        const MERGE_METHOD = 'merge';
-
-        Onyx.merge(ONYX_KEYS.TEST_KEY, {methodCalled: MERGE_METHOD});
-        Onyx.set(ONYX_KEYS.TEST_KEY, {methodCalled: SET_METHOD});
-        return waitForPromisesToResolve()
-            .then(() => expect(methodCalled).toBe(SET_METHOD));
-    });
 });


### PR DESCRIPTION
### Details
cc @kidroca 

- Added failing test that proves there is a race condition when `Onyx.set()` is called after `Onyx.merge()` (now removed but visible in commit history to be re-added later)
- Curious to see the places we are actually doing this in practice so might add logging to report a `set()` after a `merge()` for a given key. So I added an alert log.

### Related Issues
https://github.com/Expensify/App/issues/5930

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->
