### PR TITLE
Add waitForCollectionCallback to keysChanged

### DIFF
--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -260,6 +260,12 @@ function keysChanged(collectionKey, collection) {
         if (isSubscribedToCollectionKey) {
             if (_.isFunction(subscriber.callback)) {
                 const cachedCollection = getCachedCollection(collectionKey);
+
+                if (subscriber.waitForCollectionCallback) {
+                    subscriber.callback(cachedCollection);
+                    return;
+                }
+
                 _.each(collection, (data, dataKey) => {
                     subscriber.callback(cachedCollection[dataKey], dataKey);
                 });

--- a/tests/unit/onyxTest.js
+++ b/tests/unit/onyxTest.js
@@ -489,12 +489,6 @@ describe('Onyx', () => {
             },
         };
 
-        // AND an API response for that collection
-        const apiResponse = {
-            ...initialCollectionData,
-            test_connect_collection_4: {ID: 123, value: 'four'},
-        };
-
         Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_CONNECT_COLLECTION, initialCollectionData);
         return waitForPromisesToResolve()
             .then(() => {
@@ -510,17 +504,34 @@ describe('Onyx', () => {
                 // THEN we expect the callback to be called only once and the initial stored value to be initialCollectionData
                 expect(mockCallback.mock.calls.length).toBe(1);
                 expect(mockCallback.mock.calls[0][0]).toEqual(initialCollectionData);
+            });
+    });
 
+    it('should return all collection keys as a single object when updating a collection key with waitForCollectionCallback = true', () => {
+        const valuesReceived = {};
+        const mockCallback = jest.fn(data => valuesReceived[data.ID] = data.value);
+        const collectionUpdate = {
+            test_connect_collection_3: {ID: 234, value: 'three'},
+            test_connect_collection_4: {ID: 123, value: 'four'},
+        };
+
+        // GIVEN an Onyx.connect call with waitForCollectionCallback=true
+        Onyx.connect({
+            key: ONYX_KEYS.COLLECTION.TEST_CONNECT_COLLECTION,
+            waitForCollectionCallback: true,
+            callback: mockCallback,
+        });
+        return waitForPromisesToResolve()
+            .then(() => {
                 // WHEN we update the collection, e.g. the API returns a response
-                Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_CONNECT_COLLECTION, apiResponse);
+                Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_CONNECT_COLLECTION, collectionUpdate);
                 return waitForPromisesToResolve();
             })
             .then(() => {
-                // THEN we expect the callback to have called twice, once for the initial connect call and once for the API response
+                // THEN we expect the callback to have called twice (once for the initial connect call and once for the collection update)
+                // AND the value should be equal to collectionUpdate
                 expect(mockCallback.mock.calls.length).toBe(2);
-
-                // AND all the updated collection data should be returned as a single object
-                expect(mockCallback.mock.calls[1][0]).toEqual(apiResponse);
+                expect(mockCallback.mock.calls[1][0]).toEqual(collectionUpdate);
             });
     });
 });

--- a/tests/unit/onyxTest.js
+++ b/tests/unit/onyxTest.js
@@ -522,7 +522,7 @@ describe('Onyx', () => {
         });
         return waitForPromisesToResolve()
             .then(() => {
-                // WHEN we update the collection, e.g. the API returns a response
+                // WHEN mergeCollection is called with an updated collection
                 Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_POLICY, collectionUpdate);
                 return waitForPromisesToResolve();
             })


### PR DESCRIPTION
cc @tgolen 

### Details
In https://github.com/Expensify/react-native-onyx/pull/163, we added a new param `waitForCollectionCallback` to `Onyx.connect` that waits for the collection to be read and triggers the callback only once. However, we forgot to add that param to `keysChanged` which means that the callback is being triggered for each key when we update the collection.

This PR fixes that and ensures that the callback is called only once when we update the collection.

### Related Issues
https://github.com/Expensify/react-native-onyx/pull/163

### Automated Tests
Added in `onyxTests`

### Linked PRs
https://github.com/Expensify/App/pull/10051