### PR TITLE
Fix multiSet when pairs is empty

### DIFF
--- a/lib/storage/providers/SQLiteStorage.js
+++ b/lib/storage/providers/SQLiteStorage.js
@@ -68,6 +68,9 @@ const provider = {
             pair[0],
             JSON.stringify(_.isUndefined(pair[1]) ? null : pair[1]),
         ]);
+        if (_.isEmpty(stringifiedPairs)) {
+            return Promise.resolve();
+        }
         return db.executeBatchAsync([['REPLACE INTO keyvaluepairs (record_key, valueJSON) VALUES (?, json(?));', stringifiedPairs]]);
     },
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
The native apps are crashing because there's an action (unknown at the moment) that calls `Onyx.multiSet` with an empty object as argument. This happens because the [query](https://github.com/Expensify/react-native-onyx/blob/main/lib/storage/providers/SQLiteStorage.js#L71) for multiSet is expecting an array with key-value pairs.

<img width="353" alt="Screenshot 2023-01-20 at 10 32 59" src="https://user-images.githubusercontent.com/6829422/213810595-59a5567f-70ff-459d-bcca-a0b455d542c6.png">

Additionally, this bug was reported [here](https://expensify.slack.com/archives/C049HHMV9SM/p1674245798276619).

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/App/issues/14437

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
N/A

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->
N/A atm, a new PR will be created when this change is deployed to npm