### PR TITLE
Remove null values

### DIFF
--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -799,7 +799,7 @@ function notifyCollectionSubscribersOnNextTick(key, value) {
  * @return {Promise}
  */
 function remove(key) {
-    cache.drop(key)
+    cache.drop(key);
     notifySubscribersOnNextTick(key, null);
     return Storage.removeItem(key);
 }
@@ -846,9 +846,11 @@ function evictStorageAndRetry(error, onyxMethod, ...args) {
  * @returns {Promise}
  */
 function set(key, value) {
-    if (!value) {
-        return remove(key)
+    if (_.isNull(value)) {
+        Logger.logInfo(`Removing the key: ${key} as it called set() with null value`);
+        return remove(key);
     }
+
     // Logging properties only since values could be sensitive things we don't want to log
     Logger.logInfo(`set() called for key: ${key}${_.isObject(value) ? ` properties: ${_.keys(value).join(',')}` : ''}`);
 
@@ -1296,6 +1298,7 @@ const Onyx = {
     mergeCollection,
     update,
     clear,
+    getAllKeys,
     init,
     registerLogger: Logger.registerLogger,
     addToEvictionBlockList,

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -847,12 +847,8 @@ function evictStorageAndRetry(error, onyxMethod, ...args) {
  */
 function set(key, value) {
     if (_.isNull(value)) {
-        Logger.logInfo(`Removing the key: ${key} as it called set() with null value`);
         return remove(key);
     }
-
-    // Logging properties only since values could be sensitive things we don't want to log
-    Logger.logInfo(`set() called for key: ${key}${_.isObject(value) ? ` properties: ${_.keys(value).join(',')}` : ''}`);
 
     // eslint-disable-next-line no-use-before-define
     if (hasPendingMergeForKey(key)) {

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -799,8 +799,7 @@ function notifyCollectionSubscribersOnNextTick(key, value) {
  * @return {Promise}
  */
 function remove(key) {
-    // Cache the fact that the value was removed
-    cache.set(key, null);
+    cache.drop(key)
     notifySubscribersOnNextTick(key, null);
     return Storage.removeItem(key);
 }
@@ -847,6 +846,9 @@ function evictStorageAndRetry(error, onyxMethod, ...args) {
  * @returns {Promise}
  */
 function set(key, value) {
+    if (!value) {
+        return remove(key)
+    }
     // Logging properties only since values could be sensitive things we don't want to log
     Logger.logInfo(`set() called for key: ${key}${_.isObject(value) ? ` properties: ${_.keys(value).join(',')}` : ''}`);
 

--- a/lib/OnyxCache.js
+++ b/lib/OnyxCache.js
@@ -104,6 +104,8 @@ class OnyxCache {
      */
     drop(key) {
         delete this.storageMap[key];
+        this.storageKeys.delete(key);
+        this.recentKeys.delete(key);
     }
 
     /**

--- a/tests/unit/onyxCacheTest.js
+++ b/tests/unit/onyxCacheTest.js
@@ -174,20 +174,6 @@ describe('Onyx', () => {
         });
 
         describe('drop', () => {
-            it('Should NOT remove the key from all keys', () => {
-                // Given cache with some items
-                cache.set('mockKey', 'mockValue');
-                cache.set('mockKey2', 'mockValue');
-                cache.set('mockKey3', 'mockValue');
-
-                // When an key is removed
-                cache.drop('mockKey2');
-
-                // Then getAllKeys should still include the key
-                const allKeys = cache.getAllKeys();
-                expect(allKeys).toEqual(expect.arrayContaining(['mockKey2']));
-            });
-
             it('Should remove the key from cache', () => {
                 // Given cache with some items
                 cache.set('mockKey', {items: ['mockValue', 'mockValue2']});
@@ -199,6 +185,7 @@ describe('Onyx', () => {
                 // Then a value should not be available in cache
                 expect(cache.hasCacheForKey('mockKey')).toBe(false);
                 expect(cache.getValue('mockKey')).not.toBeDefined();
+                expect(cache.getAllKeys('mockKey').includes('mockKey')).toBe(false);
             });
         });
 

--- a/tests/unit/onyxTest.js
+++ b/tests/unit/onyxTest.js
@@ -51,7 +51,6 @@ describe('Onyx', () => {
         })
         .then((keys) => {
             expect(keys.includes(ONYX_KEYS.OTHER_TEST)).toBe(false);
-            return Onyx.set(ONYX_KEYS.OTHER_TEST, 42);
         }));
 
     it('should set a simple key', () => {

--- a/tests/unit/onyxTest.js
+++ b/tests/unit/onyxTest.js
@@ -36,24 +36,23 @@ describe('Onyx', () => {
         return Onyx.clear();
     });
 
-    it('should remove key value from OnyxCache/Storage when set is called with null value',
-        () => Onyx.set(ONYX_KEYS.OTHER_TEST, 42)
-            .then(() => Onyx.getAllKeys())
-            .then((keys) => {
-                expect(keys.includes(ONYX_KEYS.OTHER_TEST)).toBe(true);
-                return Onyx.set(ONYX_KEYS.OTHER_TEST, null);
-            })
-            .then(() => {
-                // Checks if cache value is removed.
-                expect(cache.getAllKeys().length).toBe(0);
+    it('should remove key value from OnyxCache/Storage when set is called with null value', () => Onyx.set(ONYX_KEYS.OTHER_TEST, 42)
+        .then(() => Onyx.getAllKeys())
+        .then((keys) => {
+            expect(keys.includes(ONYX_KEYS.OTHER_TEST)).toBe(true);
+            return Onyx.set(ONYX_KEYS.OTHER_TEST, null);
+        })
+        .then(() => {
+            // Checks if cache value is removed.
+            expect(cache.getAllKeys().length).toBe(0);
 
-                // When cache keys length is 0, we fetch the keys from storage.
-                return Onyx.getAllKeys();
-            })
-            .then((keys) => {
-                expect(keys.includes(ONYX_KEYS.OTHER_TEST)).toBe(false);
-                return Onyx.set(ONYX_KEYS.OTHER_TEST, 42);
-            }));
+            // When cache keys length is 0, we fetch the keys from storage.
+            return Onyx.getAllKeys();
+        })
+        .then((keys) => {
+            expect(keys.includes(ONYX_KEYS.OTHER_TEST)).toBe(false);
+            return Onyx.set(ONYX_KEYS.OTHER_TEST, 42);
+        }));
 
     it('should set a simple key', () => {
         let testKeyValue;

--- a/tests/unit/onyxTest.js
+++ b/tests/unit/onyxTest.js
@@ -24,10 +24,36 @@ Onyx.init({
 describe('Onyx', () => {
     let connectionID;
 
+    /** @type OnyxCache */
+    let cache;
+
+    beforeEach(() => {
+        cache = require('../../lib/OnyxCache').default;
+    });
+
     afterEach(() => {
         Onyx.disconnect(connectionID);
         return Onyx.clear();
     });
+
+    it('should remove key value from OnyxCache/Storage when set is called with null value',
+        () => Onyx.set(ONYX_KEYS.OTHER_TEST, 42)
+            .then(() => Onyx.getAllKeys())
+            .then((keys) => {
+                expect(keys.includes(ONYX_KEYS.OTHER_TEST)).toBe(true);
+                return Onyx.set(ONYX_KEYS.OTHER_TEST, null);
+            })
+            .then(() => {
+                // Checks if cache value is removed.
+                expect(cache.getAllKeys().length).toBe(0);
+
+                // When cache keys length is 0, we fetch the keys from storage.
+                return Onyx.getAllKeys();
+            })
+            .then((keys) => {
+                expect(keys.includes(ONYX_KEYS.OTHER_TEST)).toBe(false);
+                return Onyx.set(ONYX_KEYS.OTHER_TEST, 42);
+            }));
 
     it('should set a simple key', () => {
         let testKeyValue;


### PR DESCRIPTION
### Details
When Onyx.set() is called with null value we are storing it in OnyxCache and AsyncStorage without removing the data from the both. This is leading to iOS crashes for AsyncStorage.multiMerge() operation. More information can be found at the root cause analysis here - https://github.com/Expensify/App/issues/13907#issuecomment-1368779185
Reviewer - @jasperhuangg 

### Related Issues
https://github.com/Expensify/App/issues/13907

### Automated Tests
I have added added test naming 'should remove key value from OnyxCache/Storage when set is called with null value' which verifies if the data is removed from OnyxCache and Storage.

### Linked PRs
None. Currently Expensify is using '1.0.29' which is lower than current onyx version '1.0.32'. We have to confirm if we can update Expensify package.json with change or should we wait. Anyways it shouldn't block this PR.
