### PR TITLE
Allow clear in onyx update

### DIFF
--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -817,10 +817,10 @@ function mergeCollection(collectionKey, collection) {
 function update(data) {
     // First, validate the Onyx object is in the format we expect
     _.each(data, ({onyxMethod, key}) => {
-        if (!_.contains(['set', 'merge', 'mergeCollection'], onyxMethod)) {
+        if (!_.contains(['clear', 'set', 'merge', 'mergeCollection'], onyxMethod)) {
             throw new Error(`Invalid onyxMethod ${onyxMethod} in Onyx update.`);
         }
-        if (!_.isString(key)) {
+        if (onyxMethod !== 'clear' && !_.isString(key)) {
             throw new Error(`Invalid ${typeof key} key provided in Onyx update. Onyx key must be of type string.`);
         }
     });
@@ -835,6 +835,9 @@ function update(data) {
                 break;
             case 'mergeCollection':
                 mergeCollection(key, value);
+                break;
+            case 'clear':
+                clear();
                 break;
             default:
                 break;

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-native-onyx-pkg",
+  "name": "react-native-onyx",
   "version": "1.0.7",
   "author": "Expensify, Inc.",
   "homepage": "https://expensify.com",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-native-onyx",
+  "name": "react-native-onyx-pkg",
   "version": "1.0.7",
   "author": "Expensify, Inc.",
   "homepage": "https://expensify.com",


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->
cc @marcaaron @Julesssss @Justicea83 since y'all are reviewing the related Web-E PR 👍 

### Details
<!-- Explanation of the change or anything fishy that is going on -->
As noted by @marcaaron [here](https://github.com/Expensify/Web-Expensify/pull/34159#discussion_r914123184), we use `Onyx.clear()` when signing out of NewDot. This is fine but in the recent API refactor we need to call `Onyx.clear` in a few places after closing an account (the related PRs & issue) & maybe even after signing in

Currently we do `Onyx.clear().then` because `Onyx.set` is faster than `Onyx.clear`. We won't have to use `.then` if we use `Onyx.merge` though b/c `Onyx.merge` is slower than `Onyx.clear`
- Investigation here: https://github.com/Expensify/react-native-onyx/pull/129#discussion_r883005645
- Comments in code here: https://github.com/Expensify/react-native-onyx/blob/445769a1eab5aad1bcbfd74d18e7bf237abe780a/lib/Onyx.js#L721-L735

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/Expensify/issues/213701

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
Not needed, just adding the ability to have `clear` be an `onyxMethod`

Note: This PR was tested in combination with:
- https://github.com/Expensify/App/pull/9635
- https://github.com/Expensify/Web-Expensify/pull/34159

Results here: https://github.com/Expensify/Web-Expensify/pull/34159#issuecomment-1179061881

### Linked PRs
https://github.com/Expensify/App/pull/9635/files
