### PR TITLE
Fix a bug where full state was being passed to a withOnyx selector

### DIFF
--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -523,7 +523,7 @@ function keyChanged(key, data, canUpdateSubscriber) {
             // returned by the selector and only if the selected data has changed.
             if (subscriber.selector) {
                 subscriber.withOnyxInstance.setState((prevState) => {
-                    const previousValue = getSubsetOfData(prevState, subscriber.selector);
+                    const previousValue = getSubsetOfData(prevState[subscriber.statePropertyName], subscriber.selector);
                     const newValue = getSubsetOfData(data, subscriber.selector);
                     if (!deepEqual(previousValue, newValue)) {
                         return {

--- a/tests/unit/subscribeToPropertiesTest.js
+++ b/tests/unit/subscribeToPropertiesTest.js
@@ -98,13 +98,18 @@ describe('Only the specific property changes when using withOnyx() and ', () => 
     });
 
     it('connecting to a single non-collection key with a selector function', () => {
+        const mockedSelector = jest.fn(obj => obj && obj.a);
         const TestComponentWithOnyx = withOnyx({
             propertyA: {
                 key: ONYX_KEYS.TEST_KEY,
-                selector: obj => obj && obj.a,
+                selector: mockedSelector,
             },
         })(ViewWithObject);
-        return runAssertionsWithComponent(TestComponentWithOnyx);
+        return runAssertionsWithComponent(TestComponentWithOnyx)
+            .then(() => {
+                // This checks for a bug where the entire state object was being passed to the selector
+                expect(mockedSelector).not.toHaveBeenCalledWith({ loading: false, propertyA: null });
+            });
     });
 
     /**
@@ -188,7 +193,7 @@ describe('Only the specific property changes when using withOnyx() and ', () => 
      * @param {Object} TestComponentWithOnyx
      * @returns {Promise}
      */
-    const runAllAssertionsForCollectionKey = (TestComponentWithOnyx) => {
+    const runAllAssertionsForCollectionMemberKey = (TestComponentWithOnyx) => {
         let renderedComponent = render(<ErrorBoundary><TestComponentWithOnyx /></ErrorBoundary>);
         return waitForPromisesToResolve()
 
@@ -244,7 +249,7 @@ describe('Only the specific property changes when using withOnyx() and ', () => 
                 selector: 'a',
             },
         })(ViewWithObject);
-        return runAllAssertionsForCollectionKey(TestComponentWithOnyx);
+        return runAllAssertionsForCollectionMemberKey(TestComponentWithOnyx);
     });
 
     it('connecting to a collection member with a selector function', () => {
@@ -254,6 +259,6 @@ describe('Only the specific property changes when using withOnyx() and ', () => 
                 selector: obj => obj && obj.a,
             },
         })(ViewWithObject);
-        return runAllAssertionsForCollectionKey(TestComponentWithOnyx);
+        return runAllAssertionsForCollectionMemberKey(TestComponentWithOnyx);
     });
 });

--- a/tests/unit/subscribeToPropertiesTest.js
+++ b/tests/unit/subscribeToPropertiesTest.js
@@ -16,6 +16,23 @@ Onyx.init({
     registerStorageEventListener: () => {},
 });
 
