### PR TITLE
Limit use of unnecessary spread for performance

### DIFF
--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -232,10 +232,10 @@ function getCachedCollection(collectionKey) {
         if (!cachedValue) {
             return prev;
         }
-        return ({
-            ...prev,
-            [curr]: cachedValue,
-        });
+
+        // eslint-disable-next-line no-param-reassign
+        prev[curr] = cachedValue;
+        return prev;
     }, {});
 }
 
@@ -444,10 +444,11 @@ function connect(mapping) {
             // initial data as a single object when using collection keys.
             if ((mapping.withOnyxInstance && isCollectionKey(mapping.key)) || mapping.waitForCollectionCallback) {
                 Promise.all(_.map(matchingKeys, key => get(key)))
-                    .then(values => _.reduce(values, (finalObject, value, i) => ({
-                        ...finalObject,
-                        [matchingKeys[i]]: value,
-                    }), {}))
+                    .then(values => _.reduce(values, (finalObject, value, i) => {
+                        // eslint-disable-next-line no-param-reassign
+                        finalObject[matchingKeys[i]] = value;
+                        return finalObject;
+                    }, {}))
                     .then(val => sendDataToConnection(mapping, val));
             } else {
                 _.each(matchingKeys, (key) => {


### PR DESCRIPTION
### Details

@luacmartins found some spread calls that were taking a long time in [this thread](https://expensify.slack.com/archives/C03SYCHD988/p1659566036249319).

Looking at the code and it seems like there is no clear reason to use the spread operator over simply building an object up one key at a time. When objects become large it is more and more expensive to do the spread as each iteration creates a copy.

### Related Issues

https://github.com/Expensify/Expensify/issues/219425

### Automated Tests
❌ 

### Linked PRs

Let's add these changes into [this PR](https://github.com/Expensify/App/pull/10239)