### PR TITLE
Add OSBotify to CLA allowlist, unblocking releases

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -36,4 +36,4 @@ jobs:
                   remote-organization-name: 'Expensify'
                   remote-repository-name: 'CLA'
                   lock-pullrequest-aftermerge: false
-                  allowlist: 'snyk-bot'
+                  allowlist: 'snyk-bot,OSBotify'


### PR DESCRIPTION

### Details

React-Native-Onyx repo releases are blocked, because the OSBotify version bump commits are failing the [CLA check](https://github.com/Expensify/react-native-onyx/runs/7346340630?check_suite_focus=true). I think this is because we [just rotated](https://github.com/Expensify/Expensify/issues/217767) the access token.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/Expensify/issues/218843

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
N/A

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->
N/A