### PR TITLE
Set default key states when clearing the cache

### DIFF
--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -707,11 +707,11 @@ function initializeWithDefaultKeyStates() {
 /**
  * Clear out all the data in the store
  *
- * Note that calling Onyx.clear and then Onyx.set on a key with a default
+ * Note that calling Onyx.clear() and then Onyx.set() on a key with a default
  * key state may store an unexpected value in Storage.
  *
- * Onyx.set might call Storage.setItem before Onyx.clear calls
- * Storage.setItem. Use Onyx.merge instead if possible.
+ * Onyx.set() might call Storage.setItem() before Onyx.clear() calls
+ * Storage.setItem(). Use Onyx.merge() instead if possible.
  *
  * @returns {Promise<void>}
  */

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -707,6 +707,12 @@ function initializeWithDefaultKeyStates() {
 /**
  * Clear out all the data in the store
  *
+ * Note that calling Onyx.clear and then Onyx.set on a key with a default
+ * key state may store an unexpected value in Storage.
+ *
+ * Onyx.set might call Storage.setItem before Onyx.clear calls
+ * Storage.setItem. Use Onyx.merge instead if possible.
+ *
  * @returns {Promise<void>}
  */
 function clear() {

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -718,6 +718,7 @@ function clear() {
                 cache.set(key, resetValue);
             });
         })
+        .then(() => console.log('[Onyx test] Done clearing the Onyx cache'))
         .then(Storage.clear);
 }
 

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -718,7 +718,6 @@ function clear() {
                 cache.set(key, resetValue);
             });
         })
-        .then(() => console.log('[Onyx test] Done clearing the Onyx cache'))
         .then(Storage.clear);
 }
 

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -735,8 +735,8 @@ function clear() {
                 // Optimistically inform subscribers on the next tick
                 Promise.resolve().then(() => keyChanged(key, resetValue));
             });
