### PR TITLE
Make onyx method mergeCollection lowercase

### DIFF
--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -817,7 +817,7 @@ function mergeCollection(collectionKey, collection) {
 function update(data) {
     // First, validate the Onyx object is in the format we expect
     _.each(data, ({onyxMethod, key}) => {
-        if (!_.contains(['clear', 'set', 'merge', 'mergeCollection'], onyxMethod)) {
+        if (!_.contains(['clear', 'set', 'merge', 'mergecollection'], onyxMethod)) {
             throw new Error(`Invalid onyxMethod ${onyxMethod} in Onyx update.`);
         }
         if (onyxMethod !== 'clear' && !_.isString(key)) {
@@ -833,7 +833,7 @@ function update(data) {
             case 'merge':
                 merge(key, value);
                 break;
-            case 'mergeCollection':
+            case 'mergecollection':
                 mergeCollection(key, value);
                 break;
             case 'clear':

--- a/tests/unit/onyxTest.js
+++ b/tests/unit/onyxTest.js
@@ -390,7 +390,7 @@ describe('Onyx', () => {
                 // WHEN we pass a mergeCollection data object to Onyx.update
                 Onyx.update([
                     {
-                        onyxMethod: 'mergeCollection',
+                        onyxMethod: 'mergecollection',
                         key: ONYX_KEYS.COLLECTION.TEST_KEY,
                         value: {
                             test_1: {


### PR DESCRIPTION
### Details
While https://github.com/Expensify/App/pull/9878 the App implementation of the new OpenPaymentDetailsPage API, I noticed that we're sending the Onyx update method as lower case. This PR changes the [expected case](https://github.com/Expensify/react-native-onyx/blob/1bb3b9572b555c2c53d84a87775d4bf4888f5423/lib/Onyx.js#L820) to lowercase. 

[This ](https://github.com/Expensify/Web-Expensify/blob/dcb72fa4e5d84889ba09104b7cc66f19df67c985/lib/Onyx.php#L51-L63)is the Web-E logic which expects a lower case Onyx method. 

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/Expensify/issues/218762

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
I updated the `should use update data object to merge a collection of keys` test case. 