### PR TITLE
Prevent setting state on unmounted withOnyx components

### DIFF
--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -358,6 +358,12 @@ function keyChanged(key, data) {
  * @param {String} key
  */
 function sendDataToConnection(config, val, key) {
+    // If the mapping no longer exists then we should not send any data.
+    // This means our subscriber disconnected or withOnyx wrapped component unmounted.
+    if (!callbackToStateMapping[config.connectionID]) {
+        return;
+    }
+
     if (config.withOnyxInstance) {
         config.withOnyxInstance.setWithOnyxState(config.statePropertyName, val);
     } else if (_.isFunction(config.callback)) {
@@ -388,6 +394,7 @@ function sendDataToConnection(config, val, key) {
 function connect(mapping) {
     const connectionID = lastConnectionID++;
     callbackToStateMapping[connectionID] = mapping;
+    callbackToStateMapping[connectionID].connectionID = connectionID;
 
     if (mapping.initWithStoredValues === false) {
         return connectionID;


### PR DESCRIPTION
### Details
Calls to `Onyx.connect()` can call `setState()` after a component unmounts. This stashes a reference to the `connectionID` in the connection map. When `withOnyx()` unmounts it should be calling `disconnect()` which will remove the connection from the map. However, we don't check to see if it's been deleted when we call `sendDataToConnection()`.

### Related Issues

https://github.com/Expensify/Expensify/issues/198762

### Linked PRs

