### PR TITLE
Add decrypted key to `.gitignore` to fix GitHub actions warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ dist/
 
 # IDEs
 .idea
+
+# Decrypted private key we do not want to commit
+.github/OSBotify-private-key.asc


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
We were seeing an warning when running the GitHub actions that said `Warning: 1 uncommitted change` - From debugging we figured out that it was the decrypted key. We should not commit this key, so we can add it to the gitignore.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/Expensify/issues/212012

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
1. Merge this PR
2. I will check the logs for the GitHub action to verify that it fixes this warning