### PR TITLE
Update version to 1.0.2 and tweak when we build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,13 +58,6 @@ jobs:
             - name: Set new version in GitHub ENV
               run: echo "NEW_VERSION=$(jq '.version' package.json)" >> $GITHUB_ENV
 
-            - name: Build package
-              run: npm run build
-
-            - run: npm publish
-              env:
-                NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
             - name: Push branch and publish tags
               run: git push --tags
 
@@ -86,3 +79,11 @@ jobs:
               run: gh pr merge --merge --delete-branch ${{ env.BRANCH_NAME }}
               env:
                 GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Build package
+              run: npm run build
+
+            - name: Publish to npm
+              run: npm publish
+              env:
+                NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-onyx",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,12 +1,17 @@
 {
   "name": "react-native-onyx",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": "Expensify, Inc.",
   "homepage": "https://expensify.com",
   "description": "State management for React Native",
   "license": "MIT",
   "private": false,
-  "keywords": ["React Native", "React", "Persistant storage", "Pub/Sub"],
+  "keywords": [
+    "React Native",
+    "React",
+    "Persistant storage",
+    "Pub/Sub"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/Expensify/react-native-onyx.git"


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
The last run failed because we didn't update the code to 1.0.2, this updates the code to match the failed run. Additionally this will not distribute the package until the version bump is completed.

### Related Issues
https://github.com/Expensify/react-native-onyx/runs/6618799484?check_suite_focus=true

### Automated Tests
1. Merge this PR
2. Verify it fixes the broken run