### PR TITLE
Add waitForCollectionCallback param to Onyx.connect

### DIFF
--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -391,6 +391,7 @@ function sendDataToConnection(config, val, key) {
  *      This is used by any non-React code to connect to Onyx
  * @param {Boolean} [mapping.initWithStoredValues] If set to false, then no data will be prefilled into the
  *  component
+ * @param {Boolean} [mapping.waitForCollectionCallback] If set to true, it will trigger the callback once and return all data as a single object
  * @returns {Number} an ID to use when calling disconnect
  */
 function connect(mapping) {
@@ -441,7 +442,7 @@ function connect(mapping) {
             // to expect a single key or multiple keys in the case of a collection.
             // React components are an exception since we'll want to send their
             // initial data as a single object when using collection keys.
-            if (mapping.withOnyxInstance && isCollectionKey(mapping.key)) {
+            if ((mapping.withOnyxInstance && isCollectionKey(mapping.key)) || mapping.waitForCollectionCallback) {
                 Promise.all(_.map(matchingKeys, key => get(key)))
                     .then(values => _.reduce(values, (finalObject, value, i) => ({
                         ...finalObject,

--- a/tests/unit/onyxTest.js
+++ b/tests/unit/onyxTest.js
@@ -472,6 +472,8 @@ describe('Onyx', () => {
     it('should return all collection keys as a single object when waitForCollectionCallback = true', () => {
         const valuesReceived = {};
         const mockCallback = jest.fn(data => valuesReceived[data.ID] = data.value);
+
+        // GIVEN some collection data
         const collectionData = {
             test_connect_collection_1: {
                 ID: 123,
@@ -489,6 +491,7 @@ describe('Onyx', () => {
         Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_CONNECT_COLLECTION, collectionData);
         return waitForPromisesToResolve()
             .then(() => {
+                // WHEN we call Onyx.connect with the waitForCollectionCallback = true param
                 connectionID = Onyx.connect({
                     key: ONYX_KEYS.COLLECTION.TEST_CONNECT_COLLECTION,
                     waitForCollectionCallback: true,
@@ -497,7 +500,10 @@ describe('Onyx', () => {
                 return waitForPromisesToResolve();
             })
             .then(() => {
+                // THEN the callback should be triggered only once
                 expect(mockCallback.mock.calls.length).toBe(1);
+
+                // AND all the collection data should be returned as a single object
                 expect(mockCallback.mock.calls[0][0]).toEqual(collectionData);
             });
     });

--- a/tests/unit/onyxTest.js
+++ b/tests/unit/onyxTest.js
@@ -6,6 +6,7 @@ const ONYX_KEYS = {
     OTHER_TEST: 'otherTest',
     COLLECTION: {
         TEST_KEY: 'test_',
+        TEST_CONNECT_COLLECTION: 'test_connect_collection_',
     },
 };
 
@@ -466,5 +467,38 @@ describe('Onyx', () => {
             // THEN we should expect the error message below
             expect(error.message).toEqual('Invalid boolean key provided in Onyx update. Onyx key must be of type string.');
         }
+    });
+
+    it('should return all collection keys as a single object when waitForCollectionCallback = true', () => {
+        const valuesReceived = {};
+        const mockCallback = jest.fn(data => valuesReceived[data.ID] = data.value);
+        const collectionData = {
+            test_connect_collection_1: {
+                ID: 123,
+                value: 'one',
+            },
+            test_connect_collection_2: {
+                ID: 234,
+                value: 'two',
+            },
+            test_connect_collection_3: {
+                ID: 345,
+                value: 'three',
+            },
+        };
+        Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_CONNECT_COLLECTION, collectionData);
+        return waitForPromisesToResolve()
+            .then(() => {
+                connectionID = Onyx.connect({
+                    key: ONYX_KEYS.COLLECTION.TEST_CONNECT_COLLECTION,
+                    waitForCollectionCallback: true,
+                    callback: mockCallback,
+                });
+                return waitForPromisesToResolve();
+            })
+            .then(() => {
+                expect(mockCallback.mock.calls.length).toBe(1);
+                expect(mockCallback.mock.calls[0][0]).toEqual(collectionData);
+            });
     });
 });


### PR DESCRIPTION
### Details
Adds `waitForCollectionCallback` as a param to `Onyx.connect` to trigger a single callback when connecting to a collection

cc @tgolen I found that a `connectToCollection` method would share most of its logic with `connect` so I added a param instead of creating a new method.

### Related Issues
https://github.com/Expensify/App/pull/10051#discussion_r932712218

### Automated Tests
Added to `tests/unit/onyxTest.js`

### Linked PRs
https://github.com/Expensify/App/pull/10051
