### PR TITLE
Remove `keysToDisableSyncEvents`

### DIFF
--- a/API.md
+++ b/API.md
@@ -65,20 +65,20 @@ value will be saved to storage after the default value.</p>
 <a name="isCollectionMemberKey"></a>
 
 ## isCollectionMemberKey(collectionKey, key) ⇒ <code>Boolean</code>
-**Kind**: global function
+**Kind**: global function  
 
 | Param | Type |
 | --- | --- |
-| collectionKey | <code>String</code> |
-| key | <code>String</code> |
+| collectionKey | <code>String</code> | 
+| key | <code>String</code> | 
 
 <a name="connect"></a>
 
 ## connect(mapping) ⇒ <code>Number</code>
 Subscribes a react component's state directly to a store key
 
-**Kind**: global function
-**Returns**: <code>Number</code> - an ID to use when calling disconnect
+**Kind**: global function  
+**Returns**: <code>Number</code> - an ID to use when calling disconnect  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -90,7 +90,7 @@ Subscribes a react component's state directly to a store key
 | [mapping.initWithStoredValues] | <code>Boolean</code> | If set to false, then no data will be prefilled into the  component |
 | [mapping.waitForCollectionCallback] | <code>Boolean</code> | If set to true, it will return the entire collection to the callback as a single object |
 
-**Example**
+**Example**  
 ```js
 const connectionID = Onyx.connect({
     key: ONYXKEYS.SESSION,
@@ -102,14 +102,14 @@ const connectionID = Onyx.connect({
 ## disconnect(connectionID, [keyToRemoveFromEvictionBlocklist])
 Remove the listener for a react component
 
-**Kind**: global function
+**Kind**: global function  
 
 | Param | Type | Description |
 | --- | --- | --- |
 | connectionID | <code>Number</code> | unique id returned by call to Onyx.connect() |
 | [keyToRemoveFromEvictionBlocklist] | <code>String</code> |  |
 
-**Example**
+**Example**  
 ```js
 Onyx.disconnect(connectionID);
 ```
@@ -121,19 +121,19 @@ For this reason, Onyx works more similar to what you might expect from a native 
 available async. Since we have code in our main applications that might expect things to work this way it's not safe to change this
 behavior just yet.
 
-**Kind**: global function
+**Kind**: global function  
 
 | Param | Type |
 | --- | --- |
-| key | <code>String</code> |
-| value | <code>\*</code> |
+| key | <code>String</code> | 
+| value | <code>\*</code> | 
 
 <a name="set"></a>
 
 ## set(key, value) ⇒ <code>Promise</code>
 Write a value to our store with the given key
 
-**Kind**: global function
+**Kind**: global function  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -145,13 +145,13 @@ Write a value to our store with the given key
 ## multiSet(data) ⇒ <code>Promise</code>
 Sets multiple keys and values
 
-**Kind**: global function
+**Kind**: global function  
 
 | Param | Type | Description |
 | --- | --- | --- |
 | data | <code>Object</code> | object keyed by ONYXKEYS and the values to set |
 
-**Example**
+**Example**  
 ```js
 Onyx.multiSet({'key1': 'a', 'key2': 'b'});
 ```
@@ -169,14 +169,14 @@ Calls to `Onyx.merge()` are batched so that any calls performed in a single tick
 applied in the order they were called. Note: `Onyx.set()` calls do not work this way so use caution when mixing
 `Onyx.merge()` and `Onyx.set()`.
 
-**Kind**: global function
+**Kind**: global function  
 
 | Param | Type | Description |
 | --- | --- | --- |
 | key | <code>String</code> | ONYXKEYS key |
 | value | <code>Object</code> \| <code>Array</code> | Object or Array value to merge |
 
-**Example**
+**Example**  
 ```js
 Onyx.merge(ONYXKEYS.EMPLOYEE_LIST, ['Joe']); // -> ['Joe']
 Onyx.merge(ONYXKEYS.EMPLOYEE_LIST, ['Jack']); // -> ['Joe', 'Jack']
@@ -204,20 +204,20 @@ Onyx.get(key) before calling Storage.setItem() via Onyx.set().
 Storage.setItem() from Onyx.clear() will have already finished and the merged
 value will be saved to storage after the default value.
 
-**Kind**: global function
+**Kind**: global function  
 <a name="mergeCollection"></a>
 
 ## mergeCollection(collectionKey, collection) ⇒ <code>Promise</code>
 Merges a collection based on their keys
 
-**Kind**: global function
+**Kind**: global function  
 
 | Param | Type | Description |
 | --- | --- | --- |
 | collectionKey | <code>String</code> | e.g. `ONYXKEYS.COLLECTION.REPORT` |
 | collection | <code>Object</code> | Object collection keyed by individual collection member keys and values |
 