+class ErrorBoundary extends React.Component {
+    // Error boundaries have to implement this method. It's for providing a fallback UI, but
+    // we don't need that for unit testing, so this is basically a no-op.
+    static getDerivedStateFromError(error) {
+        return {error};
+    }
+
+    componentDidCatch(error, errorInfo) {
+        console.error(error, errorInfo);
+    }
+
+    render() {
+        // eslint-disable-next-line react/prop-types
+        return this.props.children;
+    }
+}
+
 describe('Only the specific property changes when using withOnyx() and ', () => {
     // Cleanup (ie. unmount) all rendered components and clear out Onyx after each test so that each test starts
     // with a clean slate
@@ -30,13 +47,13 @@ describe('Only the specific property changes when using withOnyx() and ', () => 
      * @returns {Promise}
      */
     const runAssertionsWithComponent = (TestComponentWithOnyx) => {
-        let renderedComponent = render(<TestComponentWithOnyx />);
+        let renderedComponent = render(<ErrorBoundary><TestComponentWithOnyx /></ErrorBoundary>);
         return waitForPromisesToResolve()
 
             // When Onyx is updated with an object that has multiple properties
             .then(() => Onyx.merge(ONYX_KEYS.TEST_KEY, {a: 'one', b: 'two'}))
             .then(() => {
-                renderedComponent = render(<TestComponentWithOnyx />);
+                renderedComponent = render(<ErrorBoundary><TestComponentWithOnyx /></ErrorBoundary>);
                 return waitForPromisesToResolve();
             })
 
@@ -48,7 +65,7 @@ describe('Only the specific property changes when using withOnyx() and ', () => 
             // When Onyx is updated with a change to property a
             .then(() => Onyx.merge(ONYX_KEYS.TEST_KEY, {a: 'two'}))
             .then(() => {
-                renderedComponent = render(<TestComponentWithOnyx />);
+                renderedComponent = render(<ErrorBoundary><TestComponentWithOnyx /></ErrorBoundary>);
                 return waitForPromisesToResolve();
             })
 
@@ -60,7 +77,7 @@ describe('Only the specific property changes when using withOnyx() and ', () => 
             // When Onyx is updated with a change to property b
             .then(() => Onyx.merge(ONYX_KEYS.TEST_KEY, {b: 'two'}))
             .then(() => {
-                renderedComponent = render(<TestComponentWithOnyx />);
+                renderedComponent = render(<ErrorBoundary><TestComponentWithOnyx /></ErrorBoundary>);
                 return waitForPromisesToResolve();
             })
 
@@ -84,7 +101,7 @@ describe('Only the specific property changes when using withOnyx() and ', () => 
         const TestComponentWithOnyx = withOnyx({
             propertyA: {
                 key: ONYX_KEYS.TEST_KEY,
-                selector: obj => obj.a,
+                selector: obj => obj && obj.a,
             },
         })(ViewWithObject);
         return runAssertionsWithComponent(TestComponentWithOnyx);
@@ -97,7 +114,7 @@ describe('Only the specific property changes when using withOnyx() and ', () => 
      * @returns {Promise}
      */
     const runAllAssertionsForCollection = (TestComponentWithOnyx) => {
-        let renderedComponent = render(<TestComponentWithOnyx />);
+        let renderedComponent = render(<ErrorBoundary><TestComponentWithOnyx /></ErrorBoundary>);
         return waitForPromisesToResolve()
 
             // When Onyx is updated with an object that has multiple properties
@@ -109,7 +126,7 @@ describe('Only the specific property changes when using withOnyx() and ', () => 
                 return waitForPromisesToResolve();
             })
             .then(() => {
-                renderedComponent = render(<TestComponentWithOnyx />);
+                renderedComponent = render(<ErrorBoundary><TestComponentWithOnyx /></ErrorBoundary>);
                 return waitForPromisesToResolve();
             })
 
@@ -172,7 +189,7 @@ describe('Only the specific property changes when using withOnyx() and ', () => 
      * @returns {Promise}
      */
     const runAllAssertionsForCollectionKey = (TestComponentWithOnyx) => {
-        let renderedComponent = render(<TestComponentWithOnyx />);
+        let renderedComponent = render(<ErrorBoundary><TestComponentWithOnyx /></ErrorBoundary>);
         return waitForPromisesToResolve()
 
             // When Onyx is updated with an object that has multiple properties
@@ -184,7 +201,7 @@ describe('Only the specific property changes when using withOnyx() and ', () => 
                 return waitForPromisesToResolve();
             })
             .then(() => {
-                renderedComponent = render(<TestComponentWithOnyx />);
+                renderedComponent = render(<ErrorBoundary><TestComponentWithOnyx /></ErrorBoundary>);
                 return waitForPromisesToResolve();
             })
 
@@ -234,7 +251,7 @@ describe('Only the specific property changes when using withOnyx() and ', () => 
         const TestComponentWithOnyx = withOnyx({
             itemWithPropertyA: {
                 key: `${ONYX_KEYS.COLLECTION.TEST_KEY}1`,
-                selector: obj => obj.a,
+                selector: obj => obj && obj.a,
             },
         })(ViewWithObject);
         return runAllAssertionsForCollectionKey(TestComponentWithOnyx);


### PR DESCRIPTION
### Details
There was this code that was passing the entire state object to the selector. That's wrong. Instead, it should only be passing the piece of state that the withOnyx mapping is working with.

cc @marcaaron 

### Related Issues
Fixes an issue I found while testing https://github.com/Expensify/App/pull/12083

### Automated Tests
Covered by automated tests
