### PR TITLE
Batch updates

### DIFF
--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -7,6 +7,7 @@ import * as Logger from './Logger';
 import cache from './OnyxCache';
 import createDeferredTask from './createDeferredTask';
 import mergeWithCustomized from './mergeWithCustomized';
+import unstable_batchedUpdates from './batch';
 
 // Keeps track of the last connectionID that was used so we can keep incrementing it
 let lastConnectionID = 0;
@@ -603,6 +604,9 @@ function disconnect(connectionID, keyToRemoveFromEvictionBlocklist) {
     delete callbackToStateMapping[connectionID];
 }
 
+let pendingUpdates = [];
+let scheduled = false;
+
 /**
  * This method mostly exists for historical reasons as this library was initially designed without a memory cache and one was added later.
  * For this reason, Onyx works more similar to what you might expect from a native AsyncStorage with reads, writes, etc all becoming
@@ -614,7 +618,22 @@ function disconnect(connectionID, keyToRemoveFromEvictionBlocklist) {
  */
 // eslint-disable-next-line rulesdir/no-negated-variables
 function notifySubscribersOnNextTick(key, value) {
-    Promise.resolve().then(() => keyChanged(key, value));
+    pendingUpdates.push([key, value]);
+    if (!scheduled) {
+        scheduled = true;
+        setTimeout(() => {
+            scheduled = false;
+            const updatesCopy = pendingUpdates;
+            pendingUpdates = [];
+
+            // eslint-disable-next-line prefer-arrow-callback
+            unstable_batchedUpdates(function flushUpdatesOnyx() {
+                for (let i = 0; i < updatesCopy.length; ++i) {
+                    keyChanged(updatesCopy[i][0], updatesCopy[i][1]);
+                }
+            });
+        }, 0);
+    }
 }
 
 /**

--- a/lib/batch.js
+++ b/lib/batch.js
@@ -1,0 +1,3 @@
+import {unstable_batchedUpdates} from 'react-dom';
+
+export default unstable_batchedUpdates;

--- a/lib/batch.native.js
+++ b/lib/batch.native.js
@@ -1,0 +1,3 @@
+import {unstable_batchedUpdates} from 'react-native';
+
+export default unstable_batchedUpdates;


### PR DESCRIPTION
Unfortunately, tests are not passing will check what's the issue.  
[update] looks like tests expects keyChange to be called before storage.set is resolved what kills performance optimisations 

I see 3 options:
- wait of fabric and check if it solves the problem with too many renders
- update tests
- try to batch only setStates (not sure if it's enough to just do it on withOnyx as some components may just use Onyx.connect and update state there?)

### Details
https://expensify.slack.com/archives/C035J5C9FAP/p1664786930667779 

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->