-        })
-        .then(Storage.clear);
+            Storage.clear();
+        });
 }
 
 /**

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -710,8 +710,18 @@ function initializeWithDefaultKeyStates() {
  * Note that calling Onyx.clear() and then Onyx.set() on a key with a default
  * key state may store an unexpected value in Storage.
  *
+ * E.g.
+ * Onyx.clear();
+ * Onyx.set(ONYXKEYS.DEFAULT_KEY, 'default');
+ * Storage.getItem(ONYXKEYS.DEFAULT_KEY)
+ *     .then((storedValue) => console.log(storedValue));
+ * null is logged instead of the expected 'default'
+ *
  * Onyx.set() might call Storage.setItem() before Onyx.clear() calls
- * Storage.setItem(). Use Onyx.merge() instead if possible.
+ * Storage.setItem(). Use Onyx.merge() instead if possible. Onyx.merge() calls
+ * Onyx.get(key) before calling Storage.setItem() via Onyx.set().
+ * Storage.setItem() from Onyx.clear() will have already finished and the merged
+ * value will be saved to storage after the default value.
  *
  * @returns {Promise<void>}
  */

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -714,8 +714,10 @@ function clear() {
         .then((keys) => {
             _.each(keys, (key) => {
                 const resetValue = lodashGet(defaultKeyStates, key, null);
-                keyChanged(key, resetValue);
                 cache.set(key, resetValue);
+
+                // Optimistically inform subscribers on the next tick
+                Promise.resolve().then(() => keyChanged(key, resetValue));
             });
         })
         .then(Storage.clear);

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -1,6 +1,7 @@
 import _ from 'underscore';
 import Str from 'expensify-common/lib/str';
 import lodashMerge from 'lodash/merge';
+import lodashGet from 'lodash/get';
 import Storage from './storage';
 
 import {registerLogger, logInfo, logAlert} from './Logger';
@@ -712,12 +713,12 @@ function clear() {
     return getAllKeys()
         .then((keys) => {
             _.each(keys, (key) => {
-                keyChanged(key, null);
-                cache.set(key, null);
+                const resetValue = lodashGet(defaultKeyStates, key, null);
+                keyChanged(key, resetValue);
+                cache.set(key, resetValue);
             });
         })
-        .then(Storage.clear)
-        .then(initializeWithDefaultKeyStates);
+        .then(Storage.clear);
 }
 
 /**

--- a/tests/unit/onyxClearNativeStorageTest.js
+++ b/tests/unit/onyxClearNativeStorageTest.js
@@ -8,7 +8,7 @@ const ONYX_KEYS = {
 
 jest.useFakeTimers();
 
-const storageCallResolveList = [];
+let storageCallResolveList = [];
 function addStorageCallResolve(name) {
     storageCallResolveList.push(name);
 }
@@ -17,7 +17,7 @@ function storageCallResolveOrder(methodName) {
     return storageCallResolveList.indexOf(methodName) + 1;
 }
 
-const storageCallQueue = [];
+let storageCallQueue = [];
 
 // Mock clear to wait for promises and add a delay
 Storage.clear = jest.fn(() => Promise.all(storageCallQueue)
@@ -62,6 +62,8 @@ describe('Set data while storage is clearing', () => {
     });
 
     afterEach(() => {
+        storageCallResolveList = [];
+        storageCallQueue = [];
         Onyx.disconnect(connectionID);
         Onyx.clear();
         jest.runAllTimers();

--- a/tests/unit/onyxClearNativeStorageTest.js
+++ b/tests/unit/onyxClearNativeStorageTest.js
@@ -1,4 +1,4 @@
-import AsyncStorageMock from '@react-native-async-storage/async-storage';
+import AsyncStorageMock from '../../__mocks__/@react-native-async-storage/async-storage';
 import Storage from '../../lib/storage';
 import waitForPromisesToResolve from '../utils/waitForPromisesToResolve';
 

--- a/tests/unit/onyxClearNativeStorageTest.js
+++ b/tests/unit/onyxClearNativeStorageTest.js
@@ -127,4 +127,31 @@ describe('Set data while storage is clearing', () => {
                 expect(storedValue).resolves.not.toBe(setValue);
             });
     });
+
+    it('should replace the value of Onyx.set with the default key state in the cache', () => {
+        let defaultValue;
+        connectionID = Onyx.connect({
+            key: ONYX_KEYS.DEFAULT_KEY,
+            initWithStoredValues: false,
+            callback: val => defaultValue = val,
+        });
+        const setValue = 'set';
+        expect.assertions(6);
+        Onyx.set(ONYX_KEYS.DEFAULT_KEY, setValue);
+        Storage.clear = jest.fn(() => AsyncStorageMock.clear());
+        Onyx.clear();
+        return waitForPromisesToResolve()
+            .then(() => {
+                expect(storageCallResolveOrder('setItem')).toBe(1);
+                expect(storageCallResolveOrder('clear')).toBe(2);
+                expect(defaultValue).toBe('default');
+                const cachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
+                expect(cachedValue).toBe('default');
+                const storedValue = Storage.getItem(ONYX_KEYS.DEFAULT_KEY);
+
+                // The default key state is never stored during Onyx.clear
+                expect(storedValue).resolves.not.toBe('default');
+                expect(storedValue).resolves.toBeNull();
+            });
+    });
 });

--- a/tests/unit/onyxClearNativeStorageTest.js
+++ b/tests/unit/onyxClearNativeStorageTest.js
@@ -5,6 +5,9 @@ import waitForPromisesToResolve from '../utils/waitForPromisesToResolve';
 const ONYX_KEYS = {
     DEFAULT_KEY: 'defaultKey',
 };
+const SET_VALUE = 'set';
+const MERGED_VALUE = 'merged';
+const DEFAULT_VALUE = 'default';
 
 let storageCallResolveList = [];
 function addStorageCallResolve(name) {
@@ -50,7 +53,7 @@ describe('Set data while storage is clearing', () => {
             keys: ONYX_KEYS,
             registerStorageEventListener: () => {},
             initialKeyStates: {
-                [ONYX_KEYS.DEFAULT_KEY]: 'default',
+                [ONYX_KEYS.DEFAULT_KEY]: DEFAULT_VALUE,
             },
         });
     });
@@ -77,11 +80,10 @@ describe('Set data while storage is clearing', () => {
             initWithStoredValues: false,
             callback: val => defaultValue = val,
         });
-        const mergedValue = 'merged';
         expect.assertions(5);
         Storage.clear = jest.fn(() => {
             // Call merge between the cache and storage clearing
-            Onyx.merge(ONYX_KEYS.DEFAULT_KEY, mergedValue);
+            Onyx.merge(ONYX_KEYS.DEFAULT_KEY, MERGED_VALUE);
             AsyncStorageMock.clear();
             return waitForPromisesToResolve();
         });
@@ -90,11 +92,11 @@ describe('Set data while storage is clearing', () => {
             .then(() => {
                 expect(storageCallResolveOrder('clear')).toBe(1);
                 expect(storageCallResolveOrder('setItem')).toBe(2);
-                expect(defaultValue).toBe(mergedValue);
+                expect(defaultValue).toBe(MERGED_VALUE);
                 const cachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
-                expect(cachedValue).toBe(mergedValue);
+                expect(cachedValue).toBe(MERGED_VALUE);
                 const storedValue = Storage.getItem(ONYX_KEYS.DEFAULT_KEY);
-                expect(storedValue).resolves.toBe(mergedValue);
+                expect(storedValue).resolves.toBe(MERGED_VALUE);
             });
     });
 
@@ -105,11 +107,10 @@ describe('Set data while storage is clearing', () => {
             initWithStoredValues: false,
             callback: val => defaultValue = val,
         });
-        const setValue = 'set';
         expect.assertions(5);
         Storage.clear = jest.fn(() => {
             // Call set between the cache and storage clearing
-            Onyx.set(ONYX_KEYS.DEFAULT_KEY, setValue);
+            Onyx.set(ONYX_KEYS.DEFAULT_KEY, SET_VALUE);
             AsyncStorageMock.clear();
             return waitForPromisesToResolve();
         });
@@ -120,11 +121,11 @@ describe('Set data while storage is clearing', () => {
                 // AsyncStorage.setItem resolves before AsyncStorage.clear
                 expect(storageCallResolveOrder('setItem')).toBe(1);
                 expect(storageCallResolveOrder('clear')).toBe(2);
-                expect(defaultValue).toBe(setValue);
+                expect(defaultValue).toBe(SET_VALUE);
                 const cachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
-                expect(cachedValue).toBe(setValue);
+                expect(cachedValue).toBe(SET_VALUE);
                 const storedValue = Storage.getItem(ONYX_KEYS.DEFAULT_KEY);
-                expect(storedValue).resolves.not.toBe(setValue);
+                expect(storedValue).resolves.not.toBe(SET_VALUE);
             });
     });
 
@@ -135,22 +136,21 @@ describe('Set data while storage is clearing', () => {
             initWithStoredValues: false,
             callback: val => defaultValue = val,
         });
-        const setValue = 'set';
         expect.assertions(6);
-        Onyx.set(ONYX_KEYS.DEFAULT_KEY, setValue);
+        Onyx.set(ONYX_KEYS.DEFAULT_KEY, SET_VALUE);
         Storage.clear = jest.fn(() => AsyncStorageMock.clear());
         Onyx.clear();
         return waitForPromisesToResolve()
             .then(() => {
                 expect(storageCallResolveOrder('setItem')).toBe(1);
                 expect(storageCallResolveOrder('clear')).toBe(2);
-                expect(defaultValue).toBe('default');
+                expect(defaultValue).toBe(DEFAULT_VALUE);
                 const cachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
-                expect(cachedValue).toBe('default');
+                expect(cachedValue).toBe(DEFAULT_VALUE);
                 const storedValue = Storage.getItem(ONYX_KEYS.DEFAULT_KEY);
 
                 // The default key state is never stored during Onyx.clear
-                expect(storedValue).resolves.not.toBe('default');
+                expect(storedValue).resolves.not.toBe(DEFAULT_VALUE);
                 expect(storedValue).resolves.toBeNull();
             });
     });

--- a/tests/unit/onyxClearNativeStorageTest.js
+++ b/tests/unit/onyxClearNativeStorageTest.js
@@ -50,6 +50,12 @@ describe('Set data while storage is clearing', () => {
 
     beforeAll(() => {
         Onyx = require('../../index').default;
+    });
+
+    // Always use a "fresh" cache instance
+    beforeEach(() => {
+        onyxValue = null;
+        cache = require('../../lib/OnyxCache').default;
         Onyx.init({
             keys: ONYX_KEYS,
             registerStorageEventListener: () => {},
@@ -57,12 +63,6 @@ describe('Set data while storage is clearing', () => {
                 [ONYX_KEYS.DEFAULT_KEY]: DEFAULT_VALUE,
             },
         });
-    });
-
-    // Always use a "fresh" cache instance
-    beforeEach(() => {
-        onyxValue = null;
-        cache = require('../../lib/OnyxCache').default;
         connectionID = Onyx.connect({
             key: ONYX_KEYS.DEFAULT_KEY,
             initWithStoredValues: false,

--- a/tests/unit/onyxClearNativeStorageTest.js
+++ b/tests/unit/onyxClearNativeStorageTest.js
@@ -82,8 +82,10 @@ describe('Set data while storage is clearing', () => {
 
     it('should persist the value of Onyx.merge when called between the cache and storage clearing', () => {
         expect.assertions(5);
+
+        // WHEN Onyx.clear() is called
         Storage.clear = jest.fn(() => {
-            // Call merge between the cache and storage clearing
+            // WHEN merge is called between the cache and storage clearing, on a key with a default key state
             Onyx.merge(ONYX_KEYS.DEFAULT_KEY, MERGED_VALUE);
             AsyncStorageMock.clear();
             return waitForPromisesToResolve();
@@ -91,8 +93,11 @@ describe('Set data while storage is clearing', () => {
         Onyx.clear();
         return waitForPromisesToResolve()
             .then(() => {
+                // THEN the storage finishes clearing before Storage.setItem finishes for the merged value
                 expect(getStorageCallResolveOrder('clear')).toBe(1);
                 expect(getStorageCallResolveOrder('setItem')).toBe(2);
+
+                // THEN the value in Onyx, the cache, and the storage are the merged value
                 expect(onyxValue).toBe(MERGED_VALUE);
                 const cachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
                 expect(cachedValue).toBe(MERGED_VALUE);

--- a/tests/unit/onyxClearNativeStorageTest.js
+++ b/tests/unit/onyxClearNativeStorageTest.js
@@ -146,32 +146,15 @@ describe('Set data while storage is clearing', () => {
     });
 
     it('should replace the value of Onyx.merge with the default key state in the cache', () => {
-        let onyxValue;
-        connectionID = Onyx.connect({
-            key: ONYX_KEYS.DEFAULT_KEY,
-            initWithStoredValues: false,
-            callback: val => onyxValue = val,
-        });
         expect.assertions(6);
         Onyx.merge(ONYX_KEYS.DEFAULT_KEY, MERGED_VALUE);
         Storage.clear = jest.fn(() => AsyncStorageMock.clear());
         Onyx.clear();
         return waitForPromisesToResolve()
             .then(() => {
-                // Onnyx.merge calls Onyx.set which sets "merged" in the cache.
-                // The within Onyx.clear as the cache clears keyChanged is
-                // called with the resetValue of 'defaut' so the onyxValue is
-                // 'default' and same for the cache. Then keyChanged is called
-                // from Onyx.set and the onyxValue is 'merged'. At that point
-                // the cache is done clearing. Storage.setItem finishes setting
-                // the storage to 'merged'. Then clear finishes, setting it to
-                // null.
-                // The end result is that the cachedValue is 'default',
-                // the onyxValue is 'merged', and the storage is null.
-
                 expect(storageCallResolveOrder('setItem')).toBe(1);
                 expect(storageCallResolveOrder('clear')).toBe(2);
-                expect(onyxValue).toBe(MERGED_VALUE);
+                expect(onyxValue).toBe(DEFAULT_VALUE);
                 const cachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
                 expect(cachedValue).toBe(DEFAULT_VALUE);
                 const storedValue = Storage.getItem(ONYX_KEYS.DEFAULT_KEY);

--- a/tests/unit/onyxClearNativeStorageTest.js
+++ b/tests/unit/onyxClearNativeStorageTest.js
@@ -98,7 +98,7 @@ describe('Set data while storage is clearing', () => {
                 expect(getStorageCallResolveOrder('clear')).toBe(1);
                 expect(getStorageCallResolveOrder('setItem')).toBe(2);
 
-                // THEN the value in Onyx, the cache, and the storage are the merged value
+                // THEN the value in Onyx, the cache, and the storage is the merged value
                 expect(onyxValue).toBe(MERGED_VALUE);
                 const cachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
                 expect(cachedValue).toBe(MERGED_VALUE);
@@ -109,37 +109,51 @@ describe('Set data while storage is clearing', () => {
 
     it('should replace the value of Onyx.set with the default key state in the cache', () => {
         expect.assertions(5);
+
+        // GIVEN that Onyx is completely clear
+        // WHEN set then clear is called on a key with a default key state
         Onyx.set(ONYX_KEYS.DEFAULT_KEY, SET_VALUE);
         Storage.clear = jest.fn(() => AsyncStorageMock.clear());
         Onyx.clear();
         return waitForPromisesToResolve()
             .then(() => {
+                // THEN the Storage.setItem finishes for the set value before the storage finishes clearing
                 expect(getStorageCallResolveOrder('setItem')).toBe(1);
                 expect(getStorageCallResolveOrder('clear')).toBe(2);
+
+                // THEN the value in Onyx and the cache is the default key state
                 expect(onyxValue).toBe(DEFAULT_VALUE);
                 const cachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
                 expect(cachedValue).toBe(DEFAULT_VALUE);
-                const storedValue = Storage.getItem(ONYX_KEYS.DEFAULT_KEY);
 
+                // THEN the value in Storage is null
                 // The default key state is never stored during Onyx.clear
+                const storedValue = Storage.getItem(ONYX_KEYS.DEFAULT_KEY);
                 return expect(storedValue).resolves.toBeNull();
             });
     });
 
     it('should replace the value of Onyx.merge with the default key state in the cache', () => {
         expect.assertions(5);
+
+        // GIVEN that Onyx is completely clear
+        // WHEN merge then clear is called on a key with a default key state
         Onyx.merge(ONYX_KEYS.DEFAULT_KEY, MERGED_VALUE);
         Storage.clear = jest.fn(() => AsyncStorageMock.clear());
         Onyx.clear();
         return waitForPromisesToResolve()
             .then(() => {
+                // THEN the Storage.setItem finishes for the merged value before the storage finishes clearing
                 expect(getStorageCallResolveOrder('setItem')).toBe(1);
                 expect(getStorageCallResolveOrder('clear')).toBe(2);
+
+                // THEN the value in Onyx and the cache is the default key state
                 expect(onyxValue).toBe(DEFAULT_VALUE);
                 const cachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
                 expect(cachedValue).toBe(DEFAULT_VALUE);
                 const storedValue = Storage.getItem(ONYX_KEYS.DEFAULT_KEY);
 
+                // THEN the value in Storage is null
                 // The default key state is never stored during Onyx.clear
                 return expect(storedValue).resolves.toBeNull();
             });

--- a/tests/unit/onyxClearNativeStorageTest.js
+++ b/tests/unit/onyxClearNativeStorageTest.js
@@ -6,7 +6,7 @@ const ONYX_KEYS = {
     DEFAULT_KEY: 'defaultKey',
 };
 
-
+jest.useFakeTimers();
 Storage.clear = jest.fn(() => new Promise(resolve => setTimeout(resolve, 500))
     .then(() => console.log('[Onyx test] Storage is clearing now'))
     .then(() => AsyncStorageMock.clear()));
@@ -20,8 +20,6 @@ describe('Set data while storage is clearing', () => {
 
     beforeAll(() => {
         Onyx = require('../../index').default;
-        jest.useRealTimers();
-
         Onyx.init({
             keys: ONYX_KEYS,
             registerStorageEventListener: () => {},
@@ -38,7 +36,8 @@ describe('Set data while storage is clearing', () => {
 
     afterEach(() => {
         Onyx.disconnect(connectionID);
-        return Onyx.clear();
+        Onyx.clear();
+        jest.runAllTimers();
     });
 
     it('should store merged values when calling merge on a default key after clear', () => {
@@ -59,6 +58,7 @@ describe('Set data while storage is clearing', () => {
                 .then(() => console.log('[Onyx test] Value stored from merge'))
                 .then(resolve);
         }, 0));
+        jest.runAllTimers();
         return waitForPromisesToResolve()
             .then(() => {
                 expect(defaultValue).toEqual('merged');

--- a/tests/unit/onyxClearNativeStorageTest.js
+++ b/tests/unit/onyxClearNativeStorageTest.js
@@ -81,9 +81,9 @@ describe('Set data while storage is clearing', () => {
         expect.assertions(5);
         Storage.clear = jest.fn(() => {
             // Call merge between the cache and storage clearing
-            const afterMerge = Onyx.merge(ONYX_KEYS.DEFAULT_KEY, mergedValue);
-            const afterClear = AsyncStorageMock.clear();
-            return Promise.all([afterMerge, afterClear]);
+            Onyx.merge(ONYX_KEYS.DEFAULT_KEY, mergedValue);
+            AsyncStorageMock.clear();
+            return waitForPromisesToResolve();
         });
         Onyx.clear();
         return waitForPromisesToResolve()
@@ -109,9 +109,9 @@ describe('Set data while storage is clearing', () => {
         expect.assertions(5);
         Storage.clear = jest.fn(() => {
             // Call set between the cache and storage clearing
-            const afterSet = Onyx.set(ONYX_KEYS.DEFAULT_KEY, setValue);
-            const afterClear = AsyncStorageMock.clear();
-            return Promise.all([afterSet, afterClear]);
+            Onyx.set(ONYX_KEYS.DEFAULT_KEY, setValue);
+            AsyncStorageMock.clear();
+            return waitForPromisesToResolve();
         });
         Onyx.clear();
         return waitForPromisesToResolve()

--- a/tests/unit/onyxClearNativeStorageTest.js
+++ b/tests/unit/onyxClearNativeStorageTest.js
@@ -76,10 +76,11 @@ describe('Set data while storage is clearing', () => {
             initWithStoredValues: false,
             callback: val => defaultValue = val,
         });
+        const mergedValue = 'merged';
         Onyx.clear();
         Storage.clear = jest.fn(() => {
             // Merge after the cache has cleared but before the storage actually clears
-            Onyx.merge(ONYX_KEYS.DEFAULT_KEY, 'merged');
+            Onyx.merge(ONYX_KEYS.DEFAULT_KEY, mergedValue);
             const clearPromise = new Promise(resolve => setTimeout(resolve, 500))
                 .then(() => AsyncStorageMock.clear())
                 .then(addStorageCallResolve('clear'));
@@ -91,11 +92,11 @@ describe('Set data while storage is clearing', () => {
             .then(() => {
                 expect(storageCallResolveOrder('clear')).toBe(1);
                 expect(storageCallResolveOrder('setItem')).toBe(2);
-                expect(defaultValue).toBe('merged');
+                expect(defaultValue).toBe(mergedValue);
                 const cachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
-                expect(cachedValue).toBe('merged');
+                expect(cachedValue).toBe(mergedValue);
                 const storedValue = Storage.getItem(ONYX_KEYS.DEFAULT_KEY);
-                expect(storedValue).resolves.toBe('merged');
+                expect(storedValue).resolves.toBe(mergedValue);
                 Storage.clear.mockRestore();
             });
     });

--- a/tests/unit/onyxClearNativeStorageTest.js
+++ b/tests/unit/onyxClearNativeStorageTest.js
@@ -94,6 +94,8 @@ describe('Set data while storage is clearing', () => {
                 expect(defaultValue).toEqual('merged');
                 const cachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
                 expect(cachedValue).toEqual('merged');
+                const storedValue = Storage.getItem(ONYX_KEYS.DEFAULT_KEY);
+                expect(storedValue).resolves.toBe('merged');
                 Storage.clear.mockRestore();
             });
     });

--- a/tests/unit/onyxClearNativeStorageTest.js
+++ b/tests/unit/onyxClearNativeStorageTest.js
@@ -32,9 +32,9 @@ AsyncStorageMock.clear = jest.fn(() => Promise.all(storageCallQueue)
 
 // Track when AsyncStorageMock.setItem calls resolve.
 const asyncStorageMockSetItem = AsyncStorageMock.setItem;
-AsyncStorageMock.setItem = jest.fn(() => Promise.all(storageCallQueue)
+AsyncStorageMock.setItem = jest.fn((key, value) => Promise.all(storageCallQueue)
     .then(() => {
-        const setItemPromise = asyncStorageMockSetItem()
+        const setItemPromise = asyncStorageMockSetItem(key, value)
             .then(addStorageCallResolve('setItem'));
         storageCallQueue.push(setItemPromise);
         return setItemPromise;

--- a/tests/unit/onyxClearNativeStorageTest.js
+++ b/tests/unit/onyxClearNativeStorageTest.js
@@ -10,10 +10,6 @@ const MERGED_VALUE = 'merged';
 const DEFAULT_VALUE = 'default';
 
 let storageCallResolveList = [];
-function addStorageCallResolve(name) {
-    storageCallResolveList.push(name);
-}
-
 function storageCallResolveOrder(methodName) {
     return storageCallResolveList.indexOf(methodName) + 1;
 }
@@ -25,7 +21,7 @@ const asyncStorageMockClear = AsyncStorageMock.clear;
 AsyncStorageMock.clear = jest.fn(() => Promise.all(storageCallQueue)
     .then(() => {
         const clearPromise = asyncStorageMockClear()
-            .then(addStorageCallResolve('clear'));
+            .then(storageCallResolveList.push('clear'));
         storageCallQueue.push(clearPromise);
         return clearPromise;
     }));
@@ -35,7 +31,7 @@ const asyncStorageMockSetItem = AsyncStorageMock.setItem;
 AsyncStorageMock.setItem = jest.fn((key, value) => Promise.all(storageCallQueue)
     .then(() => {
         const setItemPromise = asyncStorageMockSetItem(key, value)
-            .then(addStorageCallResolve('setItem'));
+            .then(storageCallResolveList.push('setItem'));
         storageCallQueue.push(setItemPromise);
         return setItemPromise;
     }));

--- a/tests/unit/onyxClearNativeStorageTest.js
+++ b/tests/unit/onyxClearNativeStorageTest.js
@@ -1,6 +1,7 @@
 import AsyncStorageMock from '../../__mocks__/@react-native-async-storage/async-storage';
 import Storage from '../../lib/storage';
 import waitForPromisesToResolve from '../utils/waitForPromisesToResolve';
+import Onyx from '../../lib/Onyx';
 
 const ONYX_KEYS = {
     DEFAULT_KEY: 'defaultKey',
@@ -45,15 +46,10 @@ AsyncStorageMock.setItem = jest.fn((key, value) => Promise.all(storageCallQueue)
 
 describe('Set data while storage is clearing', () => {
     let connectionID;
-    let Onyx;
     let onyxValue;
 
     /** @type OnyxCache */
     let cache;
-
-    beforeAll(() => {
-        Onyx = require('../../index').default;
-    });
 
     // Always use a "fresh" cache instance
     beforeEach(() => {

--- a/tests/unit/onyxClearNativeStorageTest.js
+++ b/tests/unit/onyxClearNativeStorageTest.js
@@ -83,6 +83,7 @@ describe('Set data while storage is clearing', () => {
     it('should persist the value of Onyx.merge when called between the cache and storage clearing', () => {
         expect.assertions(5);
 
+        // GIVEN that Onyx is completely clear
         // WHEN Onyx.clear() is called
         Storage.clear = jest.fn(() => {
             // WHEN merge is called between the cache and storage clearing, on a key with a default key state

--- a/tests/unit/onyxClearNativeStorageTest.js
+++ b/tests/unit/onyxClearNativeStorageTest.js
@@ -98,7 +98,7 @@ describe('Set data while storage is clearing', () => {
                 const cachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
                 expect(cachedValue).toBe(MERGED_VALUE);
                 const storedValue = Storage.getItem(ONYX_KEYS.DEFAULT_KEY);
-                expect(storedValue).resolves.toBe(MERGED_VALUE);
+                return expect(storedValue).resolves.toBe(MERGED_VALUE);
             });
     });
 
@@ -121,12 +121,12 @@ describe('Set data while storage is clearing', () => {
                 const cachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
                 expect(cachedValue).toBe(SET_VALUE);
                 const storedValue = Storage.getItem(ONYX_KEYS.DEFAULT_KEY);
-                expect(storedValue).resolves.not.toBe(SET_VALUE);
+                return expect(storedValue).resolves.toBe(SET_VALUE);
             });
     });
 
     it('should replace the value of Onyx.set with the default key state in the cache', () => {
-        expect.assertions(6);
+        expect.assertions(5);
         Onyx.set(ONYX_KEYS.DEFAULT_KEY, SET_VALUE);
         Storage.clear = jest.fn(() => AsyncStorageMock.clear());
         Onyx.clear();
@@ -140,13 +140,12 @@ describe('Set data while storage is clearing', () => {
                 const storedValue = Storage.getItem(ONYX_KEYS.DEFAULT_KEY);
 
                 // The default key state is never stored during Onyx.clear
-                expect(storedValue).resolves.not.toBe(DEFAULT_VALUE);
-                expect(storedValue).resolves.toBeNull();
+                return expect(storedValue).resolves.toBeNull();
             });
     });
 
     it('should replace the value of Onyx.merge with the default key state in the cache', () => {
-        expect.assertions(6);
+        expect.assertions(5);
         Onyx.merge(ONYX_KEYS.DEFAULT_KEY, MERGED_VALUE);
         Storage.clear = jest.fn(() => AsyncStorageMock.clear());
         Onyx.clear();
@@ -160,8 +159,7 @@ describe('Set data while storage is clearing', () => {
                 const storedValue = Storage.getItem(ONYX_KEYS.DEFAULT_KEY);
 
                 // The default key state is never stored during Onyx.clear
-                expect(storedValue).resolves.not.toBe(DEFAULT_VALUE);
-                expect(storedValue).resolves.toBeNull();
+                return expect(storedValue).resolves.toBeNull();
             });
     });
 });

--- a/tests/unit/onyxClearNativeStorageTest.js
+++ b/tests/unit/onyxClearNativeStorageTest.js
@@ -1,5 +1,4 @@
-import AsyncStorageMock from '../../__mocks__/@react-native-async-storage/async-storage';
-import Storage from '../../lib/storage';
+import Storage from '../../__mocks__/@react-native-async-storage/async-storage';
 import waitForPromisesToResolve from '../utils/waitForPromisesToResolve';
 import Onyx from '../../lib/Onyx';
 
@@ -38,7 +37,6 @@ describe('Set data while storage is clearing', () => {
 
     afterEach(() => {
         Onyx.disconnect(connectionID);
-        Storage.clear.mockReset();
         return Onyx.clear();
     });
 
@@ -47,13 +45,10 @@ describe('Set data while storage is clearing', () => {
 
         // GIVEN that Onyx is completely clear
         // WHEN Onyx.clear() is called
-        Storage.clear = jest.fn(() => {
-            // WHEN merge is called between the cache and storage clearing, on a key with a default key state
-            Onyx.merge(ONYX_KEYS.DEFAULT_KEY, MERGED_VALUE);
-            AsyncStorageMock.clear();
-            return waitForPromisesToResolve();
-        });
         Onyx.clear();
+
+        // WHEN merge is called between the cache and storage clearing, on a key with a default key state
+        Onyx.merge(ONYX_KEYS.DEFAULT_KEY, MERGED_VALUE);
         return waitForPromisesToResolve()
             .then(() => {
                 // THEN the value in Onyx, the cache, and the storage is the merged value
@@ -71,7 +66,6 @@ describe('Set data while storage is clearing', () => {
         // GIVEN that Onyx is completely clear
         // WHEN set then clear is called on a key with a default key state
         Onyx.set(ONYX_KEYS.DEFAULT_KEY, SET_VALUE);
-        Storage.clear = jest.fn(() => AsyncStorageMock.clear());
         Onyx.clear();
         return waitForPromisesToResolve()
             .then(() => {
@@ -93,7 +87,6 @@ describe('Set data while storage is clearing', () => {
         // GIVEN that Onyx is completely clear
         // WHEN merge then clear is called on a key with a default key state
         Onyx.merge(ONYX_KEYS.DEFAULT_KEY, MERGED_VALUE);
-        Storage.clear = jest.fn(() => AsyncStorageMock.clear());
         Onyx.clear();
         return waitForPromisesToResolve()
             .then(() => {

--- a/tests/unit/onyxClearNativeStorageTest.js
+++ b/tests/unit/onyxClearNativeStorageTest.js
@@ -74,11 +74,11 @@ describe('Set data while storage is clearing', () => {
     });
 
     it('should persist the value of Onyx.merge when called between the cache and storage clearing', () => {
-        let defaultValue;
+        let onyxValue;
         connectionID = Onyx.connect({
             key: ONYX_KEYS.DEFAULT_KEY,
             initWithStoredValues: false,
-            callback: val => defaultValue = val,
+            callback: val => onyxValue = val,
         });
         expect.assertions(5);
         Storage.clear = jest.fn(() => {
@@ -92,7 +92,7 @@ describe('Set data while storage is clearing', () => {
             .then(() => {
                 expect(storageCallResolveOrder('clear')).toBe(1);
                 expect(storageCallResolveOrder('setItem')).toBe(2);
-                expect(defaultValue).toBe(MERGED_VALUE);
+                expect(onyxValue).toBe(MERGED_VALUE);
                 const cachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
                 expect(cachedValue).toBe(MERGED_VALUE);
                 const storedValue = Storage.getItem(ONYX_KEYS.DEFAULT_KEY);
@@ -101,11 +101,11 @@ describe('Set data while storage is clearing', () => {
     });
 
     it('should cache the value of Onyx.set when called between the cache and storage clearing', () => {
-        let defaultValue;
+        let onyxValue;
         connectionID = Onyx.connect({
             key: ONYX_KEYS.DEFAULT_KEY,
             initWithStoredValues: false,
-            callback: val => defaultValue = val,
+            callback: val => onyxValue = val,
         });
         expect.assertions(5);
         Storage.clear = jest.fn(() => {
@@ -121,7 +121,7 @@ describe('Set data while storage is clearing', () => {
                 // AsyncStorage.setItem resolves before AsyncStorage.clear
                 expect(storageCallResolveOrder('setItem')).toBe(1);
                 expect(storageCallResolveOrder('clear')).toBe(2);
-                expect(defaultValue).toBe(SET_VALUE);
+                expect(onyxValue).toBe(SET_VALUE);
                 const cachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
                 expect(cachedValue).toBe(SET_VALUE);
                 const storedValue = Storage.getItem(ONYX_KEYS.DEFAULT_KEY);
@@ -130,11 +130,11 @@ describe('Set data while storage is clearing', () => {
     });
 
     it('should replace the value of Onyx.set with the default key state in the cache', () => {
-        let defaultValue;
+        let onyxValue;
         connectionID = Onyx.connect({
             key: ONYX_KEYS.DEFAULT_KEY,
             initWithStoredValues: false,
-            callback: val => defaultValue = val,
+            callback: val => onyxValue = val,
         });
         expect.assertions(6);
         Onyx.set(ONYX_KEYS.DEFAULT_KEY, SET_VALUE);
@@ -144,7 +144,7 @@ describe('Set data while storage is clearing', () => {
             .then(() => {
                 expect(storageCallResolveOrder('setItem')).toBe(1);
                 expect(storageCallResolveOrder('clear')).toBe(2);
-                expect(defaultValue).toBe(DEFAULT_VALUE);
+                expect(onyxValue).toBe(DEFAULT_VALUE);
                 const cachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
                 expect(cachedValue).toBe(DEFAULT_VALUE);
                 const storedValue = Storage.getItem(ONYX_KEYS.DEFAULT_KEY);

--- a/tests/unit/onyxClearNativeStorageTest.js
+++ b/tests/unit/onyxClearNativeStorageTest.js
@@ -10,7 +10,14 @@ const MERGED_VALUE = 'merged';
 const DEFAULT_VALUE = 'default';
 
 let storageCallResolveList = [];
-function storageCallResolveOrder(methodName) {
+
+/**
+ * Get the order in which the storage method call resolved so we can assert that
+ * updates to storage are made in the expected order.
+ * @param {String} methodName The name of the storage method
+ * @returns {Number}
+ */
+function getStorageCallResolveOrder(methodName) {
     return storageCallResolveList.indexOf(methodName) + 1;
 }
 
@@ -88,8 +95,8 @@ describe('Set data while storage is clearing', () => {
         Onyx.clear();
         return waitForPromisesToResolve()
             .then(() => {
-                expect(storageCallResolveOrder('clear')).toBe(1);
-                expect(storageCallResolveOrder('setItem')).toBe(2);
+                expect(getStorageCallResolveOrder('clear')).toBe(1);
+                expect(getStorageCallResolveOrder('setItem')).toBe(2);
                 expect(onyxValue).toBe(MERGED_VALUE);
                 const cachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
                 expect(cachedValue).toBe(MERGED_VALUE);
@@ -111,8 +118,8 @@ describe('Set data while storage is clearing', () => {
             .then(() => {
                 // Onyx.set is faster than merge.
                 // AsyncStorage.setItem resolves before AsyncStorage.clear
-                expect(storageCallResolveOrder('setItem')).toBe(1);
-                expect(storageCallResolveOrder('clear')).toBe(2);
+                expect(getStorageCallResolveOrder('setItem')).toBe(1);
+                expect(getStorageCallResolveOrder('clear')).toBe(2);
                 expect(onyxValue).toBe(SET_VALUE);
                 const cachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
                 expect(cachedValue).toBe(SET_VALUE);
@@ -128,8 +135,8 @@ describe('Set data while storage is clearing', () => {
         Onyx.clear();
         return waitForPromisesToResolve()
             .then(() => {
-                expect(storageCallResolveOrder('setItem')).toBe(1);
-                expect(storageCallResolveOrder('clear')).toBe(2);
+                expect(getStorageCallResolveOrder('setItem')).toBe(1);
+                expect(getStorageCallResolveOrder('clear')).toBe(2);
                 expect(onyxValue).toBe(DEFAULT_VALUE);
                 const cachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
                 expect(cachedValue).toBe(DEFAULT_VALUE);
@@ -147,8 +154,8 @@ describe('Set data while storage is clearing', () => {
         Onyx.clear();
         return waitForPromisesToResolve()
             .then(() => {
-                expect(storageCallResolveOrder('setItem')).toBe(1);
-                expect(storageCallResolveOrder('clear')).toBe(2);
+                expect(getStorageCallResolveOrder('setItem')).toBe(1);
+                expect(getStorageCallResolveOrder('clear')).toBe(2);
                 expect(onyxValue).toBe(DEFAULT_VALUE);
                 const cachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
                 expect(cachedValue).toBe(DEFAULT_VALUE);

--- a/tests/unit/onyxClearNativeStorageTest.js
+++ b/tests/unit/onyxClearNativeStorageTest.js
@@ -106,29 +106,6 @@ describe('Set data while storage is clearing', () => {
             });
     });
 
-    it('should cache the value of Onyx.set when called between the cache and storage clearing', () => {
-        expect.assertions(5);
-        Storage.clear = jest.fn(() => {
-            // Call set between the cache and storage clearing
-            Onyx.set(ONYX_KEYS.DEFAULT_KEY, SET_VALUE);
-            AsyncStorageMock.clear();
-            return waitForPromisesToResolve();
-        });
-        Onyx.clear();
-        return waitForPromisesToResolve()
-            .then(() => {
-                // Onyx.set is faster than merge.
-                // AsyncStorage.setItem resolves before AsyncStorage.clear
-                expect(getStorageCallResolveOrder('setItem')).toBe(1);
-                expect(getStorageCallResolveOrder('clear')).toBe(2);
-                expect(onyxValue).toBe(SET_VALUE);
-                const cachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
-                expect(cachedValue).toBe(SET_VALUE);
-                const storedValue = Storage.getItem(ONYX_KEYS.DEFAULT_KEY);
-                return expect(storedValue).resolves.toBe(SET_VALUE);
-            });
-    });
-
     it('should replace the value of Onyx.set with the default key state in the cache', () => {
         expect.assertions(5);
         Onyx.set(ONYX_KEYS.DEFAULT_KEY, SET_VALUE);

--- a/tests/unit/onyxClearNativeStorageTest.js
+++ b/tests/unit/onyxClearNativeStorageTest.js
@@ -91,9 +91,9 @@ describe('Set data while storage is clearing', () => {
             .then(() => {
                 expect(storageCallResolveOrder('clear')).toBe(1);
                 expect(storageCallResolveOrder('setItem')).toBe(2);
-                expect(defaultValue).toEqual('merged');
+                expect(defaultValue).toBe('merged');
                 const cachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
-                expect(cachedValue).toEqual('merged');
+                expect(cachedValue).toBe('merged');
                 const storedValue = Storage.getItem(ONYX_KEYS.DEFAULT_KEY);
                 expect(storedValue).resolves.toBe('merged');
                 Storage.clear.mockRestore();

--- a/tests/unit/onyxClearNativeStorageTest.js
+++ b/tests/unit/onyxClearNativeStorageTest.js
@@ -76,6 +76,7 @@ describe('Set data while storage is clearing', () => {
             initWithStoredValues: false,
             callback: val => defaultValue = val,
         });
+        Onyx.clear();
         Storage.clear = jest.fn(() => {
             // Merge after the cache has cleared but before the storage actually clears
             Onyx.merge(ONYX_KEYS.DEFAULT_KEY, 'merged');
@@ -85,7 +86,6 @@ describe('Set data while storage is clearing', () => {
             storageCallQueue.push(clearPromise);
             return clearPromise;
         });
-        Onyx.clear();
         jest.runAllTimers();
         waitForPromisesToResolve()
             .then(() => {

--- a/tests/unit/onyxClearNativeStorageTest.js
+++ b/tests/unit/onyxClearNativeStorageTest.js
@@ -7,8 +7,6 @@ const ONYX_KEYS = {
 };
 
 jest.useFakeTimers();
-Storage.clear = jest.fn(() => new Promise(resolve => setTimeout(resolve, 500))
-    .then(() => AsyncStorageMock.clear()));
 
 describe('Set data while storage is clearing', () => {
     let connectionID;
@@ -46,35 +44,20 @@ describe('Set data while storage is clearing', () => {
             initWithStoredValues: false,
             callback: val => defaultValue = val,
         });
-
-        // Set one value so we know if the cache cleared
-        // by asserting that cache.set was called once while clearing.
-        Onyx.set(ONYX_KEYS.DEFAULT_KEY, 'setOneValue')
+        Storage.clear = jest.fn(() => {
+            // Merge after the cache has cleared but before the storage actually clears
+            Onyx.merge(ONYX_KEYS.DEFAULT_KEY, 'merged');
+            return new Promise(resolve => setTimeout(resolve, 500))
+                .then(() => AsyncStorageMock.clear());
+        });
+        Onyx.clear();
+        jest.runAllTimers();
+        waitForPromisesToResolve()
             .then(() => {
-                // Set up spies to make sure merge is called
-                // between the cache and storage clear.
-                const clearSpy = jest.spyOn(Onyx, 'clear');
-                const cacheSetSpy = jest.spyOn(cache, 'set');
-                const storageClearSpy = jest.spyOn(Storage, 'clear');
-                Onyx.clear();
-
-                // Merge just after clear, on the next tick
-                setTimeout(() => {
-                    // Assert that Onyx.clear was called, then the cache clears,
-                    // and Storage.clear has not been called before we merge.
-                    expect(clearSpy).toHaveBeenCalled();
-                    expect(cacheSetSpy).toHaveBeenCalledWith('default');
-                    expect(storageClearSpy).not.toHaveBeenCalled();
-                    Onyx.merge(ONYX_KEYS.DEFAULT_KEY, 'merged');
-                }, 0);
-                jest.runAllTimers();
-                return waitForPromisesToResolve()
-                    .then(() => {
-                        expect(storageClearSpy).toHaveBeenCalled();
-                        expect(defaultValue).toEqual('merged');
-                        const cachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
-                        expect(cachedValue).toEqual('merged');
-                    });
+                expect(defaultValue).toEqual('merged');
+                const cachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
+                expect(cachedValue).toEqual('merged');
+                Storage.clear.mockRestore();
             });
     });
 });

--- a/tests/unit/onyxClearNativeStorageTest.js
+++ b/tests/unit/onyxClearNativeStorageTest.js
@@ -5,9 +5,11 @@ import Onyx from '../../lib/Onyx';
 const ONYX_KEYS = {
     DEFAULT_KEY: 'defaultKey',
 };
-const SET_VALUE = 'set';
-const MERGED_VALUE = 'merged';
-const DEFAULT_VALUE = 'default';
+
+// Store integers because the async storage mock adds escape characters to strings
+const SET_VALUE = 2;
+const MERGED_VALUE = 1;
+const DEFAULT_VALUE = 0;
 
 describe('Set data while storage is clearing', () => {
     let connectionID;
@@ -55,8 +57,10 @@ describe('Set data while storage is clearing', () => {
                 expect(onyxValue).toBe(MERGED_VALUE);
                 const cachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
                 expect(cachedValue).toBe(MERGED_VALUE);
-                const storedValue = Storage.getItem(ONYX_KEYS.DEFAULT_KEY);
-                return expect(storedValue).resolves.toBe(MERGED_VALUE);
+
+                // Use parseInt to convert the string value from the storage mock back to an integer
+                return Storage.getItem(ONYX_KEYS.DEFAULT_KEY)
+                    .then(storedValue => expect(parseInt(storedValue, 10)).toBe(MERGED_VALUE));
             });
     });
 

--- a/tests/unit/onyxClearNativeStorageTest.js
+++ b/tests/unit/onyxClearNativeStorageTest.js
@@ -1,5 +1,6 @@
 import AsyncStorageMock from '@react-native-async-storage/async-storage';
 import Storage from '../../lib/storage';
+import waitForPromisesToResolve from '../utils/waitForPromisesToResolve';
 
 const ONYX_KEYS = {
     DEFAULT_KEY: 'defaultKey',
@@ -58,7 +59,7 @@ describe('Set data while storage is clearing', () => {
                 .then(() => console.log('[Onyx test] Value stored from merge'))
                 .then(resolve);
         }, 0));
-        return Promise.all([afterClear, afterMerge])
+        return waitForPromisesToResolve()
             .then(() => {
                 expect(defaultValue).toEqual('merged');
                 const cachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);

--- a/tests/unit/onyxClearNativeStorageTest.js
+++ b/tests/unit/onyxClearNativeStorageTest.js
@@ -22,6 +22,7 @@ function getStorageCallResolveOrder(methodName) {
     return storageCallResolveList.indexOf(methodName) + 1;
 }
 
+// Add all storage calls to a queue and make them wait for each other to match the real implementation.
 let storageCallQueue = [];
 
 // Track when AsyncStorageMock.clear calls resolve.

--- a/tests/unit/onyxClearNativeStorageTest.js
+++ b/tests/unit/onyxClearNativeStorageTest.js
@@ -69,7 +69,7 @@ describe('Set data while storage is clearing', () => {
         jest.runAllTimers();
     });
 
-    it('should store merged values when calling merge on a default key after clear', () => {
+    it('should persist the value of Onyx.merge when called between the cache and storage clearing', () => {
         let defaultValue;
         connectionID = Onyx.connect({
             key: ONYX_KEYS.DEFAULT_KEY,
@@ -79,7 +79,7 @@ describe('Set data while storage is clearing', () => {
         const mergedValue = 'merged';
         Onyx.clear();
         Storage.clear = jest.fn(() => {
-            // Merge after the cache has cleared but before the storage actually clears
+            // Call merge between the cache and storage clearing
             Onyx.merge(ONYX_KEYS.DEFAULT_KEY, mergedValue);
             const clearPromise = new Promise(resolve => setTimeout(resolve, 500))
                 .then(() => AsyncStorageMock.clear())
@@ -108,7 +108,7 @@ describe('Set data while storage is clearing', () => {
             initWithStoredValues: false,
             callback: val => defaultValue = val,
         });
-        const setValue = 'merged';
+        const setValue = 'set';
         Onyx.clear();
         Storage.clear = jest.fn(() => {
             // Call set between the cache and storage clearing

--- a/tests/unit/onyxClearNativeStorageTest.js
+++ b/tests/unit/onyxClearNativeStorageTest.js
@@ -1,0 +1,68 @@
+import AsyncStorageMock from '@react-native-async-storage/async-storage';
+import Storage from '../../lib/storage';
+
+const ONYX_KEYS = {
+    DEFAULT_KEY: 'defaultKey',
+};
+
+
+Storage.clear = jest.fn(() => new Promise(resolve => setTimeout(resolve, 500))
+    .then(() => console.log('[Onyx test] Storage is clearing now'))
+    .then(() => AsyncStorageMock.clear()));
+
+describe('Set data while storage is clearing', () => {
+    let connectionID;
+    let Onyx;
+
+    /** @type OnyxCache */
+    let cache;
+
+    beforeAll(() => {
+        Onyx = require('../../index').default;
+        jest.useRealTimers();
+
+        Onyx.init({
+            keys: ONYX_KEYS,
+            registerStorageEventListener: () => {},
+            initialKeyStates: {
+                [ONYX_KEYS.DEFAULT_KEY]: 'default',
+            },
+        });
+    });
+
+    // Always use a "fresh" cache instance
+    beforeEach(() => {
+        cache = require('../../lib/OnyxCache').default;
+    });
+
+    afterEach(() => {
+        Onyx.disconnect(connectionID);
+        return Onyx.clear();
+    });
+
+    it('should store merged values when calling merge on a default key after clear', () => {
+        let defaultValue;
+        connectionID = Onyx.connect({
+            key: ONYX_KEYS.DEFAULT_KEY,
+            initWithStoredValues: false,
+            callback: val => defaultValue = val,
+        });
+        console.log('[Onyx test] Clearing Onyx');
+        const afterClear = Onyx.clear()
+            .then(() => console.log('[Onyx test] Done clearing Onyx'));
+
+        // Merge just after clear, on the next tick
+        const afterMerge = new Promise(resolve => setTimeout(() => {
+            console.log('[Onyx test] Calling Onyx.merge');
+            Onyx.merge(ONYX_KEYS.DEFAULT_KEY, 'merged')
+                .then(() => console.log('[Onyx test] Value stored from merge'))
+                .then(resolve);
+        }, 0));
+        return Promise.all([afterClear, afterMerge])
+            .then(() => {
+                expect(defaultValue).toEqual('merged');
+                const cachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
+                expect(cachedValue).toEqual('merged');
+            });
+    });
+});

--- a/tests/unit/onyxClearWebStorageTest.js
+++ b/tests/unit/onyxClearWebStorageTest.js
@@ -1,0 +1,62 @@
+import Storage from '../../lib/storage';
+
+const ONYX_KEYS = {
+    DEFAULT_KEY: 'defaultKey',
+};
+jest.mock('../../lib/storage');
+
+describe('Set data while storage is clearing', () => {
+    let connectionID;
+    let Onyx;
+
+    /** @type OnyxCache */
+    let cache;
+
+    beforeAll(() => {
+        Onyx = require('../../index').default;
+        jest.useRealTimers();
+
+        Onyx.init({
+            keys: ONYX_KEYS,
+            registerStorageEventListener: () => {},
+            initialKeyStates: {
+                [ONYX_KEYS.DEFAULT_KEY]: 'default',
+            },
+        });
+        const webStorageClear = Storage.clear;
+        Storage.clear = jest.fn(() => new Promise(resolve => setTimeout(resolve, 20))
+            .then(webStorageClear));
+    });
+
+    // Always use a "fresh" cache instance
+    beforeEach(() => {
+        cache = require('../../lib/OnyxCache').default;
+    });
+
+    afterEach(() => {
+        Onyx.disconnect(connectionID);
+        return Onyx.clear();
+    });
+
+    it('should store merged values when calling merge on a default key after clear', () => {
+        let defaultValue;
+        connectionID = Onyx.connect({
+            key: ONYX_KEYS.DEFAULT_KEY,
+            initWithStoredValues: false,
+            callback: val => defaultValue = val,
+        });
+        const afterClear = Onyx.clear();
+
+        // Merge just after clear, on the next tick
+        const afterMerge = new Promise(resolve => setTimeout(() => {
+            Onyx.merge(ONYX_KEYS.DEFAULT_KEY, 'merged')
+                .then(resolve);
+        }, 0));
+        return Promise.all([afterClear, afterMerge])
+            .then(() => {
+                expect(defaultValue).toEqual('merged');
+                const cachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
+                expect(cachedValue).toEqual('merged');
+            });
+    });
+});

--- a/tests/unit/onyxClearWebStorageTest.js
+++ b/tests/unit/onyxClearWebStorageTest.js
@@ -1,5 +1,4 @@
 import waitForPromisesToResolve from '../utils/waitForPromisesToResolve';
-import Onyx from '../../lib/Onyx';
 import Storage from '../../__mocks__/localforage';
 
 const ONYX_KEYS = {
@@ -10,11 +9,18 @@ const MERGED_VALUE = 'merged';
 const DEFAULT_VALUE = 'default';
 
 describe('Set data while storage is clearing', () => {
+    let Onyx;
     let connectionID;
     let onyxValue;
 
     /** @type OnyxCache */
     let cache;
+
+    beforeAll(() => {
+        // Force using WebStorage provider for these tests
+        jest.mock('../../lib/storage');
+        Onyx = require('../../lib/Onyx').default;
+    });
 
     // Always use a "fresh" cache instance
     beforeEach(() => {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->
cc @marcaaron
### Details
<!-- Explanation of the change or anything fishy that is going on -->
When we clear Onyx and reset the cache set every value to `null` OR the default key state if one exists for that key. Remove the call to `initializeWithDefaultKeyStates` since it is no longer needed. These changes prevent updating Onyx subscribers with out of date information by sending only the defaultKeyStates. See the issue for more info and an example.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/react-native-onyx/issues/125

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
[onyxClearNativeStorageTest.js](https://github.com/Expensify/react-native-onyx/blob/dcb7f0139f8b5371affdd3bb2f9ce84e4687f087/tests/unit/onyxClearNativeStorageTest.js) and [onyxClearWebStorageTest.js](https://github.com/Expensify/react-native-onyx/blob/068a98a9afd45a53114754cc96c6928ec9fccbb3/tests/unit/onyxClearWebStorageTest.js)

### Manual Tests
I had a lot of trouble adding an automated tests earlier so I also added manual tests.
1. Checkout the App branch for **Case 1**
2. `npm i` to install [this Onyx version](https://github.com/Expensify/react-native-onyx/tree/neil-test-clear) that has been modified for testing

For each case below:
1. Checkout the App branch
2. `npm run web`
3. Sign in to any account
4. Open the console
5. Sign out
6. Make sure there are no assertion errors in the console
7. For cases 1 and 2 only:
8. `command + f` in the console and search 'Onyx test'
9. Make sure that the cache clears, then data is set or merged, and then Onyx finishes clearing.

- [ ] **Case 1:** [neil-test-onyx-clear-merge](https://github.com/Expensify/App/tree/neil-test-onyx-clear-merge)

```
Onyx.clear();
Onyx.merge('someDefaultKey', 'someValue');

// Expect the value of the merge to replace the default key state
// Expect that storage matches what we have in the cache and that our call to 
// `Storage.clear()` did not clear the value of merge from storage after we called Onyx.clear()
```

- [ ] **Case 2:** [neil-test-onyx-clear-set](https://github.com/Expensify/App/tree/neil-test-onyx-clear-set)
```
Onyx.clear();
Onyx.set('someDefaultKey', 'someValue');

// Expect the value of the set to replace the default key state
// Expect that storage matches what we have in the cache and that our call 
// to `Storage.clear()` did not prevent any values from being set
```

- [ ] **Case 3:** [neil-test-onyx-set-clear](https://github.com/Expensify/App/tree/neil-test-onyx-set-clear)
```
Onyx.set('someDefaultKey', 'someValue');
Onyx.clear();

// Expect the value from the `set()` to be replaced with the default key state value
```

- [ ] **Case 4:** [neil-test-onyx-merge-clear](https://github.com/Expensify/App/tree/neil-test-onyx-merge-clear)
```
Onyx.merge('someDefaultKey', 'someValue');
Onyx.clear();

// Expect the value from the `merge()` to be replaced with the default key state value
```

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->
https://github.com/Expensify/App/pull/8855