### PR TITLE
Throw and do not evict storage when bad data is set to Onyx

### DIFF
--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -500,7 +500,7 @@ function remove(key) {
 function evictStorageAndRetry(error, onyxMethod, ...args) {
     logInfo(`Handled error: ${error}`);
 
-    if (Str.startsWith(error.message, 'Failed to execute \'put\' on \'IDBObjectStore\'')) {
+    if (error && Str.startsWith(error.message, 'Failed to execute \'put\' on \'IDBObjectStore\'')) {
         logAlert('Attempted to set invalid data set in Onyx. Please ensure all data is serializable.');
         throw error;
     }

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -500,6 +500,11 @@ function remove(key) {
 function evictStorageAndRetry(error, onyxMethod, ...args) {
     logInfo(`Handled error: ${error}`);
 
+    if (Str.startsWith(error.message, 'Failed to execute \'put\' on \'IDBObjectStore\'')) {
+        logAlert('Attempted to set invalid data set in Onyx. Please ensure all data is serializable.');
+        throw error;
+    }
+
     // Find the first key that we can remove that has no subscribers in our blocklist
     const keyForRemoval = _.find(recentlyAccessedKeys, key => !evictionBlocklist[key]);
 


### PR DESCRIPTION
### Details

When setting non-serializable data in Onyx we are catching the error and trying to empty the storage. We are at the moment naively assuming that any error is a storage issue. This will make sure that we do not treat IndexedDB "put" errors as storage issues.

### Related Issues
https://github.com/Expensify/react-native-onyx/issues/115

### Linked PRs
https://github.com/Expensify/App/pull/7343