### PR TITLE
Prevent unnecessary `setState()` calls on simple values when nothing has changed

### DIFF
--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -2,6 +2,8 @@
 import _ from 'underscore';
 import Str from 'expensify-common/lib/str';
 import lodashGet from 'lodash/get';
+import lodashTransform from 'lodash/transform';
+import {dequal} from 'dequal/lite';
 import Storage from './storage';
 import * as Logger from './Logger';
 import cache from './OnyxCache';
@@ -33,6 +35,52 @@ let defaultKeyStates = {};
 
 // Connections can be made before `Onyx.init`. They would wait for this task before resolving
 const deferredInitTask = createDeferredTask();
+
+/**
+ * Deep diff between two objects. Useful for figuring out what changed about an object from one render to the next so
+ * that state and props updates can be optimized.
+ *
+ * @param  {Object} object
+ * @param  {Object} base
+ * @return {Object}
+ */
+function diffObject(object, base) {
+    function changes(obj, comparisonObject) {
+        return lodashTransform(obj, (result, value, key) => {
+            if (_.isEqual(value, comparisonObject[key])) {
+                return;
+            }
+
+            // eslint-disable-next-line no-param-reassign
+            result[key] = (_.isObject(value) && _.isObject(comparisonObject[key]))
+                ? changes(value, comparisonObject[key])
+                : value;
+        });
+    }
+    return changes(object, base);
+}
+
+function logSetStateCall(mapping, previousValue, newValue, caller, keyThatChanged) {
+    const difference = diffObject(previousValue, newValue);
+    console.debug(`[Onyx] setState() in ${caller} because ${mapping.displayName} subscribed to key ${mapping.key}`, {
+        keyThatChanged,
+        previousValue,
+        newValue,
+        difference,
+    });
+}
+
+function traceSetState(setStateFunction, mapping, keyThatChanged, caller) {
+    const start = performance.now();
+    setStateFunction();
+    const end = performance.now();
+    console.debug(`[Onyx] setState() took ${end - start} ms`, {
+        component: mapping.displayName,
+        subscribedTo: mapping.key,
+        keyThatChanged,
+        caller,
+    });
+}
 
 /**
  * Get some data from the store
@@ -321,18 +369,24 @@ function keysChanged(collectionKey, partialCollection) {
             // We are subscribed to a collection key so we must update the data in state with the new
             // collection member key values from the partial update.
             if (isSubscribedToCollectionKey) {
-                subscriber.withOnyxInstance.setState((prevState) => {
-                    const finalCollection = _.clone(prevState[subscriber.statePropertyName] || {});
+                traceSetState(() => {
+                    subscriber.withOnyxInstance.setState((prevState) => {
+                        const finalCollection = _.clone(prevState[subscriber.statePropertyName] || {});
+                        const dataKeys = _.keys(partialCollection);
+                        for (let j = 0; j < dataKeys.length; j++) {
+                            const dataKey = dataKeys[j];
+                            finalCollection[dataKey] = cachedCollection[dataKey];
+                        }
+                        if (dequal(finalCollection, prevState[subscriber.statePropertyName])) {
+                            return null;
+                        }
 
-                    const dataKeys = _.keys(partialCollection);
-                    for (let j = 0; j < dataKeys.length; j++) {
-                        const dataKey = dataKeys[j];
-                        finalCollection[dataKey] = cachedCollection[dataKey];
-                    }
-                    return {
-                        [subscriber.statePropertyName]: finalCollection,
-                    };
-                });
+                        logSetStateCall(subscriber, prevState[subscriber.statePropertyName], finalCollection, 'keysChanged', collectionKey);
+                        return {
+                            [subscriber.statePropertyName]: finalCollection,
+                        };
+                    });
+                }, subscriber, collectionKey, 'keysChanged');
                 continue;
             }
 
@@ -345,17 +399,20 @@ function keysChanged(collectionKey, partialCollection) {
                     continue;
                 }
 
-                subscriber.withOnyxInstance.setState((prevState) => {
-                    const data = cachedCollection[subscriber.key];
+                traceSetState(() => {
+                    subscriber.withOnyxInstance.setState((prevState) => {
+                        const data = cachedCollection[subscriber.key];
 
-                    // Don't update components for no reason when the data is simple and has not changed
-                    if (!_.isObject(data) && prevState[subscriber.statePropertyName] === data) {
-                        return null;
-                    }
+                        // Don't update components for no reason when the data is simple and has not changed
+                        if (dequal(prevState[subscriber.statePropertyName], data)) {
+                            return null;
+                        }
 
-                    return {
-                        [subscriber.statePropertyName]: data,
-                    };
+                        logSetStateCall(subscriber, prevState[subscriber.statePropertyName], data, 'keysChanged', collectionKey);
+                        return {
+                            [subscriber.statePropertyName]: data,
+                        };
+                    }, subscriber, collectionKey, 'keysChanged');
                 });
             }
         }
@@ -404,29 +461,40 @@ function keyChanged(key, data) {
         if (subscriber.withOnyxInstance) {
             // Check if we are subscribing to a collection key and overwrite the collection member key value in state
             if (isCollectionKey(subscriber.key)) {
-                subscriber.withOnyxInstance.setState((prevState) => {
-                    const collection = prevState[subscriber.statePropertyName] || {};
-                    return {
-                        [subscriber.statePropertyName]: {
+                traceSetState(() => {
+                    subscriber.withOnyxInstance.setState((prevState) => {
+                        const collection = prevState[subscriber.statePropertyName] || {};
+                        const newCollection = {
                             ...collection,
                             [key]: data,
-                        },
-                    };
-                });
+                        };
+                        if (dequal(collection, newCollection)) {
+                            return null;
+                        }
+
+                        logSetStateCall(subscriber, collection, newCollection, 'keyChanged', key);
+                        return {
+                            [subscriber.statePropertyName]: newCollection,
+                        };
+                    });
+                }, subscriber, key, 'keyChanged');
                 continue;
             }
 
             // If we did not match on a collection key then we just set the new data to the state property
-            subscriber.withOnyxInstance.setState((prevState) => {
-                // Don't update components for no reason when the data is simple and has not changed
-                if (!_.isObject(data) && prevState[subscriber.statePropertyName] === data) {
-                    return null;
-                }
+            traceSetState(() => {
+                subscriber.withOnyxInstance.setState((prevState) => {
+                    // Don't update components for no reason when the data is simple and has not changed
+                    if (dequal(prevState[subscriber.statePropertyName], data)) {
+                        return null;
+                    }
 
-                return {
-                    [subscriber.statePropertyName]: data,
-                };
-            });
+                    logSetStateCall(subscriber, prevState[subscriber.statePropertyName], data, 'keyChanged', key);
+                    return {
+                        [subscriber.statePropertyName]: data,
+                    };
+                });
+            }, subscriber, key, 'keyChanged');
             continue;
         }
 
@@ -455,7 +523,10 @@ function sendDataToConnection(config, val, matchedKey) {
     }
 
     if (config.withOnyxInstance) {
-        config.withOnyxInstance.setWithOnyxState(config.statePropertyName, val);
+        logSetStateCall(config, null, val, 'sendDataToConnection');
+        traceSetState(() => {
+            config.withOnyxInstance.setWithOnyxState(config.statePropertyName, val);
+        }, config, undefined, 'sendDataToConnection');
     } else if (_.isFunction(config.callback)) {
         config.callback(val, matchedKey);
     }

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -345,8 +345,17 @@ function keysChanged(collectionKey, partialCollection) {
                     continue;
                 }
 
-                subscriber.withOnyxInstance.setState({
-                    [subscriber.statePropertyName]: cachedCollection[subscriber.key],
+                subscriber.withOnyxInstance.setState((prevState) => {
+                    const data = cachedCollection[subscriber.key];
+
+                    // Don't update components for no reason when the data is simple and has not changed
+                    if (!_.isObject(data) && prevState[subscriber.statePropertyName] === data) {
+                        return null;
+                    }
+
+                    return {
+                        [subscriber.statePropertyName]: data,
+                    };
                 });
             }
         }
@@ -408,8 +417,15 @@ function keyChanged(key, data) {
             }
 
             // If we did not match on a collection key then we just set the new data to the state property
-            subscriber.withOnyxInstance.setState({
-                [subscriber.statePropertyName]: data,
+            subscriber.withOnyxInstance.setState((prevState) => {
+                // Don't update components for no reason when the data is simple and has not changed
+                if (!_.isObject(data) && prevState[subscriber.statePropertyName] === data) {
+                    return null;
+                }
+
+                return {
+                    [subscriber.statePropertyName]: data,
+                };
             });
             continue;
         }

--- a/lib/withOnyx.js
+++ b/lib/withOnyx.js
@@ -146,11 +146,6 @@ export default function (mapOnyxToState) {
             connectMappingToOnyx(mapping, statePropertyName) {
                 const key = Str.result(mapping.key, this.props);
 
-                if (displayName === 'Component') {
-                    console.debug({mapOnyxToState, WrappedComponent});
-                    throw new Error('Component subscribed to Onyx without a displayName');
-                }
-
                 // eslint-disable-next-line rulesdir/prefer-onyx-connect-in-libs
                 this.activeConnectionIDs[key] = Onyx.connect({
                     ...mapping,

--- a/lib/withOnyx.js
+++ b/lib/withOnyx.js
@@ -25,8 +25,8 @@ export default function (mapOnyxToState) {
         .omit(config => config.initWithStoredValues === false)
         .keys()
         .value();
-
     return (WrappedComponent) => {
+        const displayName = getDisplayName(WrappedComponent);
         class withOnyx extends React.Component {
             constructor(props) {
                 super(props);
@@ -146,12 +146,18 @@ export default function (mapOnyxToState) {
             connectMappingToOnyx(mapping, statePropertyName) {
                 const key = Str.result(mapping.key, this.props);
 
+                if (displayName === 'Component') {
+                    console.debug({mapOnyxToState, WrappedComponent});
+                    throw new Error('Component subscribed to Onyx without a displayName');
+                }
+
                 // eslint-disable-next-line rulesdir/prefer-onyx-connect-in-libs
                 this.activeConnectionIDs[key] = Onyx.connect({
                     ...mapping,
                     key,
                     statePropertyName,
                     withOnyxInstance: this,
+                    displayName,
                 });
             }
 
@@ -190,7 +196,7 @@ export default function (mapOnyxToState) {
         withOnyx.defaultProps = {
             forwardedRef: undefined,
         };
-        withOnyx.displayName = `withOnyx(${getDisplayName(WrappedComponent)})`;
+        withOnyx.displayName = `withOnyx(${displayName})`;
         return React.forwardRef((props, ref) => {
             const Component = withOnyx;
             // eslint-disable-next-line react/jsx-props-no-spreading

--- a/package-lock.json
+++ b/package-lock.json
@@ -5565,6 +5565,11 @@
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
       "dev": true
     },
+    "dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="
+    },
     "destroy": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "ascii-table": "0.0.9",
+    "dequal": "^2.0.3",
     "lodash": "^4.17.21",
     "underscore": "^1.13.1"
   },

--- a/tests/unit/withOnyxTest.js
+++ b/tests/unit/withOnyxTest.js
@@ -12,6 +12,7 @@ const ONYX_KEYS = {
         TEST_KEY: 'test_',
         RELATED_KEY: 'related_',
     },
+    SIMPLE_KEY: 'simple',
 };
 
 Onyx.init({
@@ -326,6 +327,45 @@ describe('withOnyx', () => {
                 expect(onRender).toHaveBeenCalledTimes(2);
                 expect(onRender.mock.calls[0][0].testObject).toStrictEqual({ID: 1, number: 1});
                 expect(onRender.mock.calls[1][0].testObject).toStrictEqual({ID: 1, number: 2});
+            });
+    });
+
+    it('merge with a simple value should not update a connected component unless the data has changed', () => {
+        const onRender = jest.fn();
+
+        // Given there is a simple key that is not an array or object value
+        Onyx.merge(ONYX_KEYS.SIMPLE_KEY, 'string');
+
+        return waitForPromisesToResolve()
+            .then(() => {
+                // When a component subscribes to the simple key
+                const TestComponentWithOnyx = withOnyx({
+                    simple: {
+                        key: ONYX_KEYS.SIMPLE_KEY,
+                    },
+                })(ViewWithCollections);
+                render(<TestComponentWithOnyx onRender={onRender} />);
+
+                return waitForPromisesToResolve();
+            })
+            .then(() => {
+                // And we set the value to the same value it was before
+                Onyx.merge(ONYX_KEYS.SIMPLE_KEY, 'string');
+                return waitForPromisesToResolve();
+            })
+            .then(() => {
+                // THEN the component subscribed to the modified item should only render once
+                expect(onRender).toHaveBeenCalledTimes(1);
+                expect(onRender.mock.calls[0][0].simple).toBe('string');
+
+                // If we change the value to something new
+                Onyx.merge(ONYX_KEYS.SIMPLE_KEY, 'long_string');
+                return waitForPromisesToResolve();
+            })
+            .then(() => {
+                // THEN the component subscribed to the modified item should only render once
+                expect(onRender).toHaveBeenCalledTimes(2);
+                expect(onRender.mock.calls[1][0].simple).toBe('long_string');
             });
     });
 });


### PR DESCRIPTION
### Details

`setState()` calls trigger re-renders that are unnecessary. This is a small optimization. In reality, I found that we don't have tons of these in our App.

### Related Issues

### Automated Tests

Added an automated test

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->
