### PR TITLE
Trigger callbacks with merged cache data when initializing with default key states 

### DIFF
--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -699,9 +699,9 @@ function initializeWithDefaultKeyStates() {
 
             const merged = lodashMerge(asObject, defaultKeyStates);
             cache.merge(merged);
-            _.each(merged, (_, key) => {
+            _.each(merged, (val, key) => {
                 const currentValue = cache.getValue(key);
-                keyChanged(key, currentValue)
+                keyChanged(key, currentValue);
             });
         });
 }

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -699,7 +699,10 @@ function initializeWithDefaultKeyStates() {
 
             const merged = lodashMerge(asObject, defaultKeyStates);
             cache.merge(merged);
-            _.each(merged, (val, key) => keyChanged(key, val));
+            _.each(merged, (_, key) => {
+                const currentValue = cache.getValue(key);
+                keyChanged(key, currentValue)
+            });
         });
 }
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->
cc @marcaaron
### Details
<!-- Explanation of the change or anything fishy that is going on -->
Merge user provided default key value pairs with not only the data in storage, but also the data in the cache. See the issue for more context.
### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/react-native-onyx/issues/125

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->
https://github.com/Expensify/App/issues/8676