### PR TITLE
Fix storage/index.native.js to remove Platform.select

### DIFF
--- a/lib/storage/index.native.js
+++ b/lib/storage/index.native.js
@@ -1,8 +1,3 @@
-import {Platform} from 'react-native';
+import NativeStorage from './NativeStorage';
 
-const Storage = Platform.select({
-    default: () => require('./WebStorage').default,
-    native: () => require('./NativeStorage').default,
-})();
-
-export default Storage;
+export default NativeStorage;


### PR DESCRIPTION
### Details
Fixed a platform-specific file to comply with our guidelines. This was split off into a platform-specific file in [this PR](https://github.com/Expensify/react-native-onyx/pull/132), but looking back I'm pretty sure that leaving `Platform.select` inside index.native.js was a mistake.

### Related Issues
n/a

### Automated Tests
n/a

### Linked PRs
n/a

### Testing plan
Create an E/App PR to upgrade the react-native-onyx version and test that the native storage still works (if it doesn't everything will break and we will surely notice). Also tag in an C+ for a thorough review on all platforms.