### PR TITLE
Fix: simplify merge and add mergeItem to LocalForage

### DIFF
--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -891,9 +891,9 @@ function multiSet(data) {
  * @returns {Promise}
  */
 // eslint-disable-next-line rulesdir/no-negated-variables
-function notifyAndWriteToStorage(key, value, writeMethod = Storage.setItem) {
+function notifyAndWriteToStorage(key, value, shouldMerge = false) {
     // Logging properties only since values could be sensitive things we don't want to log
-    Logger.logInfo(`${writeMethod.name}() called for key: ${key}${_.isObject(value) ? ` properties: ${_.keys(value).join(',')}` : ''}`);
+    Logger.logInfo(`${shouldMerge ? Storage.mergeItem.name : Storage.setItem.name}() called for key: ${key}${_.isObject(value) ? ` properties: ${_.keys(value).join(',')}` : ''}`);
 
     // If the value in the cache is the same as what we have then do not update subscribers unless they
     // have initWithStoredValues: false then they MUST get all updates even if nothing has changed.
@@ -903,13 +903,39 @@ function notifyAndWriteToStorage(key, value, writeMethod = Storage.setItem) {
         return Promise.resolve();
     }
 
-    // Adds the key to cache when it's not available
-    cache.set(key, value);
-    notifySubscribersOnNextTick(key, value);
+    return new Promise((resolve, reject) => {
+        const writePromise = shouldMerge ? Storage.mergeItem(key, value) : Storage.setItem(key, value);
 
-    return writeMethod(key, value)
-        // eslint-disable-next-line no-use-before-define
-        .catch(error => evictStorageAndRetry(error, writeMethod === Storage.setItem ? set : merge, key, value));
+        writePromise.then(() => {
+            // eslint-disable-next-line rulesdir/no-negated-variables
+            function notifySubscribersAndWriteToCache(val) {
+                // Adds the key to cache when it's not available
+                cache.set(key, val);
+                notifySubscribersOnNextTick(key, val);
+            }
+
+            if (!shouldMerge) {
+                // If we use setItem() we don't need to wait for the storage to be read
+                // We already know, which value will be in the storage, so we can notify
+                // subscribers immediately and write the value to cache
+                notifySubscribersAndWriteToCache(value);
+                resolve();
+            } else {
+                // If we use mergeItem() we have to wait for the storage to be written,
+                // so we can read what the merged value will look like
+                // After that, we notify subscribers and write the value to cache
+                // TODO: Investigate, if we can improve/cut out this behaviour by using SQL.js
+                Storage.getItem(key).then((val) => {
+                    notifySubscribersAndWriteToCache(val);
+                    resolve();
+                });
+            }
+        }).catch((error) => {
+            // eslint-disable-next-line no-use-before-define
+            evictStorageAndRetry(error, shouldMerge ? set : merge, key, value);
+            reject();
+        });
+    });
 }
 
 /**
@@ -941,7 +967,7 @@ function merge(key, value) {
         return set(key, value);
     }
 
-    return notifyAndWriteToStorage(key, value, Storage.mergeItem);
+    return notifyAndWriteToStorage(key, value, true);
 }
 
 /**

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -884,42 +884,6 @@ function multiSet(data) {
         .catch(error => evictStorageAndRetry(error, multiSet, data));
 }
 
-// Key/value store of Onyx key and arrays of values to merge
-const mergeQueue = {};
-
-/**
- * Given an Onyx key and value this method will combine all queued
- * value updates and return a single value. Merge attempts are
- * batched. They must occur after a single call to get() so we
- * can avoid race conditions.
- *
- * @private
- * @param {String} key
- * @param {*} data
- *
- * @returns {*}
- */
-function applyMerge(key, data) {
-    const mergeValues = mergeQueue[key];
-    if (_.isObject(data) || _.every(mergeValues, _.isObject)) {
-        // Object values are merged one after the other
-        return _.reduce(mergeValues, (modifiedData, mergeValue) => {
-            // lodash adds a small overhead so we don't use it here
-            // eslint-disable-next-line prefer-object-spread, rulesdir/prefer-underscore-method
-            const newData = Object.assign({}, fastMerge(modifiedData, mergeValue));
-
-            // We will also delete any object keys that are undefined or null.
-            // Deleting keys is not supported by AsyncStorage so we do it this way.
-            // Remove all first level keys that are explicitly set to null.
-            return _.omit(newData, (value, finalObjectKey) => _.isNull(mergeValue[finalObjectKey]));
-        }, data || {});
-    }
-
-    // If we have anything else we can't merge it so we'll
-    // simply return the last value that was queued
-    return _.last(mergeValues);
-}
-
 /**
  * @param {String} key
  * @param {*} value
@@ -977,32 +941,7 @@ function merge(key, value) {
         return set(key, value);
     }
 
-    // Only SQLite storage has support for using mergeItem (for now).
-    // When we implement mergeItem() for LocalForage we can remove this check.
-    if (Storage.mergeItem) {
-        return notifyAndWriteToStorage(key, value, Storage.mergeItem);
-    }
-
-    if (mergeQueue[key]) {
-        mergeQueue[key].push(value);
-        return Promise.resolve();
-    }
-
-    mergeQueue[key] = [value];
-    return get(key)
-        .then((data) => {
-            try {
-                const modifiedData = applyMerge(key, data);
-
-                // Clean up the write queue so we don't apply these changes again
-                delete mergeQueue[key];
-                return set(key, modifiedData);
-            } catch (error) {
-                Logger.logAlert(`An error occurred while applying merge for key: ${key}, Error: ${error}`);
-            }
-
-            return Promise.resolve();
-        });
+    return notifyAndWriteToStorage(key, value, Storage.mergeItem);
 }
 
 /**

--- a/lib/storage/providers/AsyncStorage.js
+++ b/lib/storage/providers/AsyncStorage.js
@@ -57,7 +57,12 @@ const provider = {
      */
     multiMerge(pairs) {
         const stringPairs = _.map(pairs, ([key, value]) => [key, JSON.stringify(value)]);
+
         return AsyncStorage.multiMerge(stringPairs);
+    },
+
+    mergeItem(key, value) {
+        return this.multiMerge([[key, value]]);
     },
 
     /**

--- a/lib/storage/providers/LocalForage.js
+++ b/lib/storage/providers/LocalForage.js
@@ -63,6 +63,10 @@ const provider = {
         return Promise.all(tasks).then(() => Promise.resolve());
     },
 
+    mergeItem(key, value) {
+        return this.multiMerge([key, value]);
+    },
+
     /**
      * Stores multiple key-value pairs in a batch
      * @param {Array<[key, value]>} pairs

--- a/lib/storage/providers/LocalForage.js
+++ b/lib/storage/providers/LocalForage.js
@@ -64,7 +64,7 @@ const provider = {
     },
 
     mergeItem(key, value) {
-        return this.multiMerge([key, value]);
+        return this.multiMerge([[key, value]]);
     },
 
     /**

--- a/lib/storage/providers/SQLiteStorage.js
+++ b/lib/storage/providers/SQLiteStorage.js
@@ -92,7 +92,7 @@ const provider = {
     },
 
     mergeItem(key, value) {
-        return this.multiMerge([key, value]);
+        return this.multiMerge([[key, value]]);
     },
 
     /**

--- a/tests/unit/onyxMultiMergeWebStorageTest.js
+++ b/tests/unit/onyxMultiMergeWebStorageTest.js
@@ -17,7 +17,7 @@ const initialData = {
 
 localforageMock.setInitialMockData(initialData);
 
-describe('Onyx.mergeCollection() amd WebStorage', () => {
+describe('Onyx.mergeCollection() and WebStorage', () => {
     let Onyx;
 
     beforeAll(() => {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
Simplify merging in the Onyx layer and add `mergeItem()` to `LocalForage`, which essentially just uses `multiMerge()`