### PR TITLE
Ignore the `.npmrc` file created by GitHub Actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,8 @@ node_modules/
 npm-debug.log
 dist/
 
+# NPM file created by GitHub actions
+.npmrc
+
 # IDEs
 .idea


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
The [`actions/setup-node@v3` step creates a file called `.npmrc`](https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npm-registry) that we do not want to commit as it has our npm token in it, so let's ignore it. Also it is causing a warning in our GitHub Actions code: `Warning: 1 uncommitted change` when we create the PR.

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
1. Merge this PR
2. Verify it creates the 1.0.4 version
3. Verify no warning