### PR TITLE
Protect against undefined values

### DIFF
--- a/lib/storage/providers/SQLiteStorage.js
+++ b/lib/storage/providers/SQLiteStorage.js
@@ -66,7 +66,7 @@ const provider = {
     multiSet(pairs) {
         const stringifiedPairs = _.map(pairs, pair => [
             pair[0],
-            JSON.stringify(pair[1]),
+            JSON.stringify(pair[1] || null),
         ]);
         return db.executeBatchAsync([['REPLACE INTO keyvaluepairs (record_key, valueJSON) VALUES (?, json(?));', stringifiedPairs]]);
     },

--- a/lib/storage/providers/SQLiteStorage.js
+++ b/lib/storage/providers/SQLiteStorage.js
@@ -66,7 +66,7 @@ const provider = {
     multiSet(pairs) {
         const stringifiedPairs = _.map(pairs, pair => [
             pair[0],
-            JSON.stringify(pair[1] || null),
+            JSON.stringify(_.isUndefined(pair[1]) ? null : pair[1]),
         ]);
         return db.executeBatchAsync([['REPLACE INTO keyvaluepairs (record_key, valueJSON) VALUES (?, json(?));', stringifiedPairs]]);
     },


### PR DESCRIPTION
cc @marcaaron @chrispader 

### Details
Explained in this thread: https://expensify.slack.com/archives/C01GTK53T8Q/p1673550288930829

This caused a crash in the app when clearing Onyx due to one of the values passed to `multiSet()` being undefined (which is normal behavior for a value that we are trying to clear out).

<img width="439" alt="image" src="https://user-images.githubusercontent.com/1228807/212161098-fde1afdd-7a4a-453b-bd97-210a92601682.png">

### Related Issues
None

### Automated Tests
None

### Linked PRs
This will be tested and deployed with https://github.com/Expensify/App/pull/13886
