### PR TITLE
Return full object to callback subscribers when keysChanged() called

### DIFF
--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -207,6 +207,28 @@ function addAllSafeEvictionKeysToRecentlyAccessedList() {
 }
 
 /**
+ * @private
+ * @param {String} collectionKey
+ * @returns {Object}
+ */
+function getCachedCollection(collectionKey) {
+    const collectionMemberKeys = _.filter(cache.getAllKeys(), (
+        storedKey => isKeyMatch(collectionKey, storedKey)
+    ));
+
+    return _.reduce(collectionMemberKeys, (prev, curr) => {
+        const cachedValue = cache.getValue(curr);
+        if (!cachedValue) {
+            return prev;
+        }
+        return ({
+            ...prev,
+            [curr]: cachedValue,
+        });
+    }, {});
+}
+
+/**
  * When a collection of keys change, search for any callbacks matching the collection key and trigger those callbacks
  *
  * @param {String} collectionKey
@@ -225,8 +247,10 @@ function keysChanged(collectionKey, collection) {
 
         if (isSubscribedToCollectionKey) {
             if (_.isFunction(subscriber.callback)) {
+                // eslint-disable-next-line no-use-before-define
+                const cachedCollection = getCachedCollection(collectionKey);
                 _.each(collection, (data, dataKey) => {
-                    subscriber.callback(data, dataKey);
+                    subscriber.callback(cachedCollection[dataKey], dataKey);
                 });
             } else if (subscriber.withOnyxInstance) {
                 subscriber.withOnyxInstance.setState((prevState) => {

--- a/tests/unit/onyxTest.js
+++ b/tests/unit/onyxTest.js
@@ -264,4 +264,46 @@ describe('Onyx', () => {
             expect(error.message).toEqual(`Provided collection does not have all its data belonging to the same parent. CollectionKey: ${ONYX_KEYS.COLLECTION.TEST_KEY}, DataKey: not_my_test`);
         }
     });
+
+    it('should return full object to callback when calling mergeCollection()', () => {
+        const valuesReceived = {};
+        connectionID = Onyx.connect({
+            key: ONYX_KEYS.COLLECTION.TEST_KEY,
+            initWithStoredValues: false,
+            callback: (data, key) => valuesReceived[key] = data,
+        });
+
+        return Onyx.multiSet({
+            test_1: {
+                existingData: 'test',
+            },
+            test_2: {
+                existingData: 'test',
+            }
+        })
+            .then(() => Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
+                test_1: {
+                    ID: 123,
+                    value: 'one'
+                },
+                test_2: {
+                    ID: 234,
+                    value: 'two'
+                },
+            }))
+            .then(() => {
+                expect(valuesReceived).toEqual({
+                    test_1: {
+                        ID: 123,
+                        value: 'one',
+                        existingData: 'test',
+                    },
+                    test_2: {
+                        ID: 234,
+                        value: 'two',
+                        existingData: 'test',
+                    },
+                });
+            });
+    });
 });


### PR DESCRIPTION
### Details

More details in the linked issue, but as @kidroca found a while back when `Onyx.mergeCollection()` is called we only pass the source values to the callback subscribers. This is pretty weird so I wrote a test for it and fixed.

### Related Issues
https://github.com/Expensify/react-native-onyx/issues/77

### Automated Tests

✅ 

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->
