### PR TITLE
Add write queue to localForage storage provider

### DIFF
--- a/lib/promiseAllSettled.js
+++ b/lib/promiseAllSettled.js
@@ -1,0 +1,10 @@
+import _ from 'underscore';
+
+export default (arrayOfPromises) => {
+    const wrappedPromises = _.map(arrayOfPromises, p => Promise.resolve(p)
+        .then(
+            val => ({status: 'fulfilled', value: val}),
+            err => ({status: 'rejected', reason: err}),
+        ));
+    return Promise.all(wrappedPromises);
+};

--- a/lib/storage/providers/LocalForage.js
+++ b/lib/storage/providers/LocalForage.js
@@ -7,10 +7,40 @@
 import localforage from 'localforage';
 import _ from 'underscore';
 import lodashMerge from 'lodash/merge';
+import promiseAllSettled from '../../promiseAllSettled';
 
 localforage.config({
     name: 'OnyxDB'
 });
+
+const MAX_BATCH_SIZE = 20;
+const writeQueue = [];
+let isQueueProcessing = false;
+
+/**
+ * Writing very quickly to IndexedDB causes performance issues and can lock up the page and lead to jank.
+ * So, we are slowing this process down a bit here by waiting until one batch of writes is complete before moving on
+ * to the next.
+ */
+function processNextWriteQueueBatch() {
+    if (isQueueProcessing || writeQueue.length === 0) {
+        return;
+    }
+
+    isQueueProcessing = true;
+
+    const nextBatch = _.map(writeQueue.splice(0, MAX_BATCH_SIZE), ({
+        key, value, resolve, reject,
+    }) => localforage.setItem(key, value)
+        .then(resolve)
+        .catch(reject));
+
+    promiseAllSettled(nextBatch)
+        .then(() => {
+            isQueueProcessing = false;
+            processNextWriteQueueBatch();
+        });
+}
 
 const provider = {
     /**
@@ -90,7 +120,14 @@ const provider = {
      * @param {*} value
      * @return {Promise<void>}
      */
-    setItem: localforage.setItem,
+    setItem: (key, value) => (
+        new Promise((resolve, reject) => {
+            writeQueue.push({
+                key, value, resolve, reject,
+            });
+            processNextWriteQueueBatch();
+        })
+    ),
 };
 
 export default provider;

--- a/tests/unit/storage/providers/LocalForageProviderTest.js
+++ b/tests/unit/storage/providers/LocalForageProviderTest.js
@@ -15,17 +15,21 @@ describe('storage/providers/LocalForage', () => {
 
     // For some reason fake timers cause promises to hang
     beforeAll(() => jest.useRealTimers());
-    beforeEach(() => jest.resetAllMocks());
+    beforeEach(() => {
+        jest.resetAllMocks();
+        localforage.setItem = jest.fn(() => Promise.resolve());
+    });
 
     it('multiSet', () => {
         // Given multiple pairs to be saved in storage
         const pairs = SAMPLE_ITEMS.slice();
 
         // When they are saved
-        StorageProvider.multiSet(pairs);
-
-        // We expect a call to localForage.setItem for each pair
-        _.each(pairs, ([key, value]) => expect(localforage.setItem).toHaveBeenCalledWith(key, value));
+        return StorageProvider.multiSet(pairs)
+            .then(() => {
+                // We expect a call to localForage.setItem for each pair
+                _.each(pairs, ([key, value]) => expect(localforage.setItem).toHaveBeenCalledWith(key, value));
+            });
     });
 
     it('multiGet', () => {


### PR DESCRIPTION
cc @kidroca curious if you see any issues with this approach

### Details

IndexedDB writes are causing major page jank when refreshing a page or signing in for the first time. 

Trying to figure out a solution in this PR hopefully.

Just added a basic kind of queue that will limit the total number of parallel writes to IDB so we aren't locking things up too bad.

Definitely got something wrong here as there's an issue on first sign in where no data seems to load until the page is refreshed. Still looking into why, but I think in theory if we just slow down writing to IndexedDB it should help performance.

### Related Issues
### Automated Tests
### Linked PRs