### PR TITLE
Add mergeCollection method to Onyx.update

### DIFF
--- a/API.md
+++ b/API.md
@@ -220,7 +220,7 @@ Insert API responses and lifecycle data into Onyx
 
 | Param | Type | Description |
 | --- | --- | --- |
-| data | <code>Array</code> | An array of objects with shape {onyxMethod: oneOf('set', 'merge'), key: string, value: *} |
+| data | <code>Array</code> | An array of objects with shape {onyxMethod: oneOf('set', 'merge', 'mergeCollection'), key: string, value: *} |
 
 <a name="init"></a>
 

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -812,12 +812,12 @@ function mergeCollection(collectionKey, collection) {
 /**
  * Insert API responses and lifecycle data into Onyx
  *
- * @param {Array} data An array of objects with shape {onyxMethod: oneOf('set', 'merge'), key: string, value: *}
+ * @param {Array} data An array of objects with shape {onyxMethod: oneOf('set', 'merge', 'mergeCollection'), key: string, value: *}
  */
 function update(data) {
     // First, validate the Onyx object is in the format we expect
     _.each(data, ({onyxMethod, key}) => {
-        if (!_.contains(['set', 'merge'], onyxMethod)) {
+        if (!_.contains(['set', 'merge', 'mergeCollection'], onyxMethod)) {
             throw new Error(`Invalid onyxMethod ${onyxMethod} in Onyx update.`);
         }
         if (!_.isString(key)) {

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -833,6 +833,9 @@ function update(data) {
             case 'merge':
                 merge(key, value);
                 break;
+            case 'mergeCollection':
+                mergeCollection(key, value);
+                break;
             default:
                 break;
         }

--- a/tests/unit/onyxTest.js
+++ b/tests/unit/onyxTest.js
@@ -369,7 +369,7 @@ describe('Onyx', () => {
 
         return waitForPromisesToResolve()
             .then(() => {
-                // GIVEN the initial Onyx state: {test_1: {existingData: 'test',},test_2: {existingData: 'test',}}
+                // GIVEN the initial Onyx state: {test_1: {existingData: 'test',}, test_2: {existingData: 'test',}}
                 Onyx.multiSet({
                     test_1: {
                         existingData: 'test',

--- a/tests/unit/onyxTest.js
+++ b/tests/unit/onyxTest.js
@@ -325,39 +325,16 @@ describe('Onyx', () => {
             },
         });
 
-        const valuesReceived = {};
-        connectionID = Onyx.connect({
-            key: ONYX_KEYS.COLLECTION.TEST_KEY,
-            initWithStoredValues: false,
-            callback: (data, key) => valuesReceived[key] = data,
-        });
-
         return waitForPromisesToResolve()
             .then(() => {
                 // GIVEN the initial Onyx state: {test: true, otherTest: {test1: 'test1'}}
                 Onyx.set(ONYX_KEYS.TEST_KEY, true);
                 Onyx.set(ONYX_KEYS.OTHER_TEST, {test1: 'test1'});
-                Onyx.multiSet({
-                    test_1: {
-                        existingData: 'test',
-                    },
-                    test_2: {
-                        existingData: 'test',
-                    },
-                });
                 return waitForPromisesToResolve();
             })
             .then(() => {
                 expect(testKeyValue).toBe(true);
                 expect(otherTestKeyValue).toEqual({test1: 'test1'});
-                expect(valuesReceived).toEqual({
-                    test_1: {
-                        existingData: 'test',
-                    },
-                    test_2: {
-                        existingData: 'test',
-                    },
-                });
 
                 // WHEN we pass a data object to Onyx.update
                 Onyx.update([
@@ -371,20 +348,6 @@ describe('Onyx', () => {
                         key: ONYX_KEYS.OTHER_TEST,
                         value: {test2: 'test2'},
                     },
-                    {
-                        onyxMethod: 'mergeCollection',
-                        key: ONYX_KEYS.OTHER_TEST,
-                        value: {
-                            test_1: {
-                                ID: 123,
-                                value: 'one',
-                            },
-                            test_2: {
-                                ID: 234,
-                                value: 'two',
-                            },
-                        },
-                    },
                 ]);
                 return waitForPromisesToResolve();
             })
@@ -392,16 +355,6 @@ describe('Onyx', () => {
                 // THEN the final Onyx state should be {test: 'one', otherTest: {test1: 'test1', test2: 'test2'}}
                 expect(testKeyValue).toBe('one');
                 expect(otherTestKeyValue).toEqual({test1: 'test1', test2: 'test2'});
-                expect(valuesReceived).toEqual({
-                    test_1: {
-                        ID: 123,
-                        value: 'one',
-                    },
-                    test_2: {
-                        ID: 234,
-                        value: 'two',
-                    },
-                });
             });
     });
 

--- a/tests/unit/onyxTest.js
+++ b/tests/unit/onyxTest.js
@@ -325,7 +325,7 @@ describe('Onyx', () => {
             },
         });
 
-        let valuesReceived = {};
+        const valuesReceived = {};
         connectionID = Onyx.connect({
             key: ONYX_KEYS.COLLECTION.TEST_KEY,
             initWithStoredValues: false,


### PR DESCRIPTION
Enables the mergeCollection Onyx method. To be tested in the Web-E PR.

### Details
Simply enables the mergeCollection Onyx method.

### Related Issues
https://github.com/Expensify/Expensify/issues/214912

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
Added a new test specifically to test a mergeCollection Onyx update

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->
- Web-E #1: https://github.com/Expensify/Web-Expensify/pull/34205
- Web-E #2: https://github.com/Expensify/Web-Expensify/pull/34144/files