### PR TITLE
Update Onyx.clear to accept passed in default values

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,6 @@ To quickly test small changes you can directly go to `node_modules/react-native-
 To continuously work on Onyx we have to set up a task that copies content to parent project's `node_modules/react-native-onyx`:
 1. Work on Onyx feature or a fix
 2. Save files
-3. Optional: run `npm build` (if you're working or want to test on a non react-native project)
+3. Optional: run `npm run build` (if you're working or want to test on a non react-native project)
    - `npm link` would actually work outside of `react-native` and it can be used to link Onyx locally for a web only project
 4. Copy Onyx to consumer project's `node_modules/react-native-onyx`

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -1025,13 +1025,18 @@ function initializeWithDefaultKeyStates() {
  * Storage.setItem() from Onyx.clear() will have already finished and the merged
  * value will be saved to storage after the default value.
  *
+ * You may pass in additionalDefaults to set/preserve onyx data that you want to keep
+ * after clearing.
+ *
+ * @param {Object} additionalDefaults additional default values for ONYXKEYS keys
  * @returns {Promise<void>}
  */
-function clear() {
+function clear(additionalDefaults = {}) {
+    const keyStatesToPreserve = fastMerge(defaultKeyStates, additionalDefaults);
     return getAllKeys()
         .then((keys) => {
             _.each(keys, (key) => {
-                const resetValue = lodashGet(defaultKeyStates, key, null);
+                const resetValue = lodashGet(keyStatesToPreserve, key, null);
                 cache.set(key, resetValue);
                 notifySubscribersOnNextTick(key, resetValue);
             });

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -661,7 +661,10 @@ function getCollectionDataAndSendAsObject(matchingKeys, mapping) {
  * @param {Boolean} [mapping.initWithStoredValues] If set to false, then no data will be prefilled into the
  *  component
  * @param {Boolean} [mapping.waitForCollectionCallback] If set to true, it will return the entire collection to the callback as a single object
- * @param {String|Function} [mapping.selector] THIS PARAM IS ONLY USED WITH withOnyx(). If included, this will be used to subscribe to a subset of an Onyx key's data. If the selector is a string, the selector is passed to lodashGet on the sourceData. If the selector is a function, the sourceData is passed to the selector and should return the simplified data. Using this setting on `withOnyx` can have very positive performance benefits because the component will only re-render when the subset of data changes. Otherwise, any change of data on any property would normally cause the component to re-render (and that can be expensive from a performance standpoint).
+ * @param {String|Function} [mapping.selector] THIS PARAM IS ONLY USED WITH withOnyx(). If included, this will be used to subscribe to a subset of an Onyx key's data.
+ *       If the selector is a string, the selector is passed to lodashGet on the sourceData. If the selector is a function, the sourceData is passed to the selector and should return the
+ *       simplified data. Using this setting on `withOnyx` can have very positive performance benefits because the component will only re-render when the subset of data changes.
+ *       Otherwise, any change of data on any property would normally cause the component to re-render (and that can be expensive from a performance standpoint).
  * @returns {Number} an ID to use when calling disconnect
  */
 function connect(mapping) {

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -1025,18 +1025,20 @@ function initializeWithDefaultKeyStates() {
  * Storage.setItem() from Onyx.clear() will have already finished and the merged
  * value will be saved to storage after the default value.
  *
- * You may pass in additionalDefaults to set/preserve onyx data that you want to keep
- * after clearing.
+ * You may pass in keyStatesToPreserve to preserve Onyx keys you don't want to clear.
  *
- * @param {Object} additionalDefaults additional default values for ONYXKEYS keys
+ * @param {Array} keyStatesToPreserve ONYXKEYS values you want to keep
  * @returns {Promise<void>}
  */
-function clear(additionalDefaults = {}) {
-    const keyStatesToPreserve = fastMerge(defaultKeyStates, additionalDefaults);
+function clear(keyStatesToPreserve = []) {
     return getAllKeys()
         .then((keys) => {
             _.each(keys, (key) => {
-                const resetValue = lodashGet(keyStatesToPreserve, key, null);
+                if (_.contains(keyStatesToPreserve, key)) {
+                    return;
+                }
+
+                const resetValue = lodashGet(defaultKeyStates, key, null);
                 cache.set(key, resetValue);
                 notifySubscribersOnNextTick(key, resetValue);
             });

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -1036,16 +1036,19 @@ function initializeWithDefaultKeyStates() {
 function clear(keyStatesToPreserve = []) {
     return getAllKeys()
         .then((keys) => {
+            const keyValuesToPreserve = [];
             _.each(keys, (key) => {
                 if (_.contains(keyStatesToPreserve, key)) {
-                    return;
+                    keyValuesToPreserve.push([key, get(key)]);
+                } else {
+                    const resetValue = lodashGet(defaultKeyStates, key, null);
+                    cache.set(key, resetValue);
+                    notifySubscribersOnNextTick(key, resetValue);
                 }
-
-                const resetValue = lodashGet(defaultKeyStates, key, null);
-                cache.set(key, resetValue);
-                notifySubscribersOnNextTick(key, resetValue);
             });
-            return Storage.clear();
+            return Storage.clear().then(() => {
+                Storage.multiSet(keyValuesToPreserve);
+            });
         });
 }
 

--- a/tests/unit/onyxClearNativeStorageTest.js
+++ b/tests/unit/onyxClearNativeStorageTest.js
@@ -111,13 +111,13 @@ describe('Set data while storage is clearing', () => {
         expect.assertions(6);
 
         // Given that Onyx has a value, and we have a variable listening to that value
-        Onyx.set(ONYX_KEYS.REGULAR_KEY, SET_VALUE);
         let valueToKeep;
         Onyx.connect({
             key: ONYX_KEYS.REGULAR_KEY,
             initWithStoredValues: false,
             callback: val => valueToKeep = val,
         });
+        Onyx.set(ONYX_KEYS.REGULAR_KEY, SET_VALUE);
 
         // When clear is called with a key to preserve
         Onyx.clear([ONYX_KEYS.REGULAR_KEY]);
@@ -132,15 +132,12 @@ describe('Set data while storage is clearing', () => {
                 // Then the value in Storage is null
                 expect(defaultKeyStoredValue).resolves.toBeNull();
 
-                // Then the value of the preserved key is also still set
+                // Then the value of the preserved key is also still set in both the cache and storage
                 expect(valueToKeep).toBe(SET_VALUE);
                 const regularKeyCachedValue = cache.getValue(ONYX_KEYS.REGULAR_KEY);
                 expect(regularKeyCachedValue).toBe(SET_VALUE);
-                const regularKeyStoredValue = Storage.getItem(ONYX_KEYS.REGULAR_KEY);
-
-                // Then the value in Storage is null
-                // A preserved key state, much like any other default key state, is never stored during Onyx.clear
-                return expect(regularKeyStoredValue).resolves.toBeNull();
+                return Storage.getItem(ONYX_KEYS.REGULAR_KEY)
+                    .then(storedValue => expect(parseInt(storedValue, 10)).toBe(SET_VALUE));
             });
     });
 });

--- a/tests/unit/onyxClearNativeStorageTest.js
+++ b/tests/unit/onyxClearNativeStorageTest.js
@@ -121,9 +121,7 @@ describe('Set data while storage is clearing', () => {
         });
 
         // When clear is called with an additional default value
-        Onyx.clear({
-            [ONYX_KEYS.REGULAR_KEY]: ADDITIONAL_DEFAULT_VALUE,
-        });
+        Onyx.clear([ONYX_KEYS.REGULAR_KEY]);
         return waitForPromisesToResolve()
             .then(() => {
                 // Then the value in Onyx and the cache is the default key state
@@ -136,9 +134,9 @@ describe('Set data while storage is clearing', () => {
                 expect(defaultKeyStoredValue).resolves.toBeNull();
 
                 // Then the value we preserved is also still set
-                expect(valueToKeep).toBe(ADDITIONAL_DEFAULT_VALUE);
+                expect(valueToKeep).toBe(SET_VALUE);
                 const regularKeyCachedValue = cache.getValue(ONYX_KEYS.REGULAR_KEY);
-                expect(regularKeyCachedValue).toBe(ADDITIONAL_DEFAULT_VALUE);
+                expect(regularKeyCachedValue).toBe(SET_VALUE);
                 const regularKeyStoredValue = Storage.getItem(ONYX_KEYS.REGULAR_KEY);
 
                 // Then the value in Storage is null

--- a/tests/unit/onyxClearNativeStorageTest.js
+++ b/tests/unit/onyxClearNativeStorageTest.js
@@ -139,7 +139,7 @@ describe('Set data while storage is clearing', () => {
                 expect(valueToKeep).toBe(ADDITIONAL_DEFAULT_VALUE);
                 const regularKeyCachedValue = cache.getValue(ONYX_KEYS.REGULAR_KEY);
                 expect(regularKeyCachedValue).toBe(ADDITIONAL_DEFAULT_VALUE);
-                const regularKeyStoredValue = Storage.getItem(ONYX_KEYS.DEFAULT_KEY);
+                const regularKeyStoredValue = Storage.getItem(ONYX_KEYS.REGULAR_KEY);
 
                 // Then the value in Storage is null
                 // An additional passed in default, much like any other default key state, is never stored during Onyx.clear

--- a/tests/unit/onyxClearNativeStorageTest.js
+++ b/tests/unit/onyxClearNativeStorageTest.js
@@ -8,7 +8,6 @@ const ONYX_KEYS = {
 };
 
 // Store integers because the async storage mock adds escape characters to strings
-const ADDITIONAL_DEFAULT_VALUE = 3;
 const SET_VALUE = 2;
 const MERGED_VALUE = 1;
 const DEFAULT_VALUE = 0;
@@ -108,10 +107,10 @@ describe('Set data while storage is clearing', () => {
             });
     });
 
-    it('should preserve the value of any additional defaults passed in', () => {
+    it('should preserve the value of any keyStatesToPreserve passed in', () => {
         expect.assertions(6);
 
-        // Given that Onyx has a value and we have a variable listening to that value
+        // Given that Onyx has a value, and we have a variable listening to that value
         Onyx.set(ONYX_KEYS.REGULAR_KEY, SET_VALUE);
         let valueToKeep;
         Onyx.connect({
@@ -120,11 +119,11 @@ describe('Set data while storage is clearing', () => {
             callback: val => valueToKeep = val,
         });
 
-        // When clear is called with an additional default value
+        // When clear is called with a key to preserve
         Onyx.clear([ONYX_KEYS.REGULAR_KEY]);
         return waitForPromisesToResolve()
             .then(() => {
-                // Then the value in Onyx and the cache is the default key state
+                // Then the value in Onyx and the cache for the default key is the default key state
                 expect(onyxValue).toBe(DEFAULT_VALUE);
                 const defaultKeyCachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
                 expect(defaultKeyCachedValue).toBe(DEFAULT_VALUE);
@@ -133,14 +132,14 @@ describe('Set data while storage is clearing', () => {
                 // Then the value in Storage is null
                 expect(defaultKeyStoredValue).resolves.toBeNull();
 
-                // Then the value we preserved is also still set
+                // Then the value of the preserved key is also still set
                 expect(valueToKeep).toBe(SET_VALUE);
                 const regularKeyCachedValue = cache.getValue(ONYX_KEYS.REGULAR_KEY);
                 expect(regularKeyCachedValue).toBe(SET_VALUE);
                 const regularKeyStoredValue = Storage.getItem(ONYX_KEYS.REGULAR_KEY);
 
                 // Then the value in Storage is null
-                // An additional passed in default, much like any other default key state, is never stored during Onyx.clear
+                // A preserved key state, much like any other default key state, is never stored during Onyx.clear
                 return expect(regularKeyStoredValue).resolves.toBeNull();
             });
     });

--- a/tests/unit/onyxClearWebStorageTest.js
+++ b/tests/unit/onyxClearWebStorageTest.js
@@ -123,9 +123,7 @@ describe('Set data while storage is clearing', () => {
         });
 
         // When clear is called with an additional default value
-        Onyx.clear({
-            [ONYX_KEYS.REGULAR_KEY]: ADDITIONAL_DEFAULT_VALUE,
-        });
+        Onyx.clear([ONYX_KEYS.REGULAR_KEY]);
         return waitForPromisesToResolve()
             .then(() => {
                 // Then the value in Onyx and the cache is the default key state
@@ -139,9 +137,9 @@ describe('Set data while storage is clearing', () => {
                 expect(storedValue).resolves.toBeNull();
 
                 // Then the value we preserved is also still set
-                expect(valueToKeep).toBe(ADDITIONAL_DEFAULT_VALUE);
+                expect(valueToKeep).toBe(SET_VALUE);
                 const regularKeyCachedValue = cache.getValue(ONYX_KEYS.REGULAR_KEY);
-                expect(regularKeyCachedValue).toBe(ADDITIONAL_DEFAULT_VALUE);
+                expect(regularKeyCachedValue).toBe(SET_VALUE);
                 const regularKeyStoredValue = Storage.getItem(ONYX_KEYS.REGULAR_KEY);
 
                 // Then the value in Storage is null

--- a/tests/unit/onyxClearWebStorageTest.js
+++ b/tests/unit/onyxClearWebStorageTest.js
@@ -113,13 +113,13 @@ describe('Set data while storage is clearing', () => {
         expect.assertions(6);
 
         // Given that Onyx has a value, and we have a variable listening to that value
-        Onyx.set(ONYX_KEYS.REGULAR_KEY, SET_VALUE);
         let valueToKeep;
         Onyx.connect({
             key: ONYX_KEYS.REGULAR_KEY,
             initWithStoredValues: false,
             callback: val => valueToKeep = val,
         });
+        Onyx.set(ONYX_KEYS.REGULAR_KEY, SET_VALUE);
 
         // When clear is called with a key to preserve
         Onyx.clear([ONYX_KEYS.REGULAR_KEY]);
@@ -135,15 +135,12 @@ describe('Set data while storage is clearing', () => {
                 // The default key state is never stored during Onyx.clear
                 expect(storedValue).resolves.toBeNull();
 
-                // Then the value of the preserved key is also still set
+                // Then the value of the preserved key is also still set in both the cache and storage
                 expect(valueToKeep).toBe(SET_VALUE);
                 const regularKeyCachedValue = cache.getValue(ONYX_KEYS.REGULAR_KEY);
                 expect(regularKeyCachedValue).toBe(SET_VALUE);
                 const regularKeyStoredValue = Storage.getItem(ONYX_KEYS.REGULAR_KEY);
-
-                // Then the value in Storage is null
-                // A preserved key state, much like any other default key state, is never stored during Onyx.clear
-                return expect(regularKeyStoredValue).resolves.toBeUndefined();
+                return expect(regularKeyStoredValue).resolves.toBe(SET_VALUE);
             });
     });
 });

--- a/tests/unit/onyxClearWebStorageTest.js
+++ b/tests/unit/onyxClearWebStorageTest.js
@@ -142,7 +142,7 @@ describe('Set data while storage is clearing', () => {
                 expect(valueToKeep).toBe(ADDITIONAL_DEFAULT_VALUE);
                 const regularKeyCachedValue = cache.getValue(ONYX_KEYS.REGULAR_KEY);
                 expect(regularKeyCachedValue).toBe(ADDITIONAL_DEFAULT_VALUE);
-                const regularKeyStoredValue = Storage.getItem(ONYX_KEYS.DEFAULT_KEY);
+                const regularKeyStoredValue = Storage.getItem(ONYX_KEYS.REGULAR_KEY);
 
                 // Then the value in Storage is null
                 // An additional passed in default, much like any other default key state, is never stored during Onyx.clear

--- a/tests/unit/onyxClearWebStorageTest.js
+++ b/tests/unit/onyxClearWebStorageTest.js
@@ -5,7 +5,6 @@ const ONYX_KEYS = {
     DEFAULT_KEY: 'defaultKey',
     REGULAR_KEY: 'regularKey',
 };
-const ADDITIONAL_DEFAULT_VALUE = 'additionalDefaultValue';
 const SET_VALUE = 'set';
 const MERGED_VALUE = 'merged';
 const DEFAULT_VALUE = 'default';
@@ -110,10 +109,10 @@ describe('Set data while storage is clearing', () => {
             });
     });
 
-    it('should preserve the value of any additional defaults passed in', () => {
+    it('should preserve the value of any keyStatesToPreserve passed in', () => {
         expect.assertions(6);
 
-        // Given that Onyx has a value and we have a variable listening to that value
+        // Given that Onyx has a value, and we have a variable listening to that value
         Onyx.set(ONYX_KEYS.REGULAR_KEY, SET_VALUE);
         let valueToKeep;
         Onyx.connect({
@@ -122,11 +121,11 @@ describe('Set data while storage is clearing', () => {
             callback: val => valueToKeep = val,
         });
 
-        // When clear is called with an additional default value
+        // When clear is called with a key to preserve
         Onyx.clear([ONYX_KEYS.REGULAR_KEY]);
         return waitForPromisesToResolve()
             .then(() => {
-                // Then the value in Onyx and the cache is the default key state
+                // Then the value in Onyx and the cache for the default key is the default key state
                 expect(onyxValue).toBe(DEFAULT_VALUE);
                 const cachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
                 expect(cachedValue).toBe(DEFAULT_VALUE);
@@ -136,14 +135,14 @@ describe('Set data while storage is clearing', () => {
                 // The default key state is never stored during Onyx.clear
                 expect(storedValue).resolves.toBeNull();
 
-                // Then the value we preserved is also still set
+                // Then the value of the preserved key is also still set
                 expect(valueToKeep).toBe(SET_VALUE);
                 const regularKeyCachedValue = cache.getValue(ONYX_KEYS.REGULAR_KEY);
                 expect(regularKeyCachedValue).toBe(SET_VALUE);
                 const regularKeyStoredValue = Storage.getItem(ONYX_KEYS.REGULAR_KEY);
 
                 // Then the value in Storage is null
-                // An additional passed in default, much like any other default key state, is never stored during Onyx.clear
+                // A preserved key state, much like any other default key state, is never stored during Onyx.clear
                 return expect(regularKeyStoredValue).resolves.toBeUndefined();
             });
     });


### PR DESCRIPTION
@neil-marcellini please review

### Details
Add an `additionalDefaults` param to `clear` to allow it to accept passed in default values

### Related Issues
https://github.com/Expensify/App/issues/13062

### Automated Tests
Added tests in [onyxClearWebStorageTest.js](https://github.com/Expensify/react-native-onyx/blob/317a6172b9c12ad435636af7c1e96e9387858d01/tests/unit/onyxClearWebStorageTest.js#L113-L151) and [onyxClearNativeStorageTest.js](https://github.com/Expensify/react-native-onyx/blob/317a6172b9c12ad435636af7c1e96e9387858d01/tests/unit/onyxClearNativeStorageTest.js#L111-L148)

### Linked PRs
https://github.com/Expensify/App/pull/13384