### PR TITLE
Throw if we are trying to merge a non object value to the cache. noop if `mergeCollection()` is called with a bad value.

### DIFF
--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -1046,7 +1046,7 @@ function clear() {
  * @returns {Promise}
  */
 function mergeCollection(collectionKey, collection) {
-    if (!_.isObject(collection) || _.isArray(collection)) {
+    if (!_.isObject(collection) || _.isArray(collection) || _.isEmpty(collection)) {
         Logger.logInfo('mergeCollection() called with invalid or empty value. Skipping this update.');
         return Promise.resolve();
     }

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -1046,7 +1046,7 @@ function clear() {
  * @returns {Promise}
  */
 function mergeCollection(collectionKey, collection) {
-    if (!_.isObject(collection) || _.isEmpty(collection)) {
+    if (!_.isObject(collection) || _.isArray(collection)) {
         Logger.logInfo('mergeCollection() called with invalid or empty value. Skipping this update.');
         return Promise.resolve();
     }

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -1046,6 +1046,11 @@ function clear() {
  * @returns {Promise}
  */
 function mergeCollection(collectionKey, collection) {
+    if (!_.isObject(collection) || _.isEmpty(collection)) {
+        Logger.logInfo('mergeCollection() called with invalid or empty value. Skipping this update.');
+        return Promise.resolve();
+    }
+
     // Confirm all the collection keys belong to the same parent
     _.each(collection, (_data, dataKey) => {
         if (isKeyMatch(collectionKey, dataKey)) {

--- a/lib/OnyxCache.js
+++ b/lib/OnyxCache.js
@@ -111,6 +111,10 @@ class OnyxCache {
      * @param {Record<string, *>} data - a map of (cache) key - values
      */
     merge(data) {
+        if (!_.isObject(data) || _.isArray(data)) {
+            throw new Error('data passed to cache.merge() must be an Object of onyx key/value pairs');
+        }
+
         // lodash adds a small overhead so we don't use it here
         // eslint-disable-next-line prefer-object-spread, rulesdir/prefer-underscore-method
         this.storageMap = Object.assign({}, fastMerge(this.storageMap, data));

--- a/tests/unit/onyxCacheTest.js
+++ b/tests/unit/onyxCacheTest.js
@@ -348,6 +348,13 @@ describe('Onyx', () => {
                 // Then getAllStorage keys should return updated storage keys
                 expect(cache.getAllKeys()).toEqual(['mockKey', 'mockKey2', 'mockKey3', 'mockKey4']);
             });
+
+            it('Should throw if called with anything that is not an object', () => {
+                expect(() => cache.merge([])).toThrow();
+                expect(() => cache.merge('')).toThrow();
+                expect(() => cache.merge(0)).toThrow();
+                expect(() => cache.merge({})).not.toThrow();
+            });
         });
 
         describe('hasPendingTask', () => {


### PR DESCRIPTION
### Details

~This should hold until we sent this to production -> https://github.com/Expensify/Web-Expensify/pull/35299~

cc @chiragsalian 

### Related Issues

https://github.com/Expensify/App/issues/12109

### Automated Tests

Yes

### Linked PRs

TODO