-**Example**
+**Example**  
 ```js
 Onyx.mergeCollection(ONYXKEYS.COLLECTION.REPORT, {
     [`${ONYXKEYS.COLLECTION.REPORT}1`]: report1,
@@ -229,7 +229,7 @@ Onyx.mergeCollection(ONYXKEYS.COLLECTION.REPORT, {
 ## update(data)
 Insert API responses and lifecycle data into Onyx
 
-**Kind**: global function
+**Kind**: global function  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -240,7 +240,7 @@ Insert API responses and lifecycle data into Onyx
 ## init([options])
 Initialize the store with actions and listening for storage events
 
-**Kind**: global function
+**Kind**: global function  
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -251,9 +251,8 @@ Initialize the store with actions and listening for storage events
 | [options.maxCachedKeysCount] | <code>Number</code> | <code>55</code> | Sets how many recent keys should we try to keep in cache Setting this to 0 would practically mean no cache We try to free cache when we connect to a safe eviction key |
 | [options.captureMetrics] | <code>Boolean</code> |  | Enables Onyx benchmarking and exposes the get/print/reset functions |
 | [options.shouldSyncMultipleInstances] | <code>Boolean</code> |  | Auto synchronize storage events between multiple instances of Onyx running in different tabs/windows. Defaults to true for platforms that support local storage (web/desktop) |
-| [option.keysToDisableSyncEvents] | <code>Array.&lt;String&gt;</code> | <code>[]</code> | Contains keys for which we want to disable sync event across tabs. |
 
-**Example**
+**Example**  
 ```js
 Onyx.init({
     keys: ONYXKEYS,

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -986,8 +986,6 @@ function update(data) {
  * @param {Boolean} [options.captureMetrics] Enables Onyx benchmarking and exposes the get/print/reset functions
  * @param {Boolean} [options.shouldSyncMultipleInstances] Auto synchronize storage events between multiple instances
  * of Onyx running in different tabs/windows. Defaults to true for platforms that support local storage (web/desktop)
- * @param {String[]} [option.keysToDisableSyncEvents=[]] Contains keys for which
- * we want to disable sync event across tabs.
  * @example
  * Onyx.init({
  *     keys: ONYXKEYS,
@@ -1003,7 +1001,6 @@ function init({
     maxCachedKeysCount = 1000,
     captureMetrics = false,
     shouldSyncMultipleInstances = Boolean(global.localStorage),
-    keysToDisableSyncEvents = [],
 } = {}) {
     if (captureMetrics) {
         // The code here is only bundled and applied when the captureMetrics is set
@@ -1032,7 +1029,7 @@ function init({
         .then(deferredInitTask.resolve);
 
     if (shouldSyncMultipleInstances && _.isFunction(Storage.keepInstancesSync)) {
-        Storage.keepInstancesSync(keysToDisableSyncEvents, (key, value) => {
+        Storage.keepInstancesSync((key, value) => {
             cache.set(key, value);
             keyChanged(key, value);
         });

--- a/lib/storage/WebStorage.js
+++ b/lib/storage/WebStorage.js
@@ -16,12 +16,9 @@ const webStorage = {
     ...Storage,
 
     /**
-     * Contains keys for which we want to disable sync event across tabs.
-     * @param {String[]} keysToDisableSyncEvents
-     * Storage synchronization mechanism keeping all opened tabs in sync
-     * @param {function(key: String, data: *)} onStorageKeyChanged
+     * @param {Function} onStorageKeyChanged Storage synchronization mechanism keeping all opened tabs in sync
      */
-    keepInstancesSync(keysToDisableSyncEvents, onStorageKeyChanged) {
+    keepInstancesSync(onStorageKeyChanged) {
         // Override set, remove and clear to raise storage events that we intercept in other tabs
         this.setItem = (key, value) => Storage.setItem(key, value)
             .then(() => raiseStorageSyncEvent(key));
@@ -43,10 +40,6 @@ const webStorage = {
             }
 
             const onyxKey = event.newValue;
-            if (_.contains(keysToDisableSyncEvents, onyxKey)) {
-                return;
-            }
-
             Storage.getItem(onyxKey)
                 .then(value => onStorageKeyChanged(onyxKey, value));
         });


### PR DESCRIPTION
### Details

We removed the last usage of `keysToDisableSyncEvents` array in [this PR](https://github.com/Expensify/App/pull/11450).

### Related Issues

https://github.com/Expensify/App/pull/11450

### Automated Tests
❌ 

### Linked PRs

We'll create one after the linked app PR is merged and this PR is merged.