### PR TITLE
Push branch and tags instead of just tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,7 +59,7 @@ jobs:
               run: echo "NEW_VERSION=$(jq '.version' package.json)" >> $GITHUB_ENV
 
             - name: Push branch and publish tags
-              run: git push --tags
+              run: git push && git push --tags
 
             - name: Create pull request
               run: |


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
I did not realize that `git push --tags` would only push the tags and not push the branch. This fixes this error seen [in this run](https://github.com/Expensify/react-native-onyx/runs/6618988826?check_suite_focus=true):

<img width="693" alt="Screen Shot 2022-05-26 at 7 23 41 PM" src="https://user-images.githubusercontent.com/2838819/170609792-a19111b6-6126-4ade-8719-2f1096ba0234.png">

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
1. Merge this PR
2. Verify it builds 1.0.3 and pushes it to npm