### PR TITLE
feat: add config option to disable sync events for some keys

### DIFF
--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -796,7 +796,8 @@ function mergeCollection(collectionKey, collection) {
  * @param {Boolean} [options.captureMetrics] Enables Onyx benchmarking and exposes the get/print/reset functions
  * @param {Boolean} [options.shouldSyncMultipleInstances] Auto synchronize storage events between multiple instances
  * of Onyx running in different tabs/windows. Defaults to true for platforms that support local storage (web/desktop)
- *
+ * @param {String[]} [option.keysToDisableSyncEvents=[]] Contains keys for which we want to disable sync event across tabs.
+ * 
  * @example
  * Onyx.init({
  *     keys: ONYXKEYS,
@@ -812,6 +813,7 @@ function init({
     maxCachedKeysCount = 1000,
     captureMetrics = false,
     shouldSyncMultipleInstances = Boolean(global.localStorage),
+    keysToDisableSyncEvents = [],
 } = {}) {
     if (captureMetrics) {
         // The code here is only bundled and applied when the captureMetrics is set
@@ -840,7 +842,7 @@ function init({
         .then(deferredInitTask.resolve);
 
     if (shouldSyncMultipleInstances && _.isFunction(Storage.keepInstancesSync)) {
-        Storage.keepInstancesSync((key, value) => {
+        Storage.keepInstancesSync(keysToDisableSyncEvents, (key, value) => {
             cache.set(key, value);
             keyChanged(key, value);
         });

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -796,8 +796,8 @@ function mergeCollection(collectionKey, collection) {
  * @param {Boolean} [options.captureMetrics] Enables Onyx benchmarking and exposes the get/print/reset functions
  * @param {Boolean} [options.shouldSyncMultipleInstances] Auto synchronize storage events between multiple instances
  * of Onyx running in different tabs/windows. Defaults to true for platforms that support local storage (web/desktop)
- * @param {String[]} [option.keysToDisableSyncEvents=[]] Contains keys for which we want to disable sync event across tabs.
- * 
+ * @param {String[]} [option.keysToDisableSyncEvents=[]] Contains keys for which
+ * we want to disable sync event across tabs.
  * @example
  * Onyx.init({
  *     keys: ONYXKEYS,

--- a/lib/storage/WebStorage.js
+++ b/lib/storage/WebStorage.js
@@ -16,10 +16,12 @@ const webStorage = {
     ...Storage,
 
     /**
+     * Contains keys for which we want to disable sync event across tabs.
+     * @param {String[]} keysToDisableSyncEvents
      * Storage synchronization mechanism keeping all opened tabs in sync
      * @param {function(key: String, data: *)} onStorageKeyChanged
      */
-    keepInstancesSync(onStorageKeyChanged) {
+    keepInstancesSync(keysToDisableSyncEvents, onStorageKeyChanged) {
         // Override set, remove and clear to raise storage events that we intercept in other tabs
         this.setItem = (key, value) => Storage.setItem(key, value)
             .then(() => raiseStorageSyncEvent(key));
@@ -41,6 +43,8 @@ const webStorage = {
             }
 
             const onyxKey = event.newValue;
+            if(_.contains(keysToDisableSyncEvents, onyxKey)) return;
+
             Storage.getItem(onyxKey)
                 .then(value => onStorageKeyChanged(onyxKey, value));
         });

--- a/lib/storage/WebStorage.js
+++ b/lib/storage/WebStorage.js
@@ -43,7 +43,9 @@ const webStorage = {
             }
 
             const onyxKey = event.newValue;
-            if(_.contains(keysToDisableSyncEvents, onyxKey)) return;
+            if (_.contains(keysToDisableSyncEvents, onyxKey)) {
+                return;
+            }
 
             Storage.getItem(onyxKey)
                 .then(value => onStorageKeyChanged(onyxKey, value));


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
When user opens multiple tabs with different reports. We do not want some data in onyx to sync across tabs. This pr will add a feature that we can configure keys for which we do not want to subscribe to data change.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/react-native-onyx/issues/127

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
We'd have a hard time writing an automated test here as we need the storage event to be mocked somehow.
### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->
https://github.com/Expensify/App/pull/8759