### PR TITLE
Prevent setting state for values that have not changed. Add additional Onyx debugging metrics.

### DIFF
--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -2,11 +2,13 @@
 import _ from 'underscore';
 import Str from 'expensify-common/lib/str';
 import lodashGet from 'lodash/get';
+import {dequal} from 'dequal/lite';
 import Storage from './storage';
 import * as Logger from './Logger';
 import cache from './OnyxCache';
 import createDeferredTask from './createDeferredTask';
 import mergeWithCustomized from './mergeWithCustomized';
+import * as PerformanceUtils from './metrics/PerformanceUtils';
 
 // Keeps track of the last connectionID that was used so we can keep incrementing it
 let lastConnectionID = 0;
@@ -321,17 +323,28 @@ function keysChanged(collectionKey, partialCollection) {
             // We are subscribed to a collection key so we must update the data in state with the new
             // collection member key values from the partial update.
             if (isSubscribedToCollectionKey) {
-                subscriber.withOnyxInstance.setState((prevState) => {
-                    const finalCollection = _.clone(prevState[subscriber.statePropertyName] || {});
+                PerformanceUtils.withSetStateTrace({
+                    setStateFunction() {
+                        subscriber.withOnyxInstance.setState((prevState) => {
+                            const finalCollection = _.clone(prevState[subscriber.statePropertyName] || {});
+                            const dataKeys = _.keys(partialCollection);
+                            for (let j = 0; j < dataKeys.length; j++) {
+                                const dataKey = dataKeys[j];
+                                finalCollection[dataKey] = cachedCollection[dataKey];
+                            }
+                            if (dequal(finalCollection, prevState[subscriber.statePropertyName])) {
+                                return null;
+                            }
 
-                    const dataKeys = _.keys(partialCollection);
-                    for (let j = 0; j < dataKeys.length; j++) {
-                        const dataKey = dataKeys[j];
-                        finalCollection[dataKey] = cachedCollection[dataKey];
-                    }
-                    return {
-                        [subscriber.statePropertyName]: finalCollection,
-                    };
+                            PerformanceUtils.logSetStateCall(subscriber, prevState[subscriber.statePropertyName], finalCollection, 'keysChanged', collectionKey);
+                            return {
+                                [subscriber.statePropertyName]: finalCollection,
+                            };
+                        });
+                    },
+                    mapping: subscriber,
+                    keyThatChanged: collectionKey,
+                    caller: 'keysChanged',
                 });
                 continue;
             }
@@ -345,8 +358,23 @@ function keysChanged(collectionKey, partialCollection) {
                     continue;
                 }
 
-                subscriber.withOnyxInstance.setState({
-                    [subscriber.statePropertyName]: cachedCollection[subscriber.key],
+                PerformanceUtils.withSetStateTrace({
+                    setStateFunction() {
+                        subscriber.withOnyxInstance.setState((prevState) => {
+                            const data = cachedCollection[subscriber.key];
+                            if (dequal(prevState[subscriber.statePropertyName], data)) {
+                                return null;
+                            }
+
+                            PerformanceUtils.logSetStateCall(subscriber, prevState[subscriber.statePropertyName], data, 'keysChanged', collectionKey);
+                            return {
+                                [subscriber.statePropertyName]: data,
+                            };
+                        });
+                    },
+                    mapping: subscriber,
+                    keyThatChanged: collectionKey,
+                    caller: 'keysChanged',
                 });
             }
         }
@@ -395,21 +423,48 @@ function keyChanged(key, data) {
         if (subscriber.withOnyxInstance) {
             // Check if we are subscribing to a collection key and overwrite the collection member key value in state
             if (isCollectionKey(subscriber.key)) {
-                subscriber.withOnyxInstance.setState((prevState) => {
-                    const collection = prevState[subscriber.statePropertyName] || {};
-                    return {
-                        [subscriber.statePropertyName]: {
-                            ...collection,
-                            [key]: data,
-                        },
-                    };
+                PerformanceUtils.withSetStateTrace({
+                    setStateFunction() {
+                        subscriber.withOnyxInstance.setState((prevState) => {
+                            const collection = prevState[subscriber.statePropertyName] || {};
+                            const newCollection = {
+                                ...collection,
+                                [key]: data,
+                            };
+                            if (dequal(collection, newCollection)) {
+                                return null;
+                            }
+
+                            PerformanceUtils.logSetStateCall(subscriber, collection, newCollection, 'keyChanged', key);
+                            return {
+                                [subscriber.statePropertyName]: newCollection,
+                            };
+                        });
+                    },
+                    mapping: subscriber,
+                    keyThatChanged: key,
+                    caller: 'keyChanged',
                 });
                 continue;
             }
 
             // If we did not match on a collection key then we just set the new data to the state property
-            subscriber.withOnyxInstance.setState({
-                [subscriber.statePropertyName]: data,
+            PerformanceUtils.withSetStateTrace({
+                setStateFunction() {
+                    subscriber.withOnyxInstance.setState((prevState) => {
+                        if (dequal(prevState[subscriber.statePropertyName], data)) {
+                            return null;
+                        }
+
+                        PerformanceUtils.logSetStateCall(subscriber, prevState[subscriber.statePropertyName], data, 'keyChanged', key);
+                        return {
+                            [subscriber.statePropertyName]: data,
+                        };
+                    });
+                },
+                mapping: subscriber,
+                keyThatChanged: key,
+                caller: 'keyChanged',
             });
             continue;
         }
@@ -439,7 +494,14 @@ function sendDataToConnection(config, val, matchedKey) {
     }
 
     if (config.withOnyxInstance) {
-        config.withOnyxInstance.setWithOnyxState(config.statePropertyName, val);
+        PerformanceUtils.logSetStateCall(config, null, val, 'sendDataToConnection');
+        PerformanceUtils.withSetStateTrace({
+            setStateFunction() {
+                config.withOnyxInstance.setWithOnyxState(config.statePropertyName, val);
+            },
+            mapping: config,
+            caller: 'sendDataToConnection',
+        });
     } else if (_.isFunction(config.callback)) {
         config.callback(val, matchedKey);
     }
@@ -1004,6 +1066,8 @@ function init({
     keysToDisableSyncEvents = [],
 } = {}) {
     if (captureMetrics) {
+        PerformanceUtils.setShouldCaptureMetrics(true);
+
         // The code here is only bundled and applied when the captureMetrics is set
         // eslint-disable-next-line no-use-before-define
         applyDecorators();

--- a/lib/metrics/PerformanceUtils.js
+++ b/lib/metrics/PerformanceUtils.js
@@ -1,0 +1,95 @@
+import lodashTransform from 'lodash/transform';
+import _ from 'underscore';
+import {dequal} from 'dequal/lite';
+
+let shouldCaptureMetrics = false;
+
+/**
+ * @param {Boolean} captureMetrics
+ */
+function setShouldCaptureMetrics(captureMetrics) {
+    shouldCaptureMetrics = captureMetrics;
+}
+
+/**
+ * Deep diff between two objects. Useful for figuring out what changed about an object from one render to the next so
+ * that state and props updates can be optimized.
+ *
+ * @param  {Object} object
+ * @param  {Object} base
+ * @return {Object}
+ */
+function diffObject(object, base) {
+    function changes(obj, comparisonObject) {
+        return lodashTransform(obj, (result, value, key) => {
+            if (dequal(value, comparisonObject[key])) {
+                return;
+            }
+
+            // eslint-disable-next-line no-param-reassign
+            result[key] = (_.isObject(value) && _.isObject(comparisonObject[key]))
+                ? changes(value, comparisonObject[key])
+                : value;
+        });
+    }
+    return changes(object, base);
+}
+
+/**
+ * Provide insights into why a setState() call occurred by diffing the before and after values.
+ *
+ * @param {Object} mapping
+ * @param {*} previousValue
+ * @param {*} newValue
+ * @param {String} caller
+ * @param {String} keyThatChanged
+ */
+function logSetStateCall(mapping, previousValue, newValue, caller, keyThatChanged) {
+    if (!shouldCaptureMetrics) {
+        return;
+    }
+
+    const logParams = {keyThatChanged};
+    if (_.isObject(newValue) || _.isObject(previousValue)) {
+        logParams.difference = diffObject(previousValue, newValue);
+    } else {
+        logParams.previousValue = previousValue;
+        logParams.newValue = newValue;
+    }
+
+    console.debug(`[Onyx] setState() in ${caller} because ${mapping.displayName} subscribed to key ${mapping.key}`, logParams);
+}
+
+/**
+ * Timing helper which will tell us how long it took to call the setState() method on a connected React component.
+ *
+ * @param {Object} params
+ * @param {Function} setStateFunction
+ * @param {Object} mapping
+ * @param {String} keyThatChanged
+ * @param {String} caller
+ */
+function withSetStateTrace({
+    setStateFunction, mapping, keyThatChanged, caller,
+}) {
+    if (!shouldCaptureMetrics) {
+        setStateFunction();
+        return;
+    }
+
+    const start = performance.now();
+    setStateFunction();
+    const end = performance.now();
+    console.debug(`[Onyx] setState() took ${end - start} ms`, {
+        component: mapping.displayName,
+        subscribedTo: mapping.key,
+        keyThatChanged,
+        caller,
+    });
+}
+
+export {
+    logSetStateCall,
+    withSetStateTrace,
+    setShouldCaptureMetrics,
+};

--- a/lib/withOnyx.js
+++ b/lib/withOnyx.js
@@ -25,8 +25,8 @@ export default function (mapOnyxToState) {
         .omit(config => config.initWithStoredValues === false)
         .keys()
         .value();
-
     return (WrappedComponent) => {
+        const displayName = getDisplayName(WrappedComponent);
         class withOnyx extends React.Component {
             constructor(props) {
                 super(props);
@@ -152,6 +152,7 @@ export default function (mapOnyxToState) {
                     key,
                     statePropertyName,
                     withOnyxInstance: this,
+                    displayName,
                 });
             }
 
@@ -190,7 +191,7 @@ export default function (mapOnyxToState) {
         withOnyx.defaultProps = {
             forwardedRef: undefined,
         };
-        withOnyx.displayName = `withOnyx(${getDisplayName(WrappedComponent)})`;
+        withOnyx.displayName = `withOnyx(${displayName})`;
         return React.forwardRef((props, ref) => {
             const Component = withOnyx;
             // eslint-disable-next-line react/jsx-props-no-spreading

--- a/package-lock.json
+++ b/package-lock.json
@@ -5565,6 +5565,11 @@
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
       "dev": true
     },
+    "dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="
+    },
     "destroy": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "ascii-table": "0.0.9",
+    "dequal": "^2.0.3",
     "lodash": "^4.17.21",
     "underscore": "^1.13.1"
   },

--- a/tests/unit/withOnyxTest.js
+++ b/tests/unit/withOnyxTest.js
@@ -12,6 +12,7 @@ const ONYX_KEYS = {
         TEST_KEY: 'test_',
         RELATED_KEY: 'related_',
     },
+    SIMPLE_KEY: 'simple',
 };
 
 Onyx.init({
@@ -326,6 +327,45 @@ describe('withOnyx', () => {
                 expect(onRender).toHaveBeenCalledTimes(2);
                 expect(onRender.mock.calls[0][0].testObject).toStrictEqual({ID: 1, number: 1});
                 expect(onRender.mock.calls[1][0].testObject).toStrictEqual({ID: 1, number: 2});
+            });
+    });
+
+    it('merge with a simple value should not update a connected component unless the data has changed', () => {
+        const onRender = jest.fn();
+
+        // Given there is a simple key that is not an array or object value
+        Onyx.merge(ONYX_KEYS.SIMPLE_KEY, 'string');
+
+        return waitForPromisesToResolve()
+            .then(() => {
+                // When a component subscribes to the simple key
+                const TestComponentWithOnyx = withOnyx({
+                    simple: {
+                        key: ONYX_KEYS.SIMPLE_KEY,
+                    },
+                })(ViewWithCollections);
+                render(<TestComponentWithOnyx onRender={onRender} />);
+
+                return waitForPromisesToResolve();
+            })
+            .then(() => {
+                // And we set the value to the same value it was before
+                Onyx.merge(ONYX_KEYS.SIMPLE_KEY, 'string');
+                return waitForPromisesToResolve();
+            })
+            .then(() => {
+                // THEN the component subscribed to the modified item should only render once
+                expect(onRender).toHaveBeenCalledTimes(1);
+                expect(onRender.mock.calls[0][0].simple).toBe('string');
+
+                // If we change the value to something new
+                Onyx.merge(ONYX_KEYS.SIMPLE_KEY, 'long_string');
+                return waitForPromisesToResolve();
+            })
+            .then(() => {
+                // THEN the component subscribed to the modified item should only render once
+                expect(onRender).toHaveBeenCalledTimes(2);
+                expect(onRender.mock.calls[1][0].simple).toBe('long_string');
             });
     });
 });


### PR DESCRIPTION
### Details

There are many calls to `setState()` in Onyx that can be avoided. The cost to calculate whether they have changed is lower than the cost to re-render the components that are subscribing to them. Therefore, it makes sense to use an optimized equality check to see if something has changed before we update a component.

I also added metrics that give us insights into why the `setState()` call is happening which can be enabled by using the `ONYX_METRICS=true` flag in the `.env` file.

**Note:** These metrics are currently broken on web due to some unrelated issue. And removing the `applyDecorators()` method will fix the build and allow our new logs to appear.

### Metrics

#### FCP/LCP/etc on Web

**without checks**

![Screen Shot 2022-09-27 at 10 42 26 AM](https://user-images.githubusercontent.com/32969087/192632029-b13960d9-58e3-40df-9dce-15c23b33fc13.png)

**with checks**

![Screen Shot 2022-09-27 at 10 20 14 AM](https://user-images.githubusercontent.com/32969087/192632065-db31e4b2-2e60-4df2-a7fc-33f932b8bb47.png)

#### Chat Switch Time on Web

**without `dequal` checks:**

![Screen Shot 2022-09-27 at 10 09 36 AM](https://user-images.githubusercontent.com/32969087/192625770-30729032-8a60-4043-b54a-5853d1ed0ed9.png)

**with `dequal` checks:**

![Screen Shot 2022-09-27 at 10 06 16 AM](https://user-images.githubusercontent.com/32969087/192625863-e2a5192f-f9d1-40b9-98d6-b31c2706823a.png)

There's ~ 90 ms improvement in the chat switching from reducing set state.

So far... not super impressive... but check out Android profiles on chat switching...

#### Chat Switch Time on Android

**without checks**

![Screen Shot 2022-09-27 at 10 59 30 AM](https://user-images.githubusercontent.com/32969087/192634790-4fc9d784-1b1e-4df7-965c-b2632a0fc026.png)

**with checks**

![Screen Shot 2022-09-27 at 11 00 54 AM](https://user-images.githubusercontent.com/32969087/192634811-1c10057e-5f2e-40c3-8e56-4654ed2a16e7.png)

That's 664 ms difference which is pretty great.

### Related Issues

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->
