### PR TITLE
Update Onyx.clear to accept passed in keys to preserve, and use multiSet to clear storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,6 @@ To quickly test small changes you can directly go to `node_modules/react-native-
 To continuously work on Onyx we have to set up a task that copies content to parent project's `node_modules/react-native-onyx`:
 1. Work on Onyx feature or a fix
 2. Save files
-3. Optional: run `npm build` (if you're working or want to test on a non react-native project)
+3. Optional: run `npm run build` (if you're working or want to test on a non react-native project)
    - `npm link` would actually work outside of `react-native` and it can be used to link Onyx locally for a web only project
 4. Copy Onyx to consumer project's `node_modules/react-native-onyx`

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -1036,7 +1036,8 @@ function clear(keysToPreserve = []) {
         .then((keys) => {
             const defaultKeys = _.keys(defaultKeyStates);
 
-            // We're clearing out (setting to null) all keys aren't being preserved or have defaults
+            // The only keys that should be cleared are ones that aren't default keys (because they need to remain in Onyx as their default state, and setting them to null would cause unknown behavior) 
+            // or anything specifically passed in keysToPreserve (because some keys like language preferences, offline status, or activeClients need to remain in Onyx even when signed out)
             const keysToClear = _.difference(keys, keysToPreserve, defaultKeys);
             const keyValuesToClear = _.map(keysToClear, key => [key, null]);
 

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -1028,21 +1028,31 @@ function initializeWithDefaultKeyStates() {
  * Storage.setItem() from Onyx.clear() will have already finished and the merged
  * value will be saved to storage after the default value.
  *
- * @param {Array} keysToPreserve ONYXKEYS which values you want to keep
+ * @param {Array} keysToPreserve is a list of ONYXKEYS that should not be cleared with the rest of the data
  * @returns {Promise<void>}
  */
 function clear(keysToPreserve = []) {
     return getAllKeys()
         .then((keys) => {
             const defaultKeys = _.keys(defaultKeyStates);
+
+            // We're clearing out (setting to null) all keys aren't being preserved or have defaults
             const keysToClear = _.without(keys, ..._.union(keysToPreserve, defaultKeys));
             const keyValuesToClear = _.map(keysToClear, key => [key, null]);
+
+            // If keysToPreserve contains a key that also has a default key state, we'll preserve it rather than reset
+            // it to the default.
             const defaultKeyValues = _.pairs(_.omit(defaultKeyStates, ...keysToPreserve));
+
+            // Combine the pairs of keys we're clearing and keys we're setting back to default for our multiSet call
             const newStoreKeyValues = _.union(keyValuesToClear, defaultKeyValues);
+
+            // Make sure that we also reset the cache values after clearing the values from storage.
             _.each(newStoreKeyValues, (keyValue) => {
                 cache.set(keyValue[0], keyValue[1]);
                 notifySubscribersOnNextTick(keyValue[0], keyValue[1]);
             });
+
             return Storage.multiSet(newStoreKeyValues);
         });
 }

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -1025,13 +1025,18 @@ function initializeWithDefaultKeyStates() {
  * Storage.setItem() from Onyx.clear() will have already finished and the merged
  * value will be saved to storage after the default value.
  *
+ * You may pass in additionalDefaults to set/preserve onyx data that you want to keep
+ * after clearing.
+ *
+ * @param {Object} additionalDefaults additional default values for ONYXKEYS keys
  * @returns {Promise<void>}
  */
-function clear() {
+function clear(additionalDefaults = {}) {
+    const keyStatesToPreserve = fastMerge(defaultKeyStates, additionalDefaults);
     return getAllKeys()
         .then((keys) => {
             _.each(keys, (key) => {
-                const resetValue = lodashGet(defaultKeyStates, key, null);
+                const resetValue = lodashGet(keyStatesToPreserve, key, null);
                 cache.set(key, resetValue);
                 notifySubscribersOnNextTick(key, resetValue);
             });

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -661,7 +661,10 @@ function getCollectionDataAndSendAsObject(matchingKeys, mapping) {
  * @param {Boolean} [mapping.initWithStoredValues] If set to false, then no data will be prefilled into the
  *  component
  * @param {Boolean} [mapping.waitForCollectionCallback] If set to true, it will return the entire collection to the callback as a single object
- * @param {String|Function} [mapping.selector] THIS PARAM IS ONLY USED WITH withOnyx(). If included, this will be used to subscribe to a subset of an Onyx key's data. If the selector is a string, the selector is passed to lodashGet on the sourceData. If the selector is a function, the sourceData is passed to the selector and should return the simplified data. Using this setting on `withOnyx` can have very positive performance benefits because the component will only re-render when the subset of data changes. Otherwise, any change of data on any property would normally cause the component to re-render (and that can be expensive from a performance standpoint).
+ * @param {String|Function} [mapping.selector] THIS PARAM IS ONLY USED WITH withOnyx(). If included, this will be used to subscribe to a subset of an Onyx key's data.
+ *       If the selector is a string, the selector is passed to lodashGet on the sourceData. If the selector is a function, the sourceData is passed to the selector and should return the
+ *       simplified data. Using this setting on `withOnyx` can have very positive performance benefits because the component will only re-render when the subset of data changes.
+ *       Otherwise, any change of data on any property would normally cause the component to re-render (and that can be expensive from a performance standpoint).
  * @returns {Number} an ID to use when calling disconnect
  */
 function connect(mapping) {

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -1039,7 +1039,7 @@ function clear(keysToPreserve = []) {
             const defaultKeys = _.keys(defaultKeyStates);
             const keysToClear = _.without(keys, ..._.union(keysToPreserve, defaultKeys));
             const keyValuesToClear = _.map(keysToClear, key => [key, null]);
-            const defaultKeyValues = _.pairs(defaultKeyStates);
+            const defaultKeyValues = _.pairs(_.omit(defaultKeyStates, ...keysToPreserve));
             const newStoreKeyValues = _.union(keyValuesToClear, defaultKeyValues);
             _.each(newStoreKeyValues, (keyValue) => {
                 cache.set(keyValue[0], keyValue[1]);

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -1028,7 +1028,6 @@ function initializeWithDefaultKeyStates() {
  * Storage.setItem() from Onyx.clear() will have already finished and the merged
  * value will be saved to storage after the default value.
  *
- * You may pass in keysToPreserve to preserve Onyx keys you don't want to clear.
  *
  * @param {Array} keysToPreserve ONYXKEYS which values you want to keep
  * @returns {Promise<void>}

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -1028,9 +1028,9 @@ function initializeWithDefaultKeyStates() {
  * Storage.setItem() from Onyx.clear() will have already finished and the merged
  * value will be saved to storage after the default value.
  *
- * You may pass in keyStatesToPreserve to preserve Onyx keys you don't want to clear.
+ * You may pass in keysToPreserve to preserve Onyx keys you don't want to clear.
  *
- * @param {Array} keyStatesToPreserve ONYXKEYS values you want to keep
+ * @param {Array} keysToPreserve ONYXKEYS which values you want to keep
  * @returns {Promise<void>}
  */
 function clear(keysToPreserve = []) {

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -1034,31 +1034,31 @@ function initializeWithDefaultKeyStates() {
 function clear(keysToPreserve = []) {
     return getAllKeys()
         .then((keys) => {
-            const keyValuesToClear = [];
+            const keyValuesToReset = [];
             const defaultKeys = _.keys(defaultKeyStates);
 
             // The only keys that should not be cleared are:
             // 1. Anything specifically passed in keysToPreserve (because some keys like language preferences, offline status, or activeClients need to remain in Onyx even when signed out)
             // 2. Any keys with a default state (because they need to remain in Onyx as their default, and setting them to null would cause unknown behavior)
             const keysToClear = _.difference(keys, keysToPreserve, defaultKeys);
-            keyValuesToClear.push(..._.map(keysToClear, key => [key, null]));
+            keyValuesToReset.push(..._.map(keysToClear, key => [key, null]));
 
             // Remove any keysToPreserve from the defaultKeyStates because if they are passed in it has been explicitly called out to preserve those values instead of resetting them back
             // to the default.
             const defaultKeyValuePairs = _.pairs(_.omit(defaultKeyStates, ...keysToPreserve));
 
-            // Add the default key value pairs to the keyValuesToClear so that they get set back to their default values when we clear Onyx
-            keyValuesToClear.push(...defaultKeyValuePairs);
+            // Add the default key value pairs to the keyValuesToReset so that they get set back to their default values when we clear Onyx
+            keyValuesToReset.push(...defaultKeyValuePairs);
 
-            // Make sure that we also reset the cache values after clearing the values from storage.
+            // Make sure that we also reset the cache values before clearing the values from storage.
             // We do this before clearing Storage so that any call to clear() followed by merge() on a key with a default state results in the merged value getting saved, since the update
             // from the merge() call would happen on the tick after the update from this clear()
-            _.each(keyValuesToClear, (keyValue) => {
+            _.each(keyValuesToReset, (keyValue) => {
                 cache.set(keyValue[0], keyValue[1]);
                 notifySubscribersOnNextTick(keyValue[0], keyValue[1]);
             });
 
-            return Storage.multiSet(keyValuesToClear);
+            return Storage.multiSet(keyValuesToReset);
         });
 }
 

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -1025,18 +1025,20 @@ function initializeWithDefaultKeyStates() {
  * Storage.setItem() from Onyx.clear() will have already finished and the merged
  * value will be saved to storage after the default value.
  *
- * You may pass in additionalDefaults to set/preserve onyx data that you want to keep
- * after clearing.
+ * You may pass in keyStatesToPreserve to preserve Onyx keys you don't want to clear.
  *
- * @param {Object} additionalDefaults additional default values for ONYXKEYS keys
+ * @param {Array} keyStatesToPreserve ONYXKEYS values you want to keep
  * @returns {Promise<void>}
  */
-function clear(additionalDefaults = {}) {
-    const keyStatesToPreserve = fastMerge(defaultKeyStates, additionalDefaults);
+function clear(keyStatesToPreserve = []) {
     return getAllKeys()
         .then((keys) => {
             _.each(keys, (key) => {
-                const resetValue = lodashGet(keyStatesToPreserve, key, null);
+                if (_.contains(keyStatesToPreserve, key)) {
+                    return;
+                }
+
+                const resetValue = lodashGet(defaultKeyStates, key, null);
                 cache.set(key, resetValue);
                 notifySubscribersOnNextTick(key, resetValue);
             });

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -1033,22 +1033,19 @@ function initializeWithDefaultKeyStates() {
  * @param {Array} keyStatesToPreserve ONYXKEYS values you want to keep
  * @returns {Promise<void>}
  */
-function clear(keyStatesToPreserve = []) {
+function clear(keysToPreserve = []) {
     return getAllKeys()
         .then((keys) => {
-            const keyValuesToPreserve = [];
-            _.each(keys, (key) => {
-                if (_.contains(keyStatesToPreserve, key)) {
-                    keyValuesToPreserve.push([key, get(key)]);
-                } else {
-                    const resetValue = lodashGet(defaultKeyStates, key, null);
-                    cache.set(key, resetValue);
-                    notifySubscribersOnNextTick(key, resetValue);
-                }
+            const defaultKeys = _.keys(defaultKeyStates);
+            const keysToClear = _.without(keys, ..._.union(keysToPreserve, defaultKeys));
+            const keyValuesToClear = _.map(keysToClear, key => [key, null]);
+            const defaultKeyValues = _.pairs(defaultKeyStates);
+            const newStoreKeyValues = _.union(keyValuesToClear, defaultKeyValues);
+            _.each(newStoreKeyValues, (keyValue) => {
+                cache.set(keyValue[0], keyValue[1]);
+                notifySubscribersOnNextTick(keyValue[0], keyValue[1]);
             });
-            return Storage.clear().then(() => {
-                Storage.multiSet(keyValuesToPreserve);
-            });
+            return Storage.multiSet(newStoreKeyValues);
         });
 }
 

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -1028,7 +1028,6 @@ function initializeWithDefaultKeyStates() {
  * Storage.setItem() from Onyx.clear() will have already finished and the merged
  * value will be saved to storage after the default value.
  *
- *
  * @param {Array} keysToPreserve ONYXKEYS which values you want to keep
  * @returns {Promise<void>}
  */

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -1036,16 +1036,19 @@ function initializeWithDefaultKeyStates() {
 function clear(keyStatesToPreserve = []) {
     return getAllKeys()
         .then((keys) => {
+            const keyValuesToPreserve = [];
             _.each(keys, (key) => {
                 if (_.contains(keyStatesToPreserve, key)) {
-                    return;
+                    keyValuesToPreserve.push([key, get(key)]);
+                } else {
+                    const resetValue = lodashGet(defaultKeyStates, key, null);
+                    cache.set(key, resetValue);
+                    notifySubscribersOnNextTick(key, resetValue);
                 }
-
-                const resetValue = lodashGet(defaultKeyStates, key, null);
-                cache.set(key, resetValue);
-                notifySubscribersOnNextTick(key, resetValue);
             });
-            return Storage.clear();
+            return Storage.clear().then(() => {
+                Storage.multiSet(keyValuesToPreserve);
+            });
         });
 }
 

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -1037,7 +1037,7 @@ function clear(keysToPreserve = []) {
             const keyValuesToClear = [];
             const defaultKeys = _.keys(defaultKeyStates);
 
-            // The only keys that should be cleared are:
+            // The only keys that should not be cleared are:
             // 1. Anything specifically passed in keysToPreserve (because some keys like language preferences, offline status, or activeClients need to remain in Onyx even when signed out)
             // 2. Any keys with a default state (because they need to remain in Onyx as their default, and setting them to null would cause unknown behavior)
             const keysToClear = _.difference(keys, keysToPreserve, defaultKeys);

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -1034,27 +1034,31 @@ function initializeWithDefaultKeyStates() {
 function clear(keysToPreserve = []) {
     return getAllKeys()
         .then((keys) => {
+            const keyValuesToClear = [];
             const defaultKeys = _.keys(defaultKeyStates);
 
-            // The only keys that should be cleared are ones that aren't default keys (because they need to remain in Onyx as their default state, and setting them to null would cause unknown behavior) 
-            // or anything specifically passed in keysToPreserve (because some keys like language preferences, offline status, or activeClients need to remain in Onyx even when signed out)
+            // The only keys that should be cleared are:
+            // 1. Anything specifically passed in keysToPreserve (because some keys like language preferences, offline status, or activeClients need to remain in Onyx even when signed out)
+            // 2. Any keys with a default state (because they need to remain in Onyx as their default, and setting them to null would cause unknown behavior)
             const keysToClear = _.difference(keys, keysToPreserve, defaultKeys);
-            const keyValuesToClear = _.map(keysToClear, key => [key, null]);
+            keyValuesToClear.push(..._.map(keysToClear, key => [key, null]));
 
-            // If keysToPreserve contains a key that also has a default key state, we'll preserve it rather than reset
-            // it to the default.
-            const defaultKeyValues = _.pairs(_.omit(defaultKeyStates, ...keysToPreserve));
+            // Remove any keysToPreserve from the defaultKeyStates because if they are passed in it has been explicitly called out to preserve those values instead of resetting them back
+            // to the default.
+            const defaultKeyValuePairs = _.pairs(_.omit(defaultKeyStates, ...keysToPreserve));
 
-            // Combine the pairs of keys we're clearing and keys we're setting back to default for our multiSet call
-            const newStoreKeyValues = _.union(keyValuesToClear, defaultKeyValues);
+            // Add the default key value pairs to the keyValuesToClear so that they get set back to their default values when we clear Onyx
+            keyValuesToClear.push(...defaultKeyValuePairs);
 
             // Make sure that we also reset the cache values after clearing the values from storage.
-            _.each(newStoreKeyValues, (keyValue) => {
+            // We do this before clearing Storage so that any call to clear() followed by merge() on a key with a default state results in the merged value getting saved, since the update
+            // from the merge() call would happen on the tick after the update from this clear()
+            _.each(keyValuesToClear, (keyValue) => {
                 cache.set(keyValue[0], keyValue[1]);
                 notifySubscribersOnNextTick(keyValue[0], keyValue[1]);
             });
 
-            return Storage.multiSet(newStoreKeyValues);
+            return Storage.multiSet(keyValuesToClear);
         });
 }
 

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -1037,7 +1037,7 @@ function clear(keysToPreserve = []) {
             const defaultKeys = _.keys(defaultKeyStates);
 
             // We're clearing out (setting to null) all keys aren't being preserved or have defaults
-            const keysToClear = _.without(keys, ..._.union(keysToPreserve, defaultKeys));
+            const keysToClear = _.difference(keys, keysToPreserve, defaultKeys);
             const keyValuesToClear = _.map(keysToClear, key => [key, null]);
 
             // If keysToPreserve contains a key that also has a default key state, we'll preserve it rather than reset

--- a/tests/unit/onyxClearNativeStorageTest.js
+++ b/tests/unit/onyxClearNativeStorageTest.js
@@ -102,32 +102,24 @@ describe('Set data while storage is clearing', () => {
     });
 
     it('should preserve the value of any keysToPreserve passed in', () => {
-        expect.assertions(6);
+        expect.assertions(3);
 
         // Given that Onyx has a value, and we have a variable listening to that value
-        let valueToKeep;
+        let regularKeyOnyxValue;
         Onyx.connect({
             key: ONYX_KEYS.REGULAR_KEY,
             initWithStoredValues: false,
-            callback: val => valueToKeep = val,
+            callback: val => regularKeyOnyxValue = val,
         });
-        Onyx.set(ONYX_KEYS.REGULAR_KEY, SET_VALUE);
+        Onyx.set(ONYX_KEYS.REGULAR_KEY, SET_VALUE).then(() => {
+            // When clear is called with a key to preserve
+            Onyx.clear([ONYX_KEYS.REGULAR_KEY]);
+        });
 
-        // When clear is called with a key to preserve
-        Onyx.clear([ONYX_KEYS.REGULAR_KEY]);
         return waitForPromisesToResolve()
             .then(() => {
-                // Then the value in Onyx and the cache for the default key is the default key state
-                expect(onyxValue).toBe(DEFAULT_VALUE);
-                const defaultKeyCachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
-                expect(defaultKeyCachedValue).toBe(DEFAULT_VALUE);
-                const defaultKeyStoredValue = Storage.getItem(ONYX_KEYS.DEFAULT_KEY);
-
-                // Then the value in Storage is null
-                expect(defaultKeyStoredValue).resolves.toBeNull();
-
                 // Then the value of the preserved key is also still set in both the cache and storage
-                expect(valueToKeep).toBe(SET_VALUE);
+                expect(regularKeyOnyxValue).toBe(SET_VALUE);
                 const regularKeyCachedValue = cache.getValue(ONYX_KEYS.REGULAR_KEY);
                 expect(regularKeyCachedValue).toBe(SET_VALUE);
                 return Storage.getItem(ONYX_KEYS.REGULAR_KEY)
@@ -139,18 +131,14 @@ describe('Set data while storage is clearing', () => {
         expect.assertions(3);
 
         // Given that Onyx has a value for a key with a default, and we have a variable listening to that value
-        Onyx.connect({
-            key: ONYX_KEYS.DEFAULT_KEY,
-            initWithStoredValues: false,
-            callback: val => onyxValue = val,
+        Onyx.set(ONYX_KEYS.DEFAULT_KEY, SET_VALUE).then(() => {
+            // When clear is called with the default key to preserve
+            Onyx.clear([ONYX_KEYS.DEFAULT_KEY]);
         });
-        Onyx.set(ONYX_KEYS.DEFAULT_KEY, SET_VALUE);
 
-        // When clear is called with the default key to preserve
-        Onyx.clear([ONYX_KEYS.DEFAULT_KEY]);
         return waitForPromisesToResolve()
             .then(() => {
-                // Then the value in Onyx, the cache, and Storage is the default key state
+                // Then the value in Onyx, the cache, and Storage is the set value
                 expect(onyxValue).toBe(SET_VALUE);
                 const cachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
                 expect(cachedValue).toBe(SET_VALUE);

--- a/tests/unit/onyxClearNativeStorageTest.js
+++ b/tests/unit/onyxClearNativeStorageTest.js
@@ -111,13 +111,13 @@ describe('Set data while storage is clearing', () => {
         expect.assertions(6);
 
         // Given that Onyx has a value, and we have a variable listening to that value
-        Onyx.set(ONYX_KEYS.REGULAR_KEY, SET_VALUE);
         let valueToKeep;
         Onyx.connect({
             key: ONYX_KEYS.REGULAR_KEY,
             initWithStoredValues: false,
             callback: val => valueToKeep = val,
         });
+        Onyx.set(ONYX_KEYS.REGULAR_KEY, SET_VALUE);
 
         // When clear is called with a key to preserve
         Onyx.clear([ONYX_KEYS.REGULAR_KEY]);
@@ -132,15 +132,12 @@ describe('Set data while storage is clearing', () => {
                 // Then the value in Storage is null
                 expect(defaultKeyStoredValue).resolves.toBeNull();
 
-                // Then the value of the preserved key is also still set
+                // Then the value of the preserved key is also still set in both the cache and storage
                 expect(valueToKeep).toBe(SET_VALUE);
                 const regularKeyCachedValue = cache.getValue(ONYX_KEYS.REGULAR_KEY);
                 expect(regularKeyCachedValue).toBe(SET_VALUE);
-                const regularKeyStoredValue = Storage.getItem(ONYX_KEYS.REGULAR_KEY);
-
-                // Then the value in Storage is null
-                // A preserved key state, much like any other default key state, is never stored during Onyx.clear
-                return expect(regularKeyStoredValue).resolves.toBeNull();
+                return Storage.getItem(ONYX_KEYS.REGULAR_KEY)
+                    .then(storedValue => expect(parseInt(storedValue, 10)).toBe(SET_VALUE));
             });
     });
 });

--- a/tests/unit/onyxClearNativeStorageTest.js
+++ b/tests/unit/onyxClearNativeStorageTest.js
@@ -78,8 +78,8 @@ describe('Set data while storage is clearing', () => {
                 expect(onyxValue).toBe(DEFAULT_VALUE);
                 const cachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
                 expect(cachedValue).toBe(DEFAULT_VALUE);
-                const storedValue = Storage.getItem(ONYX_KEYS.DEFAULT_KEY);
-                return expect(storedValue).resolves.toBe(DEFAULT_VALUE);
+                return Storage.getItem(ONYX_KEYS.DEFAULT_KEY)
+                    .then(storedValue => expect(parseInt(storedValue, 10)).toBe(DEFAULT_VALUE));
             });
     });
 
@@ -96,8 +96,8 @@ describe('Set data while storage is clearing', () => {
                 expect(onyxValue).toBe(DEFAULT_VALUE);
                 const cachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
                 expect(cachedValue).toBe(DEFAULT_VALUE);
-                const storedValue = Storage.getItem(ONYX_KEYS.DEFAULT_KEY);
-                return expect(storedValue).resolves.toBe(DEFAULT_VALUE);
+                return Storage.getItem(ONYX_KEYS.DEFAULT_KEY)
+                    .then(storedValue => expect(parseInt(storedValue, 10)).toBe(DEFAULT_VALUE));
             });
     });
 

--- a/tests/unit/onyxClearNativeStorageTest.js
+++ b/tests/unit/onyxClearNativeStorageTest.js
@@ -121,9 +121,7 @@ describe('Set data while storage is clearing', () => {
         });
 
         // When clear is called with an additional default value
-        Onyx.clear({
-            [ONYX_KEYS.REGULAR_KEY]: ADDITIONAL_DEFAULT_VALUE,
-        });
+        Onyx.clear([ONYX_KEYS.REGULAR_KEY]);
         return waitForPromisesToResolve()
             .then(() => {
                 // Then the value in Onyx and the cache is the default key state
@@ -136,9 +134,9 @@ describe('Set data while storage is clearing', () => {
                 expect(defaultKeyStoredValue).resolves.toBeNull();
 
                 // Then the value we preserved is also still set
-                expect(valueToKeep).toBe(ADDITIONAL_DEFAULT_VALUE);
+                expect(valueToKeep).toBe(SET_VALUE);
                 const regularKeyCachedValue = cache.getValue(ONYX_KEYS.REGULAR_KEY);
-                expect(regularKeyCachedValue).toBe(ADDITIONAL_DEFAULT_VALUE);
+                expect(regularKeyCachedValue).toBe(SET_VALUE);
                 const regularKeyStoredValue = Storage.getItem(ONYX_KEYS.REGULAR_KEY);
 
                 // Then the value in Storage is null

--- a/tests/unit/onyxClearNativeStorageTest.js
+++ b/tests/unit/onyxClearNativeStorageTest.js
@@ -139,7 +139,7 @@ describe('Set data while storage is clearing', () => {
                 expect(valueToKeep).toBe(ADDITIONAL_DEFAULT_VALUE);
                 const regularKeyCachedValue = cache.getValue(ONYX_KEYS.REGULAR_KEY);
                 expect(regularKeyCachedValue).toBe(ADDITIONAL_DEFAULT_VALUE);
-                const regularKeyStoredValue = Storage.getItem(ONYX_KEYS.DEFAULT_KEY);
+                const regularKeyStoredValue = Storage.getItem(ONYX_KEYS.REGULAR_KEY);
 
                 // Then the value in Storage is null
                 // An additional passed in default, much like any other default key state, is never stored during Onyx.clear

--- a/tests/unit/onyxClearNativeStorageTest.js
+++ b/tests/unit/onyxClearNativeStorageTest.js
@@ -101,7 +101,7 @@ describe('Set data while storage is clearing', () => {
             });
     });
 
-    it('should preserve the value of any keyStatesToPreserve passed in', () => {
+    it('should preserve the value of any keysToPreserve passed in', () => {
         expect.assertions(6);
 
         // Given that Onyx has a value, and we have a variable listening to that value
@@ -131,6 +131,30 @@ describe('Set data while storage is clearing', () => {
                 const regularKeyCachedValue = cache.getValue(ONYX_KEYS.REGULAR_KEY);
                 expect(regularKeyCachedValue).toBe(SET_VALUE);
                 return Storage.getItem(ONYX_KEYS.REGULAR_KEY)
+                    .then(storedValue => expect(parseInt(storedValue, 10)).toBe(SET_VALUE));
+            });
+    });
+
+    it('should preserve the value of any keysToPreserve over any default key states', () => {
+        expect.assertions(3);
+
+        // Given that Onyx has a value for a key with a default, and we have a variable listening to that value
+        Onyx.connect({
+            key: ONYX_KEYS.DEFAULT_KEY,
+            initWithStoredValues: false,
+            callback: val => onyxValue = val,
+        });
+        Onyx.set(ONYX_KEYS.DEFAULT_KEY, SET_VALUE);
+
+        // When clear is called with the default key to preserve
+        Onyx.clear([ONYX_KEYS.DEFAULT_KEY]);
+        return waitForPromisesToResolve()
+            .then(() => {
+                // Then the value in Onyx, the cache, and Storage is the default key state
+                expect(onyxValue).toBe(SET_VALUE);
+                const cachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
+                expect(cachedValue).toBe(SET_VALUE);
+                return Storage.getItem(ONYX_KEYS.DEFAULT_KEY)
                     .then(storedValue => expect(parseInt(storedValue, 10)).toBe(SET_VALUE));
             });
     });

--- a/tests/unit/onyxClearNativeStorageTest.js
+++ b/tests/unit/onyxClearNativeStorageTest.js
@@ -74,15 +74,12 @@ describe('Set data while storage is clearing', () => {
         Onyx.clear();
         return waitForPromisesToResolve()
             .then(() => {
-                // Then the value in Onyx and the cache is the default key state
+                // Then the value in Onyx, the cache, and Storage is the default key state
                 expect(onyxValue).toBe(DEFAULT_VALUE);
                 const cachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
                 expect(cachedValue).toBe(DEFAULT_VALUE);
-
-                // Then the value in Storage is null
-                // The default key state is never stored during Onyx.clear
                 const storedValue = Storage.getItem(ONYX_KEYS.DEFAULT_KEY);
-                return expect(storedValue).resolves.toBeNull();
+                return expect(storedValue).resolves.toBe(DEFAULT_VALUE);
             });
     });
 
@@ -95,15 +92,12 @@ describe('Set data while storage is clearing', () => {
         Onyx.clear();
         return waitForPromisesToResolve()
             .then(() => {
-                // Then the value in Onyx and the cache is the default key state
+                // Then the value in Onyx, the cache, and Storage is the default key state
                 expect(onyxValue).toBe(DEFAULT_VALUE);
                 const cachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
                 expect(cachedValue).toBe(DEFAULT_VALUE);
                 const storedValue = Storage.getItem(ONYX_KEYS.DEFAULT_KEY);
-
-                // Then the value in Storage is null
-                // The default key state is never stored during Onyx.clear
-                return expect(storedValue).resolves.toBeNull();
+                return expect(storedValue).resolves.toBe(DEFAULT_VALUE);
             });
     });
 

--- a/tests/unit/onyxClearNativeStorageTest.js
+++ b/tests/unit/onyxClearNativeStorageTest.js
@@ -8,7 +8,6 @@ const ONYX_KEYS = {
 };
 
 // Store integers because the async storage mock adds escape characters to strings
-const ADDITIONAL_DEFAULT_VALUE = 3;
 const SET_VALUE = 2;
 const MERGED_VALUE = 1;
 const DEFAULT_VALUE = 0;
@@ -108,10 +107,10 @@ describe('Set data while storage is clearing', () => {
             });
     });
 
-    it('should preserve the value of any additional defaults passed in', () => {
+    it('should preserve the value of any keyStatesToPreserve passed in', () => {
         expect.assertions(6);
 
-        // Given that Onyx has a value and we have a variable listening to that value
+        // Given that Onyx has a value, and we have a variable listening to that value
         Onyx.set(ONYX_KEYS.REGULAR_KEY, SET_VALUE);
         let valueToKeep;
         Onyx.connect({
@@ -120,11 +119,11 @@ describe('Set data while storage is clearing', () => {
             callback: val => valueToKeep = val,
         });
 
-        // When clear is called with an additional default value
+        // When clear is called with a key to preserve
         Onyx.clear([ONYX_KEYS.REGULAR_KEY]);
         return waitForPromisesToResolve()
             .then(() => {
-                // Then the value in Onyx and the cache is the default key state
+                // Then the value in Onyx and the cache for the default key is the default key state
                 expect(onyxValue).toBe(DEFAULT_VALUE);
                 const defaultKeyCachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
                 expect(defaultKeyCachedValue).toBe(DEFAULT_VALUE);
@@ -133,14 +132,14 @@ describe('Set data while storage is clearing', () => {
                 // Then the value in Storage is null
                 expect(defaultKeyStoredValue).resolves.toBeNull();
 
-                // Then the value we preserved is also still set
+                // Then the value of the preserved key is also still set
                 expect(valueToKeep).toBe(SET_VALUE);
                 const regularKeyCachedValue = cache.getValue(ONYX_KEYS.REGULAR_KEY);
                 expect(regularKeyCachedValue).toBe(SET_VALUE);
                 const regularKeyStoredValue = Storage.getItem(ONYX_KEYS.REGULAR_KEY);
 
                 // Then the value in Storage is null
-                // An additional passed in default, much like any other default key state, is never stored during Onyx.clear
+                // A preserved key state, much like any other default key state, is never stored during Onyx.clear
                 return expect(regularKeyStoredValue).resolves.toBeNull();
             });
     });

--- a/tests/unit/onyxClearWebStorageTest.js
+++ b/tests/unit/onyxClearWebStorageTest.js
@@ -76,15 +76,12 @@ describe('Set data while storage is clearing', () => {
         Onyx.clear();
         return waitForPromisesToResolve()
             .then(() => {
-                // Then the value in Onyx and the cache is the default key state
+                // Then the value in Onyx, the cache, and Storage is the default key state
                 expect(onyxValue).toBe(DEFAULT_VALUE);
                 const cachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
                 expect(cachedValue).toBe(DEFAULT_VALUE);
-
-                // Then the value in Storage is null
-                // The default key state is never stored during Onyx.clear
                 const storedValue = Storage.getItem(ONYX_KEYS.DEFAULT_KEY);
-                return expect(storedValue).resolves.toBeUndefined();
+                return expect(storedValue).resolves.toBe(DEFAULT_VALUE);
             });
     });
 
@@ -97,15 +94,12 @@ describe('Set data while storage is clearing', () => {
         Onyx.clear();
         return waitForPromisesToResolve()
             .then(() => {
-                // Then the value in Onyx and the cache is the default key state
+                // Then the value in Onyx, the cache, and Storage is the default key state
                 expect(onyxValue).toBe(DEFAULT_VALUE);
                 const cachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
                 expect(cachedValue).toBe(DEFAULT_VALUE);
                 const storedValue = Storage.getItem(ONYX_KEYS.DEFAULT_KEY);
-
-                // Then the value in Storage is null
-                // The default key state is never stored during Onyx.clear
-                return expect(storedValue).resolves.toBeUndefined();
+                return expect(storedValue).resolves.toBe(DEFAULT_VALUE);
             });
     });
 

--- a/tests/unit/onyxClearWebStorageTest.js
+++ b/tests/unit/onyxClearWebStorageTest.js
@@ -123,9 +123,7 @@ describe('Set data while storage is clearing', () => {
         });
 
         // When clear is called with an additional default value
-        Onyx.clear({
-            [ONYX_KEYS.REGULAR_KEY]: ADDITIONAL_DEFAULT_VALUE,
-        });
+        Onyx.clear([ONYX_KEYS.REGULAR_KEY]);
         return waitForPromisesToResolve()
             .then(() => {
                 // Then the value in Onyx and the cache is the default key state
@@ -139,9 +137,9 @@ describe('Set data while storage is clearing', () => {
                 expect(storedValue).resolves.toBeNull();
 
                 // Then the value we preserved is also still set
-                expect(valueToKeep).toBe(ADDITIONAL_DEFAULT_VALUE);
+                expect(valueToKeep).toBe(SET_VALUE);
                 const regularKeyCachedValue = cache.getValue(ONYX_KEYS.REGULAR_KEY);
-                expect(regularKeyCachedValue).toBe(ADDITIONAL_DEFAULT_VALUE);
+                expect(regularKeyCachedValue).toBe(SET_VALUE);
                 const regularKeyStoredValue = Storage.getItem(ONYX_KEYS.REGULAR_KEY);
 
                 // Then the value in Storage is null

--- a/tests/unit/onyxClearWebStorageTest.js
+++ b/tests/unit/onyxClearWebStorageTest.js
@@ -113,13 +113,13 @@ describe('Set data while storage is clearing', () => {
         expect.assertions(6);
 
         // Given that Onyx has a value, and we have a variable listening to that value
-        Onyx.set(ONYX_KEYS.REGULAR_KEY, SET_VALUE);
         let valueToKeep;
         Onyx.connect({
             key: ONYX_KEYS.REGULAR_KEY,
             initWithStoredValues: false,
             callback: val => valueToKeep = val,
         });
+        Onyx.set(ONYX_KEYS.REGULAR_KEY, SET_VALUE);
 
         // When clear is called with a key to preserve
         Onyx.clear([ONYX_KEYS.REGULAR_KEY]);
@@ -135,15 +135,12 @@ describe('Set data while storage is clearing', () => {
                 // The default key state is never stored during Onyx.clear
                 expect(storedValue).resolves.toBeNull();
 
-                // Then the value of the preserved key is also still set
+                // Then the value of the preserved key is also still set in both the cache and storage
                 expect(valueToKeep).toBe(SET_VALUE);
                 const regularKeyCachedValue = cache.getValue(ONYX_KEYS.REGULAR_KEY);
                 expect(regularKeyCachedValue).toBe(SET_VALUE);
                 const regularKeyStoredValue = Storage.getItem(ONYX_KEYS.REGULAR_KEY);
-
-                // Then the value in Storage is null
-                // A preserved key state, much like any other default key state, is never stored during Onyx.clear
-                return expect(regularKeyStoredValue).resolves.toBeUndefined();
+                return expect(regularKeyStoredValue).resolves.toBe(SET_VALUE);
             });
     });
 });

--- a/tests/unit/onyxClearWebStorageTest.js
+++ b/tests/unit/onyxClearWebStorageTest.js
@@ -142,7 +142,7 @@ describe('Set data while storage is clearing', () => {
                 expect(valueToKeep).toBe(ADDITIONAL_DEFAULT_VALUE);
                 const regularKeyCachedValue = cache.getValue(ONYX_KEYS.REGULAR_KEY);
                 expect(regularKeyCachedValue).toBe(ADDITIONAL_DEFAULT_VALUE);
-                const regularKeyStoredValue = Storage.getItem(ONYX_KEYS.DEFAULT_KEY);
+                const regularKeyStoredValue = Storage.getItem(ONYX_KEYS.REGULAR_KEY);
 
                 // Then the value in Storage is null
                 // An additional passed in default, much like any other default key state, is never stored during Onyx.clear

--- a/tests/unit/onyxClearWebStorageTest.js
+++ b/tests/unit/onyxClearWebStorageTest.js
@@ -5,7 +5,6 @@ const ONYX_KEYS = {
     DEFAULT_KEY: 'defaultKey',
     REGULAR_KEY: 'regularKey',
 };
-const ADDITIONAL_DEFAULT_VALUE = 'additionalDefaultValue';
 const SET_VALUE = 'set';
 const MERGED_VALUE = 'merged';
 const DEFAULT_VALUE = 'default';
@@ -110,10 +109,10 @@ describe('Set data while storage is clearing', () => {
             });
     });
 
-    it('should preserve the value of any additional defaults passed in', () => {
+    it('should preserve the value of any keyStatesToPreserve passed in', () => {
         expect.assertions(6);
 
-        // Given that Onyx has a value and we have a variable listening to that value
+        // Given that Onyx has a value, and we have a variable listening to that value
         Onyx.set(ONYX_KEYS.REGULAR_KEY, SET_VALUE);
         let valueToKeep;
         Onyx.connect({
@@ -122,11 +121,11 @@ describe('Set data while storage is clearing', () => {
             callback: val => valueToKeep = val,
         });
 
-        // When clear is called with an additional default value
+        // When clear is called with a key to preserve
         Onyx.clear([ONYX_KEYS.REGULAR_KEY]);
         return waitForPromisesToResolve()
             .then(() => {
-                // Then the value in Onyx and the cache is the default key state
+                // Then the value in Onyx and the cache for the default key is the default key state
                 expect(onyxValue).toBe(DEFAULT_VALUE);
                 const cachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
                 expect(cachedValue).toBe(DEFAULT_VALUE);
@@ -136,14 +135,14 @@ describe('Set data while storage is clearing', () => {
                 // The default key state is never stored during Onyx.clear
                 expect(storedValue).resolves.toBeNull();
 
-                // Then the value we preserved is also still set
+                // Then the value of the preserved key is also still set
                 expect(valueToKeep).toBe(SET_VALUE);
                 const regularKeyCachedValue = cache.getValue(ONYX_KEYS.REGULAR_KEY);
                 expect(regularKeyCachedValue).toBe(SET_VALUE);
                 const regularKeyStoredValue = Storage.getItem(ONYX_KEYS.REGULAR_KEY);
 
                 // Then the value in Storage is null
-                // An additional passed in default, much like any other default key state, is never stored during Onyx.clear
+                // A preserved key state, much like any other default key state, is never stored during Onyx.clear
                 return expect(regularKeyStoredValue).resolves.toBeUndefined();
             });
     });

--- a/tests/unit/onyxClearWebStorageTest.js
+++ b/tests/unit/onyxClearWebStorageTest.js
@@ -103,7 +103,7 @@ describe('Set data while storage is clearing', () => {
             });
     });
 
-    it('should preserve the value of any keyStatesToPreserve passed in', () => {
+    it('should preserve the value of any keysToPreserve passed in', () => {
         expect.assertions(6);
 
         // Given that Onyx has a value, and we have a variable listening to that value
@@ -135,6 +135,30 @@ describe('Set data while storage is clearing', () => {
                 expect(regularKeyCachedValue).toBe(SET_VALUE);
                 const regularKeyStoredValue = Storage.getItem(ONYX_KEYS.REGULAR_KEY);
                 return expect(regularKeyStoredValue).resolves.toBe(SET_VALUE);
+            });
+    });
+
+    it('should preserve the value of any keysToPreserve over any default key states', () => {
+        expect.assertions(3);
+
+        // Given that Onyx has a value for a key with a default, and we have a variable listening to that value
+        Onyx.connect({
+            key: ONYX_KEYS.DEFAULT_KEY,
+            initWithStoredValues: false,
+            callback: val => onyxValue = val,
+        });
+        Onyx.set(ONYX_KEYS.DEFAULT_KEY, SET_VALUE);
+
+        // When clear is called with the default key to preserve
+        Onyx.clear([ONYX_KEYS.DEFAULT_KEY]);
+        return waitForPromisesToResolve()
+            .then(() => {
+                // Then the value in Onyx, the cache, and Storage is the default key state
+                expect(onyxValue).toBe(SET_VALUE);
+                const cachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
+                expect(cachedValue).toBe(SET_VALUE);
+                const storedValue = Storage.getItem(ONYX_KEYS.DEFAULT_KEY);
+                return expect(storedValue).resolves.toBe(SET_VALUE);
             });
     });
 });

--- a/tests/unit/onyxClearWebStorageTest.js
+++ b/tests/unit/onyxClearWebStorageTest.js
@@ -104,33 +104,24 @@ describe('Set data while storage is clearing', () => {
     });
 
     it('should preserve the value of any keysToPreserve passed in', () => {
-        expect.assertions(6);
+        expect.assertions(3);
 
         // Given that Onyx has a value, and we have a variable listening to that value
-        let valueToKeep;
+        let regularKeyOnyxValue;
         Onyx.connect({
             key: ONYX_KEYS.REGULAR_KEY,
             initWithStoredValues: false,
-            callback: val => valueToKeep = val,
+            callback: val => regularKeyOnyxValue = val,
         });
-        Onyx.set(ONYX_KEYS.REGULAR_KEY, SET_VALUE);
+        Onyx.set(ONYX_KEYS.REGULAR_KEY, SET_VALUE).then(() => {
+            // When clear is called with a key to preserve
+            Onyx.clear([ONYX_KEYS.REGULAR_KEY]);
+        });
 
-        // When clear is called with a key to preserve
-        Onyx.clear([ONYX_KEYS.REGULAR_KEY]);
         return waitForPromisesToResolve()
             .then(() => {
-                // Then the value in Onyx and the cache for the default key is the default key state
-                expect(onyxValue).toBe(DEFAULT_VALUE);
-                const cachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
-                expect(cachedValue).toBe(DEFAULT_VALUE);
-                const storedValue = Storage.getItem(ONYX_KEYS.DEFAULT_KEY);
-
-                // Then the value in Storage is null
-                // The default key state is never stored during Onyx.clear
-                expect(storedValue).resolves.toBeNull();
-
                 // Then the value of the preserved key is also still set in both the cache and storage
-                expect(valueToKeep).toBe(SET_VALUE);
+                expect(regularKeyOnyxValue).toBe(SET_VALUE);
                 const regularKeyCachedValue = cache.getValue(ONYX_KEYS.REGULAR_KEY);
                 expect(regularKeyCachedValue).toBe(SET_VALUE);
                 const regularKeyStoredValue = Storage.getItem(ONYX_KEYS.REGULAR_KEY);
@@ -142,18 +133,14 @@ describe('Set data while storage is clearing', () => {
         expect.assertions(3);
 
         // Given that Onyx has a value for a key with a default, and we have a variable listening to that value
-        Onyx.connect({
-            key: ONYX_KEYS.DEFAULT_KEY,
-            initWithStoredValues: false,
-            callback: val => onyxValue = val,
+        Onyx.set(ONYX_KEYS.DEFAULT_KEY, SET_VALUE).then(() => {
+            // When clear is called with the default key to preserve
+            Onyx.clear([ONYX_KEYS.DEFAULT_KEY]);
         });
-        Onyx.set(ONYX_KEYS.DEFAULT_KEY, SET_VALUE);
 
-        // When clear is called with the default key to preserve
-        Onyx.clear([ONYX_KEYS.DEFAULT_KEY]);
         return waitForPromisesToResolve()
             .then(() => {
-                // Then the value in Onyx, the cache, and Storage is the default key state
+                // Then the value in Onyx, the cache, and Storage is the set value
                 expect(onyxValue).toBe(SET_VALUE);
                 const cachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
                 expect(cachedValue).toBe(SET_VALUE);

--- a/tests/unit/onyxMultiMergeWebStorageTest.js
+++ b/tests/unit/onyxMultiMergeWebStorageTest.js
@@ -141,7 +141,11 @@ describe('Onyx.mergeCollection() amd WebStorage', () => {
     });
 
     it('setItem() and multiMerge()', () => {
-        expect(localforageMock.storageMap).toEqual({});
+        expect(localforageMock.storageMap).toEqual({
+            test_1: null,
+            test_2: null,
+            test_3: null,
+        });
 
         // Given no previous data and several calls to setItem and call to mergeCollection to update a given key
 

--- a/tests/unit/onyxMultiMergeWebStorageTest.js
+++ b/tests/unit/onyxMultiMergeWebStorageTest.js
@@ -141,6 +141,7 @@ describe('Onyx.mergeCollection() amd WebStorage', () => {
     });
 
     it('setItem() and multiMerge()', () => {
+        // The keys are still preserved after clearing Onyx from the previous test. They just have no values.
         expect(localforageMock.storageMap).toEqual({
             test_1: null,
             test_2: null,

--- a/tests/unit/onyxMultiMergeWebStorageTest.js
+++ b/tests/unit/onyxMultiMergeWebStorageTest.js
@@ -141,7 +141,7 @@ describe('Onyx.mergeCollection() amd WebStorage', () => {
     });
 
     it('setItem() and multiMerge()', () => {
-        // The keys are still preserved after clearing Onyx from the previous test. They just have no values.
+        // When Onyx is cleared, since it uses multiSet() to clear out all the values, the keys will remain with null for all the values
         expect(localforageMock.storageMap).toEqual({
             test_1: null,
             test_2: null,


### PR DESCRIPTION
@neil-marcellini please review
cc @marcaaron @tgolen 

### Details
Add a `keysToPreserve` param to `clear` to allow it to accept passed-in keys to preserve when clearing Onyx. To better support this, clear Onyx by using `multiSet` to set all keys to null (except the ones we want to preserve)

### Related Issues
https://github.com/Expensify/App/issues/13062

### Automated Tests
Added tests in [onyxClearWebStorageTest.js](https://github.com/Expensify/react-native-onyx/blob/317a6172b9c12ad435636af7c1e96e9387858d01/tests/unit/onyxClearWebStorageTest.js#L113-L151) and [onyxClearNativeStorageTest.js](https://github.com/Expensify/react-native-onyx/blob/317a6172b9c12ad435636af7c1e96e9387858d01/tests/unit/onyxClearNativeStorageTest.js#L111-L148)

Additionally, ran some quick performance tests on Android to make sure there were no regressions:
```
main:
DEBUG  [info] YUWEN clearStorageAndRedirect timing: 208 - ""
DEBUG  [info] YUWEN clearStorageAndRedirect timing: 273 - ""
DEBUG  [info] YUWEN clearStorageAndRedirect timing: 260 - ""
DEBUG  [info] YUWEN clearStorageAndRedirect timing: 230 - ""

yuwen-additionalDefaultsMultiSet:
DEBUG  [info] YUWEN clearStorageAndRedirect timing: 206 - ""
DEBUG  [info] YUWEN clearStorageAndRedirect timing: 215 - ""
DEBUG  [info] YUWEN clearStorageAndRedirect timing: 215 - ""
DEBUG  [info] YUWEN clearStorageAndRedirect timing: 218 - ""
```

### Linked PRs
https://github.com/Expensify/App/pull/13384