### PR TITLE
Fix: handle `null` values and stringify them

### DIFF
--- a/lib/storage/providers/AsyncStorage.js
+++ b/lib/storage/providers/AsyncStorage.js
@@ -6,20 +6,6 @@
 import _ from 'underscore';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
-/**
- * Values other than null and undefined should be stringified before
- * they are saved in storage
- * @param {*} value
- * @returns {string|null}
- */
-function prepareValueForStorage(value) {
-    if (_.isUndefined(value) || _.isNull(value)) {
-        return value;
-    }
-
-    return JSON.stringify(value);
-}
-
 const provider = {
     /**
      * Get the value of a given key or return `null` if it's not available in storage
@@ -51,7 +37,7 @@ const provider = {
      * @return {Promise<void>}
      */
     setItem(key, value) {
-        return AsyncStorage.setItem(key, prepareValueForStorage(value));
+        return AsyncStorage.setItem(key, JSON.stringify(value));
     },
 
     /**
@@ -60,7 +46,7 @@ const provider = {
      * @return {Promise<void>}
      */
     multiSet(pairs) {
-        const stringPairs = _.map(pairs, ([key, value]) => [key, prepareValueForStorage(value)]);
+        const stringPairs = _.map(pairs, ([key, value]) => [key, JSON.stringify(value)]);
         return AsyncStorage.multiSet(stringPairs);
     },
 
@@ -70,7 +56,7 @@ const provider = {
      * @return {Promise<void>}
      */
     multiMerge(pairs) {
-        const stringPairs = _.map(pairs, ([key, value]) => [key, prepareValueForStorage(value)]);
+        const stringPairs = _.map(pairs, ([key, value]) => [key, JSON.stringify(value)]);
         return AsyncStorage.multiMerge(stringPairs);
     },
 

--- a/tests/unit/storage/providers/AsyncStorageProviderTest.js
+++ b/tests/unit/storage/providers/AsyncStorageProviderTest.js
@@ -14,6 +14,7 @@ describe('storage/providers/AsyncStorage', () => {
         ['false', false],
         ['object', {id: 'Object', nested: {content: 'Nested object'}}],
         ['number', 100],
+        ['null', null],
     ];
 
     describe('setItem', () => {
@@ -29,6 +30,7 @@ describe('storage/providers/AsyncStorage', () => {
                 ['false', 'false'],
                 ['object', '{"id":"Object","nested":{"content":"Nested object"}}'],
                 ['number', '100'],
+                ['null', 'null'],
             ];
 
             // When sample items are saved
@@ -80,6 +82,7 @@ describe('storage/providers/AsyncStorage', () => {
                 ['false', 'false'],
                 ['object', '{"id":"Object","nested":{"content":"Nested object"}}'],
                 ['number', '100'],
+                ['null', 'null'],
             ];
 
             // When sample items are saved


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
AsyncStorage would throw an error when it is called with a `null` value instead of storing `null` for the key
In the past we stringified every value we tried to set in storage, this PR brings back the original behavior 

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
$ https://github.com/Expensify/App/issues/7361

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
Updated AsyncStorage set tests to cover `null` input and verify it's getting stringified

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->
