### PR TITLE
Upgrade react-native to v0.71.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,10 +36,10 @@
         "localforage": "^1.10.0",
         "metro-react-native-babel-preset": "^0.72.3",
         "prop-types": "^15.7.2",
-        "react": "18.1.0",
-        "react-native": "0.70.0",
+        "react": "18.2.0",
+        "react-native": "0.71.2",
         "react-native-performance": "^2.0.0",
-        "react-native-quick-sqlite": "^5.0.3",
+        "react-native-quick-sqlite": "^8.0.0-beta.2",
         "react-test-renderer": "18.1.0",
         "webpack": "^5.72.1",
         "webpack-cli": "^4.9.2",
@@ -55,7 +55,7 @@
         "localforage": "^1.10.0",
         "react": ">=18.1.0",
         "react-native-performance": "^4.0.0",
-        "react-native-quick-sqlite": "^5.0.3"
+        "react-native-quick-sqlite": "^8.0.0-beta.2"
       },
       "peerDependenciesMeta": {
         "@react-native-async-storage/async-storage": {
@@ -86,43 +86,46 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
-      "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
+      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.10.4"
+        "@babel/highlight": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.20.1",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.20.1.tgz",
-      "integrity": "sha512-EWZ4mE2diW3QALKvDMiXnbZpRvlj+nayZ112nK93SnhqOtpdsbVD4W+2tEoT3YNBAG9RBR0ISY758ZkOgsn6pQ==",
+      "version": "7.20.14",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.20.14.tgz",
+      "integrity": "sha512-0YpKHD6ImkWMEINCyDAD0HLLUH/lPCefG8ld9it8DJB2wnApraKuhgYTvTY1z7UFIfBTGy5LwncZ+5HWWGbhFw==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.17.10",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.10.tgz",
-      "integrity": "sha512-liKoppandF3ZcBnIYFjfSDHZLKdLHGJRkoWtG8zQyGJBQfIYobpnVGI5+pLBNtS6psFLDzyq8+h5HiVljW9PNA==",
+      "version": "7.20.12",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.20.12.tgz",
+      "integrity": "sha512-XsMfHovsUYHFMdrIHkZphTN/2Hzzi78R08NuHfDBehym2VsPDL6Zn/JAD/JQdnRvbSsbQc4mVaU1m6JgtTEElg==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.1.0",
-        "@babel/code-frame": "^7.16.7",
-        "@babel/generator": "^7.17.10",
-        "@babel/helper-compilation-targets": "^7.17.10",
-        "@babel/helper-module-transforms": "^7.17.7",
-        "@babel/helpers": "^7.17.9",
-        "@babel/parser": "^7.17.10",
-        "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.17.10",
-        "@babel/types": "^7.17.10",
+        "@babel/code-frame": "^7.18.6",
+        "@babel/generator": "^7.20.7",
+        "@babel/helper-compilation-targets": "^7.20.7",
+        "@babel/helper-module-transforms": "^7.20.11",
+        "@babel/helpers": "^7.20.7",
+        "@babel/parser": "^7.20.7",
+        "@babel/template": "^7.20.7",
+        "@babel/traverse": "^7.20.12",
+        "@babel/types": "^7.20.7",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.1",
+        "json5": "^2.2.2",
         "semver": "^6.3.0"
       },
       "engines": {
@@ -131,18 +134,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/babel"
-      }
-    },
-    "node_modules/@babel/core/node_modules/@babel/code-frame": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
-      "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/highlight": "^7.16.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core/node_modules/semver": {
@@ -155,12 +146,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.20.4",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.4.tgz",
-      "integrity": "sha512-luCf7yk/cm7yab6CAW1aiFnmEfBJplb/JojV56MYEK7ziWfGmFlTfmL9Ehwfy4gFhbjBfWO1wj7/TuSbVNEEtA==",
+      "version": "7.20.14",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.14.tgz",
+      "integrity": "sha512-AEmuXHdcD3A52HHXxaTmYlb8q/xMEhoRP67B3T4Oq7lbmSoqroMZzjnGj3+i1io3pdnF8iBYVu4Ilj+c4hBxYg==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.20.2",
+        "@babel/types": "^7.20.7",
         "@jridgewell/gen-mapping": "^0.3.2",
         "jsesc": "^2.5.1"
       },
@@ -208,14 +199,15 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.0.tgz",
-      "integrity": "sha512-0jp//vDGp9e8hZzBc6N/KwA5ZK3Wsm/pfm4CrY7vzegkVxc65SgSn6wYOnwHe9Js9HRQ1YTCKLGPzDtaS3RoLQ==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.7.tgz",
+      "integrity": "sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==",
       "dev": true,
       "dependencies": {
-        "@babel/compat-data": "^7.20.0",
+        "@babel/compat-data": "^7.20.5",
         "@babel/helper-validator-option": "^7.18.6",
         "browserslist": "^4.21.3",
+        "lru-cache": "^5.1.1",
         "semver": "^6.3.0"
       },
       "engines": {
@@ -223,6 +215,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^3.0.2"
       }
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
@@ -233,6 +234,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
       "version": "7.20.2",
@@ -368,9 +375,9 @@
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.20.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.20.2.tgz",
-      "integrity": "sha512-zvBKyJXRbmK07XhMuujYoJ48B5yvvmM6+wcpv6Ivj4Yg6qO7NOZOSnvZN9CRl1zz1Z4cKf8YejmCMh8clOoOeA==",
+      "version": "7.20.11",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.20.11.tgz",
+      "integrity": "sha512-uRy78kN4psmji1s2QtbtcCSaj/LILFDp0f/ymhpQH5QY3nljUZCaNWz9X1dEj/8MBdBEFECs7yRhKn8i7NjZgg==",
       "dev": true,
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.18.9",
@@ -378,9 +385,9 @@
         "@babel/helper-simple-access": "^7.20.2",
         "@babel/helper-split-export-declaration": "^7.18.6",
         "@babel/helper-validator-identifier": "^7.19.1",
-        "@babel/template": "^7.18.10",
-        "@babel/traverse": "^7.20.1",
-        "@babel/types": "^7.20.2"
+        "@babel/template": "^7.20.7",
+        "@babel/traverse": "^7.20.10",
+        "@babel/types": "^7.20.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -520,14 +527,14 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.17.9",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.9.tgz",
-      "integrity": "sha512-cPCt915ShDWUEzEp3+UNRktO2n6v49l5RSnG9M5pS24hA+2FAc5si+Pn1i4VVbQQ+jh+bIZhPFQOJOzbrOYY1Q==",
+      "version": "7.20.13",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.20.13.tgz",
+      "integrity": "sha512-nzJ0DWCL3gB5RCXbUO3KIMMsBY2Eqbx8mBpKGE/02PgyRQFcPQLbkQ1vyy596mZLaP+dAfD+R4ckASzNVmW3jg==",
       "dev": true,
       "dependencies": {
-        "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.17.9",
-        "@babel/types": "^7.17.0"
+        "@babel/template": "^7.20.7",
+        "@babel/traverse": "^7.20.13",
+        "@babel/types": "^7.20.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -562,9 +569,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.20.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.3.tgz",
-      "integrity": "sha512-OP/s5a94frIPXwjzEcv5S/tpQfc6XhxYUnmWpgdqMWGgYCuErA3SzozaRAMQgSZWKeTJxht9aWAkUY+0UzvOFg==",
+      "version": "7.20.15",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.15.tgz",
+      "integrity": "sha512-DI4a1oZuf8wC+oAJA9RW6ga3Zbe8RZFt7kD9i4qAspz3I/yHet1VvC3DiSy/fsUvv5pvJuNPh0LPOdCcqinDPg==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -2036,59 +2043,35 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.18.10",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.10.tgz",
-      "integrity": "sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.20.7.tgz",
+      "integrity": "sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.18.6",
-        "@babel/parser": "^7.18.10",
-        "@babel/types": "^7.18.10"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/template/node_modules/@babel/code-frame": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
-      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
-      "dev": true,
-      "dependencies": {
-        "@babel/highlight": "^7.18.6"
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.20.1",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.1.tgz",
-      "integrity": "sha512-d3tN8fkVJwFLkHkBN479SOsw4DMZnz8cdbL/gvuDuzy3TS6Nfw80HuQqhw1pITbIruHyh7d1fMA47kWzmcUEGA==",
+      "version": "7.20.13",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.13.tgz",
+      "integrity": "sha512-kMJXfF0T6DIS9E8cgdLCSAL+cuCK+YEZHWiLK0SXpTo8YRj5lpJu3CDNKiIBCne4m9hhTIqUg6SYTAI39tAiVQ==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.20.1",
+        "@babel/generator": "^7.20.7",
         "@babel/helper-environment-visitor": "^7.18.9",
         "@babel/helper-function-name": "^7.19.0",
         "@babel/helper-hoist-variables": "^7.18.6",
         "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/parser": "^7.20.1",
-        "@babel/types": "^7.20.0",
+        "@babel/parser": "^7.20.13",
+        "@babel/types": "^7.20.7",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/traverse/node_modules/@babel/code-frame": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
-      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
-      "dev": true,
-      "dependencies": {
-        "@babel/highlight": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2339,37 +2322,38 @@
       }
     },
     "node_modules/@jest/create-cache-key-function": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-27.5.1.tgz",
-      "integrity": "sha512-dmH1yW+makpTSURTy8VzdUwFnfQh1G8R+DxO2Ho2FFmBbKFEVm+3jWdvFhE2VqB/LATCTokkP0dotjyQyw5/AQ==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-29.4.3.tgz",
+      "integrity": "sha512-AJVFQTTy6jnZAQiAZrdOaTAPzJUrvAE/4IMe+Foav6WPhypFszqg7a4lOTyuzYQEEiT5RSrGYg9IY+/ivxiyXw==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^27.5.1"
+        "@jest/types": "^29.4.3"
       },
       "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/create-cache-key-function/node_modules/@jest/types": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.5.1.tgz",
-      "integrity": "sha512-Cx46iJ9QpwQTjIdq5VJu2QTMMs3QlEjI0x1QbBP5W1+nMzyc2XmimiRR/CbX9TO0cPTeUlxWMOu8mslYsJ8DEw==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.4.3.tgz",
+      "integrity": "sha512-bPYfw8V65v17m2Od1cv44FH+SiKW7w2Xu7trhcdTLUmSv85rfKsP+qXSjO4KGJr4dtPSzl/gvslZBXctf1qGEA==",
       "dev": true,
       "dependencies": {
+        "@jest/schemas": "^29.4.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^3.0.0",
         "@types/node": "*",
-        "@types/yargs": "^16.0.0",
+        "@types/yargs": "^17.0.8",
         "chalk": "^4.0.0"
       },
       "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/create-cache-key-function/node_modules/@types/yargs": {
-      "version": "16.0.4",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
-      "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
+      "version": "17.0.22",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.22.tgz",
+      "integrity": "sha512-pet5WJ9U8yPVRhkwuEIp5ktAeAqRZOq4UdAyWLWzxbtpyXnzbtLdKiXAjJzi/KLmPGS9wk86lUFWZFN6sISo4g==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -2481,6 +2465,18 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.4.3.tgz",
+      "integrity": "sha512-VLYKXQmtmuEz6IxJsrZwzG9NvtkQsWNnWMsKxqWNu3+CnfzJQhp0WDDKWLVV9hLKr0l3SLLFRqcYHjhtyuDVxg==",
+      "dev": true,
+      "dependencies": {
+        "@sinclair/typebox": "^0.25.16"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/source-map": {
@@ -2601,6 +2597,30 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
+      "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "node_modules/@jridgewell/source-map/node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+      "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.14",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
@@ -2646,22 +2666,22 @@
       }
     },
     "node_modules/@react-native-community/cli": {
-      "version": "9.3.2",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-9.3.2.tgz",
-      "integrity": "sha512-IAW4X0vmX/xozNpp/JVZaX7MrC85KV0OP2DF4o7lNGOfpUhzJAEWqTfkxFYS+VsRjZHDve4wSTiGIuXwE7FG1w==",
+      "version": "10.1.3",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-10.1.3.tgz",
+      "integrity": "sha512-kzh6bYLGN1q1q0IiczKSP1LTrovFeVzppYRTKohPI9VdyZwp7b5JOgaQMB/Ijtwm3MxBDrZgV9AveH/eUmUcKQ==",
       "dev": true,
       "dependencies": {
-        "@react-native-community/cli-clean": "^9.2.1",
-        "@react-native-community/cli-config": "^9.2.1",
-        "@react-native-community/cli-debugger-ui": "^9.0.0",
-        "@react-native-community/cli-doctor": "^9.3.0",
-        "@react-native-community/cli-hermes": "^9.3.1",
-        "@react-native-community/cli-plugin-metro": "^9.2.1",
-        "@react-native-community/cli-server-api": "^9.2.1",
-        "@react-native-community/cli-tools": "^9.2.1",
-        "@react-native-community/cli-types": "^9.1.0",
+        "@react-native-community/cli-clean": "^10.1.1",
+        "@react-native-community/cli-config": "^10.1.1",
+        "@react-native-community/cli-debugger-ui": "^10.0.0",
+        "@react-native-community/cli-doctor": "^10.1.1",
+        "@react-native-community/cli-hermes": "^10.1.3",
+        "@react-native-community/cli-plugin-metro": "^10.1.1",
+        "@react-native-community/cli-server-api": "^10.1.1",
+        "@react-native-community/cli-tools": "^10.1.1",
+        "@react-native-community/cli-types": "^10.0.0",
         "chalk": "^4.1.2",
-        "commander": "^9.4.0",
+        "commander": "^9.4.1",
         "execa": "^1.0.0",
         "find-up": "^4.1.0",
         "fs-extra": "^8.1.0",
@@ -2677,24 +2697,25 @@
       }
     },
     "node_modules/@react-native-community/cli-clean": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-clean/-/cli-clean-9.2.1.tgz",
-      "integrity": "sha512-dyNWFrqRe31UEvNO+OFWmQ4hmqA07bR9Ief/6NnGwx67IO9q83D5PEAf/o96ML6jhSbDwCmpPKhPwwBbsyM3mQ==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-clean/-/cli-clean-10.1.1.tgz",
+      "integrity": "sha512-iNsrjzjIRv9yb5y309SWJ8NDHdwYtnCpmxZouQDyOljUdC9MwdZ4ChbtA4rwQyAwgOVfS9F/j56ML3Cslmvrxg==",
       "dev": true,
       "dependencies": {
-        "@react-native-community/cli-tools": "^9.2.1",
+        "@react-native-community/cli-tools": "^10.1.1",
         "chalk": "^4.1.2",
         "execa": "^1.0.0",
         "prompts": "^2.4.0"
       }
     },
     "node_modules/@react-native-community/cli-config": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-config/-/cli-config-9.2.1.tgz",
-      "integrity": "sha512-gHJlBBXUgDN9vrr3aWkRqnYrPXZLztBDQoY97Mm5Yo6MidsEpYo2JIP6FH4N/N2p1TdjxJL4EFtdd/mBpiR2MQ==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-config/-/cli-config-10.1.1.tgz",
+      "integrity": "sha512-p4mHrjC+s/ayiNVG6T35GdEGdP6TuyBUg5plVGRJfTl8WT6LBfLYLk+fz/iETrEZ/YkhQIsQcEUQC47MqLNHog==",
       "dev": true,
       "dependencies": {
-        "@react-native-community/cli-tools": "^9.2.1",
+        "@react-native-community/cli-tools": "^10.1.1",
+        "chalk": "^4.1.2",
         "cosmiconfig": "^5.1.0",
         "deepmerge": "^3.2.0",
         "glob": "^7.1.3",
@@ -2711,23 +2732,23 @@
       }
     },
     "node_modules/@react-native-community/cli-debugger-ui": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-9.0.0.tgz",
-      "integrity": "sha512-7hH05ZwU9Tp0yS6xJW0bqcZPVt0YCK7gwj7gnRu1jDNN2kughf6Lg0Ys29rAvtZ7VO1PK5c1O+zs7yFnylQDUA==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-10.0.0.tgz",
+      "integrity": "sha512-8UKLcvpSNxnUTRy8CkCl27GGLqZunQ9ncGYhSrWyKrU9SWBJJGeZwi2k2KaoJi5FvF2+cD0t8z8cU6lsq2ZZmA==",
       "dev": true,
       "dependencies": {
         "serve-static": "^1.13.1"
       }
     },
     "node_modules/@react-native-community/cli-doctor": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-doctor/-/cli-doctor-9.3.0.tgz",
-      "integrity": "sha512-/fiuG2eDGC2/OrXMOWI5ifq4X1gdYTQhvW2m0TT5Lk1LuFiZsbTCp1lR+XILKekuTvmYNjEGdVpeDpdIWlXdEA==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-doctor/-/cli-doctor-10.1.1.tgz",
+      "integrity": "sha512-9uvUhr6aJu4C7pCTsD9iRS/38tx1mzIrWuEQoh2JffTXg9MOq4jesvobkyKFRD90nOvqunEvfpnWnRdWcZO0Wg==",
       "dev": true,
       "dependencies": {
-        "@react-native-community/cli-config": "^9.2.1",
-        "@react-native-community/cli-platform-ios": "^9.3.0",
-        "@react-native-community/cli-tools": "^9.2.1",
+        "@react-native-community/cli-config": "^10.1.1",
+        "@react-native-community/cli-platform-ios": "^10.1.1",
+        "@react-native-community/cli-tools": "^10.1.1",
         "chalk": "^4.1.2",
         "command-exists": "^1.2.8",
         "envinfo": "^7.7.2",
@@ -2774,40 +2795,38 @@
       }
     },
     "node_modules/@react-native-community/cli-hermes": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-hermes/-/cli-hermes-9.3.1.tgz",
-      "integrity": "sha512-Mq4PK8m5YqIdaVq5IdRfp4qK09aVO+aiCtd6vjzjNUgk1+1X5cgUqV6L65h4N+TFJYJHcp2AnB+ik1FAYXvYPQ==",
+      "version": "10.1.3",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-hermes/-/cli-hermes-10.1.3.tgz",
+      "integrity": "sha512-uYl8MLBtuu6bj0tDUzVGf30nK5i9haBv7F0u+NCOq31+zVjcwiUplrCuLorb2dMLMF+Fno9wDxi66W9MxoW4nA==",
       "dev": true,
       "dependencies": {
-        "@react-native-community/cli-platform-android": "^9.3.1",
-        "@react-native-community/cli-tools": "^9.2.1",
+        "@react-native-community/cli-platform-android": "^10.1.3",
+        "@react-native-community/cli-tools": "^10.1.1",
         "chalk": "^4.1.2",
         "hermes-profile-transformer": "^0.0.6",
         "ip": "^1.1.5"
       }
     },
     "node_modules/@react-native-community/cli-platform-android": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-android/-/cli-platform-android-9.3.1.tgz",
-      "integrity": "sha512-m0bQ6Twewl7OEZoVf79I2GZmsDqh+Gh0bxfxWgwxobsKDxLx8/RNItAo1lVtTCgzuCR75cX4EEO8idIF9jYhew==",
+      "version": "10.1.3",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-android/-/cli-platform-android-10.1.3.tgz",
+      "integrity": "sha512-8YZEpBL6yd9l4CIoFcLOgrV8x2GDujdqrdWrNsNERDAbsiFwqAQvfjyyb57GAZVuEPEJCoqUlGlMCwOh3XQb9A==",
       "dev": true,
       "dependencies": {
-        "@react-native-community/cli-tools": "^9.2.1",
+        "@react-native-community/cli-tools": "^10.1.1",
         "chalk": "^4.1.2",
         "execa": "^1.0.0",
-        "fs-extra": "^8.1.0",
         "glob": "^7.1.3",
-        "logkitty": "^0.7.1",
-        "slash": "^3.0.0"
+        "logkitty": "^0.7.1"
       }
     },
     "node_modules/@react-native-community/cli-platform-ios": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-ios/-/cli-platform-ios-9.3.0.tgz",
-      "integrity": "sha512-nihTX53BhF2Q8p4B67oG3RGe1XwggoGBrMb6vXdcu2aN0WeXJOXdBLgR900DAA1O8g7oy1Sudu6we+JsVTKnjw==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-ios/-/cli-platform-ios-10.1.1.tgz",
+      "integrity": "sha512-EB9/L8j1LqrqyfJtLRixU+d8FIP6Pr83rEgUgXgya/u8wk3h/bvX70w+Ff2skwjdPLr5dLUQ/n5KFX4r3bsNmA==",
       "dev": true,
       "dependencies": {
-        "@react-native-community/cli-tools": "^9.2.1",
+        "@react-native-community/cli-tools": "^10.1.1",
         "chalk": "^4.1.2",
         "execa": "^1.0.0",
         "glob": "^7.1.3",
@@ -2815,90 +2834,32 @@
       }
     },
     "node_modules/@react-native-community/cli-plugin-metro": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-plugin-metro/-/cli-plugin-metro-9.2.1.tgz",
-      "integrity": "sha512-byBGBH6jDfUvcHGFA45W/sDwMlliv7flJ8Ns9foCh3VsIeYYPoDjjK7SawE9cPqRdMAD4SY7EVwqJnOtRbwLiQ==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-plugin-metro/-/cli-plugin-metro-10.1.1.tgz",
+      "integrity": "sha512-wEp47le4mzlelDF5sfkaaujUDYcuLep5HZqlcMx7PkL7BA3/fSHdDo1SblqaLgZ1ca6vFU+kfbHueLDct+xwFg==",
       "dev": true,
       "dependencies": {
-        "@react-native-community/cli-server-api": "^9.2.1",
-        "@react-native-community/cli-tools": "^9.2.1",
+        "@react-native-community/cli-server-api": "^10.1.1",
+        "@react-native-community/cli-tools": "^10.1.1",
         "chalk": "^4.1.2",
-        "metro": "0.72.3",
-        "metro-config": "0.72.3",
-        "metro-core": "0.72.3",
-        "metro-react-native-babel-transformer": "0.72.3",
-        "metro-resolver": "0.72.3",
-        "metro-runtime": "0.72.3",
+        "execa": "^1.0.0",
+        "metro": "0.73.7",
+        "metro-config": "0.73.7",
+        "metro-core": "0.73.7",
+        "metro-react-native-babel-transformer": "0.73.7",
+        "metro-resolver": "0.73.7",
+        "metro-runtime": "0.73.7",
         "readline": "^1.3.0"
       }
     },
-    "node_modules/@react-native-community/cli-plugin-metro/node_modules/metro-react-native-babel-transformer": {
-      "version": "0.72.3",
-      "resolved": "https://registry.npmjs.org/metro-react-native-babel-transformer/-/metro-react-native-babel-transformer-0.72.3.tgz",
-      "integrity": "sha512-Ogst/M6ujYrl/+9mpEWqE3zF7l2mTuftDTy3L8wZYwX1pWUQWQpfU1aJBeWiLxt1XlIq+uriRjKzKoRoIK57EA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/core": "^7.14.0",
-        "babel-preset-fbjs": "^3.4.0",
-        "hermes-parser": "0.8.0",
-        "metro-babel-transformer": "0.72.3",
-        "metro-react-native-babel-preset": "0.72.3",
-        "metro-source-map": "0.72.3",
-        "nullthrows": "^1.1.1"
-      },
-      "peerDependencies": {
-        "@babel/core": "*"
-      }
-    },
-    "node_modules/@react-native-community/cli-plugin-metro/node_modules/metro-runtime": {
-      "version": "0.72.3",
-      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.72.3.tgz",
-      "integrity": "sha512-3MhvDKfxMg2u7dmTdpFOfdR71NgNNo4tzAyJumDVQKwnHYHN44f2QFZQqpPBEmqhWlojNeOxsqFsjYgeyMx6VA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "react-refresh": "^0.4.0"
-      }
-    },
-    "node_modules/@react-native-community/cli-plugin-metro/node_modules/metro-source-map": {
-      "version": "0.72.3",
-      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.72.3.tgz",
-      "integrity": "sha512-eNtpjbjxSheXu/jYCIDrbNEKzMGOvYW6/ePYpRM7gDdEagUOqKOCsi3St8NJIQJzZCsxD2JZ2pYOiomUSkT1yQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/traverse": "^7.14.0",
-        "@babel/types": "^7.0.0",
-        "invariant": "^2.2.4",
-        "metro-symbolicate": "0.72.3",
-        "nullthrows": "^1.1.1",
-        "ob1": "0.72.3",
-        "source-map": "^0.5.6",
-        "vlq": "^1.0.0"
-      }
-    },
-    "node_modules/@react-native-community/cli-plugin-metro/node_modules/ob1": {
-      "version": "0.72.3",
-      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.72.3.tgz",
-      "integrity": "sha512-OnVto25Sj7Ghp0vVm2THsngdze3tVq0LOg9LUHsAVXMecpqOP0Y8zaATW8M9gEgs2lNEAcCqV0P/hlmOPhVRvg==",
-      "dev": true
-    },
-    "node_modules/@react-native-community/cli-plugin-metro/node_modules/source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/@react-native-community/cli-server-api": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-server-api/-/cli-server-api-9.2.1.tgz",
-      "integrity": "sha512-EI+9MUxEbWBQhWw2PkhejXfkcRqPl+58+whlXJvKHiiUd7oVbewFs0uLW0yZffUutt4FGx6Uh88JWEgwOzAdkw==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-server-api/-/cli-server-api-10.1.1.tgz",
+      "integrity": "sha512-NZDo/wh4zlm8as31UEBno2bui8+ufzsZV+KN7QjEJWEM0levzBtxaD+4je0OpfhRIIkhaRm2gl/vVf7OYAzg4g==",
       "dev": true,
       "dependencies": {
-        "@react-native-community/cli-debugger-ui": "^9.0.0",
-        "@react-native-community/cli-tools": "^9.2.1",
+        "@react-native-community/cli-debugger-ui": "^10.0.0",
+        "@react-native-community/cli-tools": "^10.1.1",
         "compression": "^1.7.1",
         "connect": "^3.6.5",
         "errorhandler": "^1.5.0",
@@ -2963,9 +2924,9 @@
       "dev": true
     },
     "node_modules/@react-native-community/cli-tools": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-9.2.1.tgz",
-      "integrity": "sha512-bHmL/wrKmBphz25eMtoJQgwwmeCylbPxqFJnFSbkqJPXQz3ManQ6q/gVVMqFyz7D3v+riaus/VXz3sEDa97uiQ==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-10.1.1.tgz",
+      "integrity": "sha512-+FlwOnZBV+ailEzXjcD8afY2ogFEBeHOw/8+XXzMgPaquU2Zly9B+8W089tnnohO3yfiQiZqkQlElP423MY74g==",
       "dev": true,
       "dependencies": {
         "appdirsjs": "^1.2.4",
@@ -3059,18 +3020,18 @@
       }
     },
     "node_modules/@react-native-community/cli-types": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-types/-/cli-types-9.1.0.tgz",
-      "integrity": "sha512-KDybF9XHvafLEILsbiKwz5Iobd+gxRaPyn4zSaAerBxedug4er5VUWa8Szy+2GeYKZzMh/gsb1o9lCToUwdT/g==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-types/-/cli-types-10.0.0.tgz",
+      "integrity": "sha512-31oUM6/rFBZQfSmDQsT1DX/5fjqfxg7sf2u8kTPJK7rXVya5SRpAMaCXsPAG0omsmJxXt+J9HxUi3Ic+5Ux5Iw==",
       "dev": true,
       "dependencies": {
         "joi": "^17.2.1"
       }
     },
     "node_modules/@react-native-community/cli/node_modules/commander": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.1.tgz",
-      "integrity": "sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==",
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
       "dev": true,
       "engines": {
         "node": "^12.20.0 || >=14"
@@ -3192,9 +3153,9 @@
       "dev": true
     },
     "node_modules/@react-native/normalize-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@react-native/normalize-color/-/normalize-color-2.0.0.tgz",
-      "integrity": "sha512-Wip/xsc5lw8vsBlmY2MO/gFLp3MvuZ2baBZjDeTjjndMgM0h5sxz7AZR62RDPGgstp8Np7JzjvVqVT7tpFZqsw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@react-native/normalize-color/-/normalize-color-2.1.0.tgz",
+      "integrity": "sha512-Z1jQI2NpdFJCVgpY+8Dq/Bt3d+YUi1928Q+/CZm/oh66fzM0RUl54vvuXlPJKybH4pdCZey1eDTPaLHkMPNgWA==",
       "dev": true
     },
     "node_modules/@react-native/polyfills": {
@@ -3213,15 +3174,21 @@
       }
     },
     "node_modules/@sideway/formula": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
-      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==",
       "dev": true
     },
     "node_modules/@sideway/pinpoint": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
+      "dev": true
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.25.22",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.22.tgz",
+      "integrity": "sha512-6U6r2L7rnM7EG8G1tWzIjdB3QlsHF4slgcqXNN/SF0xJOAr0nDmT2GedlkyO3mrv8mDTJ24UuOMWR3diBrCvQQ==",
       "dev": true
     },
     "node_modules/@sinonjs/commons": {
@@ -4233,7 +4200,7 @@
     "node_modules/asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true
     },
     "node_modules/ascii-table": {
@@ -4269,9 +4236,9 @@
       "dev": true
     },
     "node_modules/ast-types/node_modules/tslib": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
       "dev": true
     },
     "node_modules/astral-regex": {
@@ -5770,9 +5737,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.6.tgz",
-      "integrity": "sha512-zZbY5giJAinCG+7AGaw0wIhNZ6J8AhWuSXKvuc1KAyMiRsvGQWqh4L+MomvhdAYjN+lqvVCMq1I41e3YHvXkyQ==",
+      "version": "1.11.7",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.7.tgz",
+      "integrity": "sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ==",
       "dev": true
     },
     "node_modules/debug": {
@@ -5948,6 +5915,17 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/deprecated-react-native-prop-types": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deprecated-react-native-prop-types/-/deprecated-react-native-prop-types-3.0.1.tgz",
+      "integrity": "sha512-J0jCJcsk4hMlIb7xwOZKLfMpuJn6l8UtrPEzzQV5ewz5gvKNYakhBuq9h2rWX7YwHHJZFhU5W8ye7dB9oN8VcQ==",
+      "dev": true,
+      "dependencies": {
+        "@react-native/normalize-color": "*",
+        "invariant": "*",
+        "prop-types": "*"
       }
     },
     "node_modules/destroy": {
@@ -8063,9 +8041,9 @@
       "dev": true
     },
     "node_modules/flow-parser": {
-      "version": "0.121.0",
-      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.121.0.tgz",
-      "integrity": "sha512-1gIBiWJNR0tKUNv8gZuk7l9rVX06OuLzY9AoGio7y/JT4V1IZErEMEq2TJS+PFcw/y0RshZ1J/27VfK1UQzYVg==",
+      "version": "0.185.2",
+      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.185.2.tgz",
+      "integrity": "sha512-2hJ5ACYeJCzNtiVULov6pljKOLygy0zddoqSI1fFetM+XRPpRshFdGEijtqlamA1XwyZ+7rhryI6FQFzvtLWUQ==",
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
@@ -10626,15 +10604,15 @@
       }
     },
     "node_modules/joi": {
-      "version": "17.7.0",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.7.0.tgz",
-      "integrity": "sha512-1/ugc8djfn93rTE3WRKdCzGGt/EtiYKxITMO4Wiv6q5JL1gl9ePt4kBsl1S499nbosspfctIQTpYIhSmHA3WAg==",
+      "version": "17.7.1",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.7.1.tgz",
+      "integrity": "sha512-teoLhIvWE298R6AeJywcjR4sX2hHjB3/xJX4qPjg+gTg+c0mzUDsziYlqPmLomq9gVsfaMcgPaGc7VxtD/9StA==",
       "dev": true,
       "dependencies": {
         "@hapi/hoek": "^9.0.0",
         "@hapi/topo": "^5.0.0",
         "@sideway/address": "^4.1.3",
-        "@sideway/formula": "^3.0.0",
+        "@sideway/formula": "^3.0.1",
         "@sideway/pinpoint": "^2.0.0"
       }
     },
@@ -11089,9 +11067,9 @@
       "dev": true
     },
     "node_modules/json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
       "bin": {
         "json5": "lib/cli.js"
@@ -11129,15 +11107,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/klaw": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
-      "integrity": "sha512-TED5xi9gGQjGpNnvRWknrwAB1eL5GciPfVFOt3Vk1OJCVDQbzuSfrF3hkUQKlsgKrG1F+0t5W0m+Fje1jIt8rw==",
-      "dev": true,
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.9"
       }
     },
     "node_modules/kleur": {
@@ -11288,12 +11257,6 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
       "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=",
-      "dev": true
-    },
-    "node_modules/lodash.sortby": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
     },
     "node_modules/lodash.throttle": {
@@ -11478,18 +11441,18 @@
       "dev": true
     },
     "node_modules/metro": {
-      "version": "0.72.3",
-      "resolved": "https://registry.npmjs.org/metro/-/metro-0.72.3.tgz",
-      "integrity": "sha512-Hb3xTvPqex8kJ1hutQNZhQadUKUwmns/Du9GikmWKBFrkiG3k3xstGAyO5t5rN9JSUEzQT6y9SWzSSOGogUKIg==",
+      "version": "0.73.7",
+      "resolved": "https://registry.npmjs.org/metro/-/metro-0.73.7.tgz",
+      "integrity": "sha512-pkRqFhuGUvkiu8HxKPUQelbCuyy6te6okMssTyLzQwsKilNLK4YMI2uD6PHnypg5SiMJ58lwfqkp/t5w72jEvw==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
-        "@babel/core": "^7.14.0",
-        "@babel/generator": "^7.14.0",
-        "@babel/parser": "^7.14.0",
+        "@babel/core": "^7.20.0",
+        "@babel/generator": "^7.20.0",
+        "@babel/parser": "^7.20.0",
         "@babel/template": "^7.0.0",
-        "@babel/traverse": "^7.14.0",
-        "@babel/types": "^7.0.0",
+        "@babel/traverse": "^7.20.0",
+        "@babel/types": "^7.20.0",
         "absolute-path": "^0.0.0",
         "accepts": "^1.3.7",
         "async": "^3.2.2",
@@ -11499,142 +11462,116 @@
         "debug": "^2.2.0",
         "denodeify": "^1.2.1",
         "error-stack-parser": "^2.0.6",
-        "fs-extra": "^1.0.0",
         "graceful-fs": "^4.2.4",
         "hermes-parser": "0.8.0",
         "image-size": "^0.6.0",
         "invariant": "^2.2.4",
         "jest-worker": "^27.2.0",
         "lodash.throttle": "^4.1.1",
-        "metro-babel-transformer": "0.72.3",
-        "metro-cache": "0.72.3",
-        "metro-cache-key": "0.72.3",
-        "metro-config": "0.72.3",
-        "metro-core": "0.72.3",
-        "metro-file-map": "0.72.3",
-        "metro-hermes-compiler": "0.72.3",
-        "metro-inspector-proxy": "0.72.3",
-        "metro-minify-uglify": "0.72.3",
-        "metro-react-native-babel-preset": "0.72.3",
-        "metro-resolver": "0.72.3",
-        "metro-runtime": "0.72.3",
-        "metro-source-map": "0.72.3",
-        "metro-symbolicate": "0.72.3",
-        "metro-transform-plugins": "0.72.3",
-        "metro-transform-worker": "0.72.3",
+        "metro-babel-transformer": "0.73.7",
+        "metro-cache": "0.73.7",
+        "metro-cache-key": "0.73.7",
+        "metro-config": "0.73.7",
+        "metro-core": "0.73.7",
+        "metro-file-map": "0.73.7",
+        "metro-hermes-compiler": "0.73.7",
+        "metro-inspector-proxy": "0.73.7",
+        "metro-minify-terser": "0.73.7",
+        "metro-minify-uglify": "0.73.7",
+        "metro-react-native-babel-preset": "0.73.7",
+        "metro-resolver": "0.73.7",
+        "metro-runtime": "0.73.7",
+        "metro-source-map": "0.73.7",
+        "metro-symbolicate": "0.73.7",
+        "metro-transform-plugins": "0.73.7",
+        "metro-transform-worker": "0.73.7",
         "mime-types": "^2.1.27",
         "node-fetch": "^2.2.0",
         "nullthrows": "^1.1.1",
-        "rimraf": "^2.5.4",
+        "rimraf": "^3.0.2",
         "serialize-error": "^2.1.0",
         "source-map": "^0.5.6",
         "strip-ansi": "^6.0.0",
         "temp": "0.8.3",
         "throat": "^5.0.0",
         "ws": "^7.5.1",
-        "yargs": "^15.3.1"
+        "yargs": "^17.5.1"
       },
       "bin": {
         "metro": "src/cli.js"
       }
     },
     "node_modules/metro-babel-transformer": {
-      "version": "0.72.3",
-      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.72.3.tgz",
-      "integrity": "sha512-PTOR2zww0vJbWeeM3qN90WKENxCLzv9xrwWaNtwVlhcV8/diNdNe82sE1xIxLFI6OQuAVwNMv1Y7VsO2I7Ejrw==",
+      "version": "0.73.7",
+      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.73.7.tgz",
+      "integrity": "sha512-s7UVkwovGTEXYEQrv5hcmSBbFJ9s9lhCRNMScn4Itgj3UMdqRr9lU8DXKEFlJ7osgRxN6n5+eXqcvhE4B1H1VQ==",
       "dev": true,
       "dependencies": {
-        "@babel/core": "^7.14.0",
+        "@babel/core": "^7.20.0",
         "hermes-parser": "0.8.0",
-        "metro-source-map": "0.72.3",
+        "metro-source-map": "0.73.7",
         "nullthrows": "^1.1.1"
       }
     },
-    "node_modules/metro-babel-transformer/node_modules/metro-source-map": {
-      "version": "0.72.3",
-      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.72.3.tgz",
-      "integrity": "sha512-eNtpjbjxSheXu/jYCIDrbNEKzMGOvYW6/ePYpRM7gDdEagUOqKOCsi3St8NJIQJzZCsxD2JZ2pYOiomUSkT1yQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/traverse": "^7.14.0",
-        "@babel/types": "^7.0.0",
-        "invariant": "^2.2.4",
-        "metro-symbolicate": "0.72.3",
-        "nullthrows": "^1.1.1",
-        "ob1": "0.72.3",
-        "source-map": "^0.5.6",
-        "vlq": "^1.0.0"
-      }
-    },
-    "node_modules/metro-babel-transformer/node_modules/ob1": {
-      "version": "0.72.3",
-      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.72.3.tgz",
-      "integrity": "sha512-OnVto25Sj7Ghp0vVm2THsngdze3tVq0LOg9LUHsAVXMecpqOP0Y8zaATW8M9gEgs2lNEAcCqV0P/hlmOPhVRvg==",
-      "dev": true
-    },
-    "node_modules/metro-babel-transformer/node_modules/source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/metro-cache": {
-      "version": "0.72.3",
-      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.72.3.tgz",
-      "integrity": "sha512-++eyZzwkXvijWRV3CkDbueaXXGlVzH9GA52QWqTgAOgSHYp5jWaDwLQ8qpsMkQzpwSyIF4LLK9aI3eA7Xa132A==",
+      "version": "0.73.7",
+      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.73.7.tgz",
+      "integrity": "sha512-CPPgI+i9yVzOEDCdmEEZ67JgOvZyNDs8kStmGUFgDuLSjj3//HhkqT5XyfWjGeH6KmyGiS8ip3cgLOVn3IsOSA==",
       "dev": true,
       "dependencies": {
-        "metro-core": "0.72.3",
-        "rimraf": "^2.5.4"
+        "metro-core": "0.73.7",
+        "rimraf": "^3.0.2"
       }
     },
     "node_modules/metro-cache-key": {
-      "version": "0.72.3",
-      "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.72.3.tgz",
-      "integrity": "sha512-kQzmF5s3qMlzqkQcDwDxrOaVxJ2Bh6WRXWdzPnnhsq9LcD3B3cYqQbRBS+3tSuXmathb4gsOdhWslOuIsYS8Rg==",
+      "version": "0.73.7",
+      "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.73.7.tgz",
+      "integrity": "sha512-GngYzrHwZU9U0Xl81H4aq9Tn5cjQyU12v9/flB0hzpeiYO5A89TIeilb4Kg8jtfC6JcmmsdK9nxYIGEq7odHhQ==",
       "dev": true
     },
+    "node_modules/metro-cache/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/metro-config": {
-      "version": "0.72.3",
-      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.72.3.tgz",
-      "integrity": "sha512-VEsAIVDkrIhgCByq8HKTWMBjJG6RlYwWSu1Gnv3PpHa0IyTjKJtB7wC02rbTjSaemcr82scldf2R+h6ygMEvsw==",
+      "version": "0.73.7",
+      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.73.7.tgz",
+      "integrity": "sha512-pD/F+vK3u37cbj1skYmI6cUsEEscqNRtW2KlDKu1m+n8nooDB2oGTOZatlS5WQa7Ga6jYQRydftlq4CLDexAfA==",
       "dev": true,
       "dependencies": {
         "cosmiconfig": "^5.0.5",
         "jest-validate": "^26.5.2",
-        "metro": "0.72.3",
-        "metro-cache": "0.72.3",
-        "metro-core": "0.72.3",
-        "metro-runtime": "0.72.3"
-      }
-    },
-    "node_modules/metro-config/node_modules/metro-runtime": {
-      "version": "0.72.3",
-      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.72.3.tgz",
-      "integrity": "sha512-3MhvDKfxMg2u7dmTdpFOfdR71NgNNo4tzAyJumDVQKwnHYHN44f2QFZQqpPBEmqhWlojNeOxsqFsjYgeyMx6VA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "react-refresh": "^0.4.0"
+        "metro": "0.73.7",
+        "metro-cache": "0.73.7",
+        "metro-core": "0.73.7",
+        "metro-runtime": "0.73.7"
       }
     },
     "node_modules/metro-core": {
-      "version": "0.72.3",
-      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.72.3.tgz",
-      "integrity": "sha512-KuYWBMmLB4+LxSMcZ1dmWabVExNCjZe3KysgoECAIV+wyIc2r4xANq15GhS94xYvX1+RqZrxU1pa0jQ5OK+/6A==",
+      "version": "0.73.7",
+      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.73.7.tgz",
+      "integrity": "sha512-H7j1Egj1VnNnsSYf9ZKv0SRwijgtRKIcaGNQq/T+er73vqqb4kR9H+2VIJYPXi6R8lT+QLIMfs6CWSUHAJUgtg==",
       "dev": true,
       "dependencies": {
         "lodash.throttle": "^4.1.1",
-        "metro-resolver": "0.72.3"
+        "metro-resolver": "0.73.7"
       }
     },
     "node_modules/metro-file-map": {
-      "version": "0.72.3",
-      "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.72.3.tgz",
-      "integrity": "sha512-LhuRnuZ2i2uxkpFsz1XCDIQSixxBkBG7oICAFyLyEMDGbcfeY6/NexphfLdJLTghkaoJR5ARFMiIxUg9fIY/pA==",
+      "version": "0.73.7",
+      "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.73.7.tgz",
+      "integrity": "sha512-BYaCo2e/4FMN4nOajeN+Za5cPfecfikzUYuFWWMyLAmHU6dj7B+PFkaJ4OEJO3vmRoeq5vMOmhpKXgysYbNXJg==",
       "dev": true,
       "dependencies": {
         "abort-controller": "^3.0.0",
@@ -11648,10 +11585,11 @@
         "jest-util": "^27.2.0",
         "jest-worker": "^27.2.0",
         "micromatch": "^4.0.4",
+        "nullthrows": "^1.1.1",
         "walker": "^1.0.7"
       },
       "optionalDependencies": {
-        "fsevents": "^2.1.2"
+        "fsevents": "^2.3.2"
       }
     },
     "node_modules/metro-file-map/node_modules/@jest/types": {
@@ -11671,19 +11609,25 @@
       }
     },
     "node_modules/metro-file-map/node_modules/@types/yargs": {
-      "version": "16.0.4",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
-      "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
+      "version": "16.0.5",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.5.tgz",
+      "integrity": "sha512-AxO/ADJOBFJScHbWhq2xAhlWP24rY4aCEG/NFaMvbT3X2MgRsLjhjQwsn0Zi5zn0LG9jUhCCZMeX9Dkuw6k+vQ==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
       }
     },
     "node_modules/metro-file-map/node_modules/ci-info": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.6.1.tgz",
-      "integrity": "sha512-up5ggbaDqOqJ4UqLKZ2naVkyqSJQgJi5lwD6b6mM748ysrghDBX0bx/qJTUHzw7zu6Mq4gycviSF5hJnwceD8w==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.8.0.tgz",
+      "integrity": "sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
       "engines": {
         "node": ">=8"
       }
@@ -11781,25 +11725,72 @@
       }
     },
     "node_modules/metro-hermes-compiler": {
-      "version": "0.72.3",
-      "resolved": "https://registry.npmjs.org/metro-hermes-compiler/-/metro-hermes-compiler-0.72.3.tgz",
-      "integrity": "sha512-QWDQASMiXNW3j8uIQbzIzCdGYv5PpAX/ZiF4/lTWqKRWuhlkP4auhVY4eqdAKj5syPx45ggpjkVE0p8hAPDZYg==",
+      "version": "0.73.7",
+      "resolved": "https://registry.npmjs.org/metro-hermes-compiler/-/metro-hermes-compiler-0.73.7.tgz",
+      "integrity": "sha512-F8PlJ8mWEEumGNH3eMRA3gjgP70ZvH4Ex5F1KY6ofD/gpn7w5HJHSPTeVw8gtUb1pYLN4nevptpyXGg04Jfcog==",
       "dev": true
     },
     "node_modules/metro-inspector-proxy": {
-      "version": "0.72.3",
-      "resolved": "https://registry.npmjs.org/metro-inspector-proxy/-/metro-inspector-proxy-0.72.3.tgz",
-      "integrity": "sha512-UPFkaq2k93RaOi+eqqt7UUmqy2ywCkuxJLasQ55+xavTUS+TQSyeTnTczaYn+YKw+izLTLllGcvqnQcZiWYhGw==",
+      "version": "0.73.7",
+      "resolved": "https://registry.npmjs.org/metro-inspector-proxy/-/metro-inspector-proxy-0.73.7.tgz",
+      "integrity": "sha512-TsAtQeKr9X7NaQHlpshu+ZkGWlPi5fFKNqieLkfqvT1oXN4PQF/4q38INyiZtWLPvoUzTR6PRnm4pcUbJ7+Nzg==",
       "dev": true,
       "dependencies": {
         "connect": "^3.6.5",
         "debug": "^2.2.0",
         "ws": "^7.5.1",
-        "yargs": "^15.3.1"
+        "yargs": "^17.5.1"
       },
       "bin": {
         "metro-inspector-proxy": "src/cli.js"
       }
+    },
+    "node_modules/metro-inspector-proxy/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/metro-inspector-proxy/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/metro-inspector-proxy/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/metro-inspector-proxy/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/metro-inspector-proxy/node_modules/debug": {
       "version": "2.6.9",
@@ -11810,16 +11801,107 @@
         "ms": "2.0.0"
       }
     },
+    "node_modules/metro-inspector-proxy/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/metro-inspector-proxy/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/metro-inspector-proxy/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true
     },
+    "node_modules/metro-inspector-proxy/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/metro-inspector-proxy/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/metro-inspector-proxy/node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/metro-inspector-proxy/node_modules/yargs": {
+      "version": "17.6.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
+      "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/metro-inspector-proxy/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/metro-minify-terser": {
+      "version": "0.73.7",
+      "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.73.7.tgz",
+      "integrity": "sha512-gbv1fmMOZm6gJ6dQoD+QktlCi2wk6nlTR8j8lQCjeeXGbs6O9e5XLWNPOexHqo7S69bdbohEnfZnLJFcxgHeNw==",
+      "dev": true,
+      "dependencies": {
+        "terser": "^5.15.0"
+      }
+    },
     "node_modules/metro-minify-uglify": {
-      "version": "0.72.3",
-      "resolved": "https://registry.npmjs.org/metro-minify-uglify/-/metro-minify-uglify-0.72.3.tgz",
-      "integrity": "sha512-dPXqtMI8TQcj0g7ZrdhC8X3mx3m3rtjtMuHKGIiEXH9CMBvrET8IwrgujQw2rkPcXiSiX8vFDbGMIlfxefDsKA==",
+      "version": "0.73.7",
+      "resolved": "https://registry.npmjs.org/metro-minify-uglify/-/metro-minify-uglify-0.73.7.tgz",
+      "integrity": "sha512-DmDCzfdbaPExQuQ7NQozCNOSOAgp5Ux9kWzmKAT8seQ38/3NtUepW+PTgxXIHmwNjJV4oHsHwlBlTwJmYihKXg==",
       "dev": true,
       "dependencies": {
         "uglify-es": "^3.1.9"
@@ -11876,42 +11958,30 @@
       }
     },
     "node_modules/metro-react-native-babel-transformer": {
-      "version": "0.72.1",
-      "resolved": "https://registry.npmjs.org/metro-react-native-babel-transformer/-/metro-react-native-babel-transformer-0.72.1.tgz",
-      "integrity": "sha512-hMnN0MOgVloAk94YuXN7sLeDaZ51Y6xIcJXxIU1s/KaygAGXk6o7VAdwf2MY/IV1SIct5lkW4Gn71u/9/EvfXA==",
+      "version": "0.73.7",
+      "resolved": "https://registry.npmjs.org/metro-react-native-babel-transformer/-/metro-react-native-babel-transformer-0.73.7.tgz",
+      "integrity": "sha512-73HW8betjX+VPm3iqsMBe8F/F2Tt+hONO6YJwcF7FonTqQYW1oTz0dOp0dClZGfHUXxpJBz6Vuo7J6TpdzDD+w==",
       "dev": true,
       "dependencies": {
-        "@babel/core": "^7.14.0",
+        "@babel/core": "^7.20.0",
         "babel-preset-fbjs": "^3.4.0",
         "hermes-parser": "0.8.0",
-        "metro-babel-transformer": "0.72.1",
-        "metro-react-native-babel-preset": "0.72.1",
-        "metro-source-map": "0.72.1",
+        "metro-babel-transformer": "0.73.7",
+        "metro-react-native-babel-preset": "0.73.7",
+        "metro-source-map": "0.73.7",
         "nullthrows": "^1.1.1"
       },
       "peerDependencies": {
         "@babel/core": "*"
       }
     },
-    "node_modules/metro-react-native-babel-transformer/node_modules/metro-babel-transformer": {
-      "version": "0.72.1",
-      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.72.1.tgz",
-      "integrity": "sha512-VK7A9gepnhrKC0DMoxtPjYYHjkkfNwzLMYJgeL6Il6IaX/K/VHTILSEqgpxfNDos2jrXazuR5+rXDLE/RCzqmw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/core": "^7.14.0",
-        "hermes-parser": "0.8.0",
-        "metro-source-map": "0.72.1",
-        "nullthrows": "^1.1.1"
-      }
-    },
     "node_modules/metro-react-native-babel-transformer/node_modules/metro-react-native-babel-preset": {
-      "version": "0.72.1",
-      "resolved": "https://registry.npmjs.org/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.72.1.tgz",
-      "integrity": "sha512-DlvMw2tFrCqD9OXBoN11fPM09kHC22FZpnkTmG4Pr4kecV+aDmEGxwakjUcjELrX1JCXz2MLPvqeJkbiP1f5CA==",
+      "version": "0.73.7",
+      "resolved": "https://registry.npmjs.org/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.73.7.tgz",
+      "integrity": "sha512-RKcmRZREjJCzHKP+JhC9QTCohkeb3xa/DtqHU14U5KWzJHdC0mMrkTZYNXhV0cryxsaVKVEw5873KhbZyZHMVw==",
       "dev": true,
       "dependencies": {
-        "@babel/core": "^7.14.0",
+        "@babel/core": "^7.20.0",
         "@babel/plugin-proposal-async-generator-functions": "^7.0.0",
         "@babel/plugin-proposal-class-properties": "^7.0.0",
         "@babel/plugin-proposal-export-default-from": "^7.0.0",
@@ -11921,7 +11991,7 @@
         "@babel/plugin-proposal-optional-chaining": "^7.0.0",
         "@babel/plugin-syntax-dynamic-import": "^7.0.0",
         "@babel/plugin-syntax-export-default-from": "^7.0.0",
-        "@babel/plugin-syntax-flow": "^7.2.0",
+        "@babel/plugin-syntax-flow": "^7.18.0",
         "@babel/plugin-syntax-nullish-coalescing-operator": "^7.0.0",
         "@babel/plugin-syntax-optional-chaining": "^7.0.0",
         "@babel/plugin-transform-arrow-functions": "^7.0.0",
@@ -11930,7 +12000,6 @@
         "@babel/plugin-transform-classes": "^7.0.0",
         "@babel/plugin-transform-computed-properties": "^7.0.0",
         "@babel/plugin-transform-destructuring": "^7.0.0",
-        "@babel/plugin-transform-exponentiation-operator": "^7.0.0",
         "@babel/plugin-transform-flow-strip-types": "^7.0.0",
         "@babel/plugin-transform-function-name": "^7.0.0",
         "@babel/plugin-transform-literals": "^7.0.0",
@@ -11956,18 +12025,18 @@
       }
     },
     "node_modules/metro-resolver": {
-      "version": "0.72.3",
-      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.72.3.tgz",
-      "integrity": "sha512-wu9zSMGdxpKmfECE7FtCdpfC+vrWGTdVr57lDA0piKhZV6VN6acZIvqQ1yZKtS2WfKsngncv5VbB8Y5eHRQP3w==",
+      "version": "0.73.7",
+      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.73.7.tgz",
+      "integrity": "sha512-mGW3XPeKBCwZnkHcKo1dhFa9olcx7SyNzG1vb5kjzJYe4Qs3yx04r/qFXIJLcIgLItB69TIGvosznUhpeOOXzg==",
       "dev": true,
       "dependencies": {
         "absolute-path": "^0.0.0"
       }
     },
     "node_modules/metro-runtime": {
-      "version": "0.72.1",
-      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.72.1.tgz",
-      "integrity": "sha512-CO+fvJKYHKuR2vo7kjsegQ2oF3FMwa4YhnUInQ+xPVxWoy8DbOpmruKBoTsQVgHwyIziXzvJa+mze/6CFvT+3A==",
+      "version": "0.73.7",
+      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.73.7.tgz",
+      "integrity": "sha512-2fxRGrF8FyrwwHY0TCitdUljzutfW6CWEpdvPilfrs8p0PI5X8xOWg8ficeYtw+DldHtHIAL2phT59PqzHTyVA==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.0.0",
@@ -11975,39 +12044,19 @@
       }
     },
     "node_modules/metro-source-map": {
-      "version": "0.72.1",
-      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.72.1.tgz",
-      "integrity": "sha512-77TZuf10Ru+USo97HwDT8UceSzOGBZB8EYTObOsR0n1sjQHjvKsMflLA9Pco13o9NsIYAG6c6P/0vIpiHKqaKA==",
+      "version": "0.73.7",
+      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.73.7.tgz",
+      "integrity": "sha512-gbC/lfUN52TtQhEsTTA+987MaFUpQlufuCI05blLGLosDcFCsARikHsxa65Gtslm/rG2MqvFLiPA5hviONNv9g==",
       "dev": true,
       "dependencies": {
-        "@babel/traverse": "^7.14.0",
-        "@babel/types": "^7.0.0",
+        "@babel/traverse": "^7.20.0",
+        "@babel/types": "^7.20.0",
         "invariant": "^2.2.4",
-        "metro-symbolicate": "0.72.1",
+        "metro-symbolicate": "0.73.7",
         "nullthrows": "^1.1.1",
-        "ob1": "0.72.1",
+        "ob1": "0.73.7",
         "source-map": "^0.5.6",
         "vlq": "^1.0.0"
-      }
-    },
-    "node_modules/metro-source-map/node_modules/metro-symbolicate": {
-      "version": "0.72.1",
-      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.72.1.tgz",
-      "integrity": "sha512-ScC3dVd2XrfZSd6kubOw7EJNp2oHdjrqOjGpFohtcXGjhqkzDosp7Fg84VgwQGN8g720xvUyEBfSMmUCXcicOQ==",
-      "dev": true,
-      "dependencies": {
-        "invariant": "^2.2.4",
-        "metro-source-map": "0.72.1",
-        "nullthrows": "^1.1.1",
-        "source-map": "^0.5.6",
-        "through2": "^2.0.1",
-        "vlq": "^1.0.0"
-      },
-      "bin": {
-        "metro-symbolicate": "src/index.js"
-      },
-      "engines": {
-        "node": ">=8.3"
       }
     },
     "node_modules/metro-source-map/node_modules/source-map": {
@@ -12020,13 +12069,13 @@
       }
     },
     "node_modules/metro-symbolicate": {
-      "version": "0.72.3",
-      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.72.3.tgz",
-      "integrity": "sha512-eXG0NX2PJzJ/jTG4q5yyYeN2dr1cUqUaY7worBB0SP5bRWRc3besfb+rXwfh49wTFiL5qR0oOawkU4ZiD4eHXw==",
+      "version": "0.73.7",
+      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.73.7.tgz",
+      "integrity": "sha512-571ThWmX5o8yGNzoXjlcdhmXqpByHU/bSZtWKhtgV2TyIAzYCYt4hawJAS5+/qDazUvjHdm8BbdqFUheM0EKNQ==",
       "dev": true,
       "dependencies": {
         "invariant": "^2.2.4",
-        "metro-source-map": "0.72.3",
+        "metro-source-map": "0.73.7",
         "nullthrows": "^1.1.1",
         "source-map": "^0.5.6",
         "through2": "^2.0.1",
@@ -12039,28 +12088,6 @@
         "node": ">=8.3"
       }
     },
-    "node_modules/metro-symbolicate/node_modules/metro-source-map": {
-      "version": "0.72.3",
-      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.72.3.tgz",
-      "integrity": "sha512-eNtpjbjxSheXu/jYCIDrbNEKzMGOvYW6/ePYpRM7gDdEagUOqKOCsi3St8NJIQJzZCsxD2JZ2pYOiomUSkT1yQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/traverse": "^7.14.0",
-        "@babel/types": "^7.0.0",
-        "invariant": "^2.2.4",
-        "metro-symbolicate": "0.72.3",
-        "nullthrows": "^1.1.1",
-        "ob1": "0.72.3",
-        "source-map": "^0.5.6",
-        "vlq": "^1.0.0"
-      }
-    },
-    "node_modules/metro-symbolicate/node_modules/ob1": {
-      "version": "0.72.3",
-      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.72.3.tgz",
-      "integrity": "sha512-OnVto25Sj7Ghp0vVm2THsngdze3tVq0LOg9LUHsAVXMecpqOP0Y8zaATW8M9gEgs2lNEAcCqV0P/hlmOPhVRvg==",
-      "dev": true
-    },
     "node_modules/metro-symbolicate/node_modules/source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -12071,69 +12098,85 @@
       }
     },
     "node_modules/metro-transform-plugins": {
-      "version": "0.72.3",
-      "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.72.3.tgz",
-      "integrity": "sha512-D+TcUvCKZbRua1+qujE0wV1onZvslW6cVTs7dLCyC2pv20lNHjFr1GtW01jN2fyKR2PcRyMjDCppFd9VwDKnSg==",
+      "version": "0.73.7",
+      "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.73.7.tgz",
+      "integrity": "sha512-M5isiWEau0jMudb5ezaNBZnYqXxcATMqnAYc+Cu25IahT1NHi5aWwLok9EBmBpN5641IZUZXScf+KnS7fPxPCQ==",
       "dev": true,
       "dependencies": {
-        "@babel/core": "^7.14.0",
-        "@babel/generator": "^7.14.0",
+        "@babel/core": "^7.20.0",
+        "@babel/generator": "^7.20.0",
         "@babel/template": "^7.0.0",
-        "@babel/traverse": "^7.14.0",
+        "@babel/traverse": "^7.20.0",
         "nullthrows": "^1.1.1"
       }
     },
     "node_modules/metro-transform-worker": {
-      "version": "0.72.3",
-      "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.72.3.tgz",
-      "integrity": "sha512-WsuWj9H7i6cHuJuy+BgbWht9DK5FOgJxHLGAyULD5FJdTG9rSMFaHDO5WfC0OwQU5h4w6cPT40iDuEGksM7+YQ==",
+      "version": "0.73.7",
+      "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.73.7.tgz",
+      "integrity": "sha512-gZYIu9JAqEI9Rxi0xGMuMW6QsHGbMSptozlTOwOd7T7yXX3WwYS/I3yLPbLhbZTjOhwMHkTt8Nhm2qBo8nh14g==",
       "dev": true,
       "dependencies": {
-        "@babel/core": "^7.14.0",
-        "@babel/generator": "^7.14.0",
-        "@babel/parser": "^7.14.0",
-        "@babel/types": "^7.0.0",
+        "@babel/core": "^7.20.0",
+        "@babel/generator": "^7.20.0",
+        "@babel/parser": "^7.20.0",
+        "@babel/types": "^7.20.0",
         "babel-preset-fbjs": "^3.4.0",
-        "metro": "0.72.3",
-        "metro-babel-transformer": "0.72.3",
-        "metro-cache": "0.72.3",
-        "metro-cache-key": "0.72.3",
-        "metro-hermes-compiler": "0.72.3",
-        "metro-source-map": "0.72.3",
-        "metro-transform-plugins": "0.72.3",
+        "metro": "0.73.7",
+        "metro-babel-transformer": "0.73.7",
+        "metro-cache": "0.73.7",
+        "metro-cache-key": "0.73.7",
+        "metro-hermes-compiler": "0.73.7",
+        "metro-source-map": "0.73.7",
+        "metro-transform-plugins": "0.73.7",
         "nullthrows": "^1.1.1"
       }
     },
-    "node_modules/metro-transform-worker/node_modules/metro-source-map": {
-      "version": "0.72.3",
-      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.72.3.tgz",
-      "integrity": "sha512-eNtpjbjxSheXu/jYCIDrbNEKzMGOvYW6/ePYpRM7gDdEagUOqKOCsi3St8NJIQJzZCsxD2JZ2pYOiomUSkT1yQ==",
+    "node_modules/metro/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "dependencies": {
-        "@babel/traverse": "^7.14.0",
-        "@babel/types": "^7.0.0",
-        "invariant": "^2.2.4",
-        "metro-symbolicate": "0.72.3",
-        "nullthrows": "^1.1.1",
-        "ob1": "0.72.3",
-        "source-map": "^0.5.6",
-        "vlq": "^1.0.0"
-      }
-    },
-    "node_modules/metro-transform-worker/node_modules/ob1": {
-      "version": "0.72.3",
-      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.72.3.tgz",
-      "integrity": "sha512-OnVto25Sj7Ghp0vVm2THsngdze3tVq0LOg9LUHsAVXMecpqOP0Y8zaATW8M9gEgs2lNEAcCqV0P/hlmOPhVRvg==",
-      "dev": true
-    },
-    "node_modules/metro-transform-worker/node_modules/source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-      "dev": true,
+        "color-convert": "^2.0.1"
+      },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/metro/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/metro/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/metro/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/metro/node_modules/debug": {
       "version": "2.6.9",
@@ -12144,21 +12187,25 @@
         "ms": "2.0.0"
       }
     },
-    "node_modules/metro/node_modules/fs-extra": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
-      "integrity": "sha512-VerQV6vEKuhDWD2HGOybV6v5I73syoc/cXAbKlgTC7M/oFVEtklWlp9QH2Ijw3IaWDOQcMkldSPa7zXy79Z/UQ==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^2.1.0",
-        "klaw": "^1.0.0"
-      }
+    "node_modules/metro/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
     },
     "node_modules/metro/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/metro/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -12178,39 +12225,53 @@
         "node": ">= 10.13.0"
       }
     },
-    "node_modules/metro/node_modules/jsonfile": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-      "integrity": "sha512-PKllAqbgLgxHaj8TElYymKCAgrASebJrWpTnEkOaTowt23VKXXN0sUeriJ+eh7y6ufb/CC5ap11pz71/cM0hUw==",
-      "dev": true,
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/metro/node_modules/metro-runtime": {
-      "version": "0.72.3",
-      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.72.3.tgz",
-      "integrity": "sha512-3MhvDKfxMg2u7dmTdpFOfdR71NgNNo4tzAyJumDVQKwnHYHN44f2QFZQqpPBEmqhWlojNeOxsqFsjYgeyMx6VA==",
+    "node_modules/metro/node_modules/metro-react-native-babel-preset": {
+      "version": "0.73.7",
+      "resolved": "https://registry.npmjs.org/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.73.7.tgz",
+      "integrity": "sha512-RKcmRZREjJCzHKP+JhC9QTCohkeb3xa/DtqHU14U5KWzJHdC0mMrkTZYNXhV0cryxsaVKVEw5873KhbZyZHMVw==",
       "dev": true,
       "dependencies": {
-        "@babel/runtime": "^7.0.0",
+        "@babel/core": "^7.20.0",
+        "@babel/plugin-proposal-async-generator-functions": "^7.0.0",
+        "@babel/plugin-proposal-class-properties": "^7.0.0",
+        "@babel/plugin-proposal-export-default-from": "^7.0.0",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.0.0",
+        "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+        "@babel/plugin-proposal-optional-catch-binding": "^7.0.0",
+        "@babel/plugin-proposal-optional-chaining": "^7.0.0",
+        "@babel/plugin-syntax-dynamic-import": "^7.0.0",
+        "@babel/plugin-syntax-export-default-from": "^7.0.0",
+        "@babel/plugin-syntax-flow": "^7.18.0",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.0.0",
+        "@babel/plugin-syntax-optional-chaining": "^7.0.0",
+        "@babel/plugin-transform-arrow-functions": "^7.0.0",
+        "@babel/plugin-transform-async-to-generator": "^7.0.0",
+        "@babel/plugin-transform-block-scoping": "^7.0.0",
+        "@babel/plugin-transform-classes": "^7.0.0",
+        "@babel/plugin-transform-computed-properties": "^7.0.0",
+        "@babel/plugin-transform-destructuring": "^7.0.0",
+        "@babel/plugin-transform-flow-strip-types": "^7.0.0",
+        "@babel/plugin-transform-function-name": "^7.0.0",
+        "@babel/plugin-transform-literals": "^7.0.0",
+        "@babel/plugin-transform-modules-commonjs": "^7.0.0",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.0.0",
+        "@babel/plugin-transform-parameters": "^7.0.0",
+        "@babel/plugin-transform-react-display-name": "^7.0.0",
+        "@babel/plugin-transform-react-jsx": "^7.0.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.0.0",
+        "@babel/plugin-transform-react-jsx-source": "^7.0.0",
+        "@babel/plugin-transform-runtime": "^7.0.0",
+        "@babel/plugin-transform-shorthand-properties": "^7.0.0",
+        "@babel/plugin-transform-spread": "^7.0.0",
+        "@babel/plugin-transform-sticky-regex": "^7.0.0",
+        "@babel/plugin-transform-template-literals": "^7.0.0",
+        "@babel/plugin-transform-typescript": "^7.5.0",
+        "@babel/plugin-transform-unicode-regex": "^7.0.0",
+        "@babel/template": "^7.0.0",
         "react-refresh": "^0.4.0"
-      }
-    },
-    "node_modules/metro/node_modules/metro-source-map": {
-      "version": "0.72.3",
-      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.72.3.tgz",
-      "integrity": "sha512-eNtpjbjxSheXu/jYCIDrbNEKzMGOvYW6/ePYpRM7gDdEagUOqKOCsi3St8NJIQJzZCsxD2JZ2pYOiomUSkT1yQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/traverse": "^7.14.0",
-        "@babel/types": "^7.0.0",
-        "invariant": "^2.2.4",
-        "metro-symbolicate": "0.72.3",
-        "nullthrows": "^1.1.1",
-        "ob1": "0.72.3",
-        "source-map": "^0.5.6",
-        "vlq": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "*"
       }
     },
     "node_modules/metro/node_modules/ms": {
@@ -12219,11 +12280,20 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true
     },
-    "node_modules/metro/node_modules/ob1": {
-      "version": "0.72.3",
-      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.72.3.tgz",
-      "integrity": "sha512-OnVto25Sj7Ghp0vVm2THsngdze3tVq0LOg9LUHsAVXMecpqOP0Y8zaATW8M9gEgs2lNEAcCqV0P/hlmOPhVRvg==",
-      "dev": true
+    "node_modules/metro/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/metro/node_modules/source-map": {
       "version": "0.5.7",
@@ -12232,6 +12302,20 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/metro/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/metro/node_modules/supports-color": {
@@ -12247,6 +12331,59 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/metro/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/metro/node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/metro/node_modules/yargs": {
+      "version": "17.6.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
+      "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/metro/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/micromatch": {
@@ -12448,9 +12585,9 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
+      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
       "dev": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
@@ -12584,9 +12721,9 @@
       "dev": true
     },
     "node_modules/ob1": {
-      "version": "0.72.1",
-      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.72.1.tgz",
-      "integrity": "sha512-TyQX2gO08klGTMuzD+xm3iVrzXiIygCB7t+NWeicOR05hkzgeWOiAZ8q40uMfIDRfEAc6hd66sJdIEhU/yUZZA==",
+      "version": "0.73.7",
+      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.73.7.tgz",
+      "integrity": "sha512-DfelfvR843KADhSUATGGhuepVMRcf5VQX+6MQLy5AW0BKDLlO7Usj6YZeAAZP7P86QwsoTxB0RXCFiA7t6S1IQ==",
       "dev": true
     },
     "node_modules/object-assign": {
@@ -13243,9 +13380,9 @@
       }
     },
     "node_modules/promise": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-8.1.0.tgz",
-      "integrity": "sha512-W04AqnILOL/sPRXziNicCjSNRruLAuIHEOVBazepu0545DDNGYHz7ar9ZgZ1fMU8/MA4mVxp5rkBWRi6OXIy3Q==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-8.3.0.tgz",
+      "integrity": "sha512-rZPNPKTOYVNEEKFaq1HqTgOwZD+4/YHS5ukLzQCypkj+OkYx7iv0mA91lJlpPPZ8vMau3IIGj5Qlwrx+8iiSmg==",
       "dev": true,
       "dependencies": {
         "asap": "~2.0.6"
@@ -13331,9 +13468,9 @@
       }
     },
     "node_modules/react": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.1.0.tgz",
-      "integrity": "sha512-4oL8ivCz5ZEPyclFQXaNksK3adutVS8l2xzZU0cqEFrE9Sb7fC0EFK5uEk74wIreL1DERyjvsU915j1pcT2uEQ==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
       "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -13343,9 +13480,9 @@
       }
     },
     "node_modules/react-devtools-core": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-4.24.0.tgz",
-      "integrity": "sha512-Rw7FzYOOzcfyUPaAm9P3g0tFdGqGq2LLiAI+wjYcp6CsF3DeeMrRS3HZAho4s273C29G/DJhx0e8BpRE/QZNGg==",
+      "version": "4.27.2",
+      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-4.27.2.tgz",
+      "integrity": "sha512-8SzmIkpO87alD7Xr6gWIEa1jHkMjawOZ+6egjazlnjB4UUcbnzGDf/vBJ4BzGuWWEM+pzrxuzsPpcMqlQkYK2g==",
       "dev": true,
       "dependencies": {
         "shell-quote": "^1.6.1",
@@ -13359,43 +13496,45 @@
       "dev": true
     },
     "node_modules/react-native": {
-      "version": "0.70.0",
-      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.70.0.tgz",
-      "integrity": "sha512-QjXLbrK9f+/B2eCzn6kAvglLV/8nwPuFGaFv7ggPpAzFRyx5bVN1dwQLHL3MrP7iXR/M7Jc6Nnid7tmRSic6vA==",
+      "version": "0.71.2",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.71.2.tgz",
+      "integrity": "sha512-ZSianM+j+09LoEdVIhrAP/uP8sQhT7dH6olCqM2xlpxmfCgA5NubsK6NABIuZiBlmmqjigyijm5Y/GhBIHDvEg==",
       "dev": true,
       "dependencies": {
-        "@jest/create-cache-key-function": "^27.0.1",
-        "@react-native-community/cli": "^9.0.0",
-        "@react-native-community/cli-platform-android": "^9.0.0",
-        "@react-native-community/cli-platform-ios": "^9.0.0",
+        "@jest/create-cache-key-function": "^29.2.1",
+        "@react-native-community/cli": "10.1.3",
+        "@react-native-community/cli-platform-android": "10.1.3",
+        "@react-native-community/cli-platform-ios": "10.1.1",
         "@react-native/assets": "1.0.0",
-        "@react-native/normalize-color": "2.0.0",
+        "@react-native/normalize-color": "2.1.0",
         "@react-native/polyfills": "2.0.0",
         "abort-controller": "^3.0.0",
         "anser": "^1.4.9",
         "base64-js": "^1.1.2",
+        "deprecated-react-native-prop-types": "^3.0.1",
         "event-target-shim": "^5.0.1",
         "invariant": "^2.2.4",
+        "jest-environment-node": "^29.2.1",
         "jsc-android": "^250230.2.1",
         "memoize-one": "^5.0.0",
-        "metro-react-native-babel-transformer": "0.72.1",
-        "metro-runtime": "0.72.1",
-        "metro-source-map": "0.72.1",
+        "metro-react-native-babel-transformer": "0.73.7",
+        "metro-runtime": "0.73.7",
+        "metro-source-map": "0.73.7",
         "mkdirp": "^0.5.1",
         "nullthrows": "^1.1.1",
         "pretty-format": "^26.5.2",
-        "promise": "^8.0.3",
-        "react-devtools-core": "4.24.0",
-        "react-native-codegen": "^0.70.4",
-        "react-native-gradle-plugin": "^0.70.2",
+        "promise": "^8.3.0",
+        "react-devtools-core": "^4.26.1",
+        "react-native-codegen": "^0.71.3",
+        "react-native-gradle-plugin": "^0.71.14",
         "react-refresh": "^0.4.0",
         "react-shallow-renderer": "^16.15.0",
         "regenerator-runtime": "^0.13.2",
-        "scheduler": "^0.22.0",
+        "scheduler": "^0.23.0",
         "stacktrace-parser": "^0.1.3",
         "use-sync-external-store": "^1.0.0",
         "whatwg-fetch": "^3.0.0",
-        "ws": "^6.1.4"
+        "ws": "^6.2.2"
       },
       "bin": {
         "react-native": "cli.js"
@@ -13404,25 +13543,25 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "react": "18.1.0"
+        "react": "18.2.0"
       }
     },
     "node_modules/react-native-codegen": {
-      "version": "0.70.6",
-      "resolved": "https://registry.npmjs.org/react-native-codegen/-/react-native-codegen-0.70.6.tgz",
-      "integrity": "sha512-kdwIhH2hi+cFnG5Nb8Ji2JwmcCxnaOOo9440ov7XDzSvGfmUStnCzl+MCW8jLjqHcE4icT7N9y+xx4f50vfBTw==",
+      "version": "0.71.5",
+      "resolved": "https://registry.npmjs.org/react-native-codegen/-/react-native-codegen-0.71.5.tgz",
+      "integrity": "sha512-rfsuc0zkuUuMjFnrT55I1mDZ+pBRp2zAiRwxck3m6qeGJBGK5OV5JH66eDQ4aa+3m0of316CqrJDRzVlYufzIg==",
       "dev": true,
       "dependencies": {
         "@babel/parser": "^7.14.0",
-        "flow-parser": "^0.121.0",
+        "flow-parser": "^0.185.0",
         "jscodeshift": "^0.13.1",
         "nullthrows": "^1.1.1"
       }
     },
     "node_modules/react-native-gradle-plugin": {
-      "version": "0.70.3",
-      "resolved": "https://registry.npmjs.org/react-native-gradle-plugin/-/react-native-gradle-plugin-0.70.3.tgz",
-      "integrity": "sha512-oOanj84fJEXUg9FoEAQomA8ISG+DVIrTZ3qF7m69VQUJyOGYyDZmPqKcjvRku4KXlEH6hWO9i4ACLzNBh8gC0A==",
+      "version": "0.71.15",
+      "resolved": "https://registry.npmjs.org/react-native-gradle-plugin/-/react-native-gradle-plugin-0.71.15.tgz",
+      "integrity": "sha512-7S3pAuPaQJlhax6EZ4JMsDNpj05TfuzX9gPgWLrFfAIWIFLuJ6aDQYAZy2TEI9QJALPoWrj8LWaqP/DGYh14pw==",
       "dev": true
     },
     "node_modules/react-native-performance": {
@@ -13435,13 +13574,106 @@
       }
     },
     "node_modules/react-native-quick-sqlite": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/react-native-quick-sqlite/-/react-native-quick-sqlite-5.0.3.tgz",
-      "integrity": "sha512-xaVPpVwFw0IB4+Tw63MhZJtUNr+CEF68grg2TWQMKK71oNjBffnL5uMMmVEmOgLKe6Wxto0JOPx/aWcgOeK9bQ==",
+      "version": "8.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/react-native-quick-sqlite/-/react-native-quick-sqlite-8.0.0-beta.2.tgz",
+      "integrity": "sha512-B7makWA5GrlkUSRderWGuuEg83QDfRPjKYdBXiGx6L1hm2BhJ4u+sv6q+bTGoXAieEKcIPh+qeA/hhEat+dC2g==",
       "dev": true,
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native/node_modules/@jest/environment": {
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.4.3.tgz",
+      "integrity": "sha512-dq5S6408IxIa+lr54zeqce+QgI+CJT4nmmA+1yzFgtcsGK8c/EyiUb9XQOgz3BMKrRDfKseeOaxj2eO8LlD3lA==",
+      "dev": true,
+      "dependencies": {
+        "@jest/fake-timers": "^29.4.3",
+        "@jest/types": "^29.4.3",
+        "@types/node": "*",
+        "jest-mock": "^29.4.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/react-native/node_modules/@jest/environment/node_modules/@jest/types": {
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.4.3.tgz",
+      "integrity": "sha512-bPYfw8V65v17m2Od1cv44FH+SiKW7w2Xu7trhcdTLUmSv85rfKsP+qXSjO4KGJr4dtPSzl/gvslZBXctf1qGEA==",
+      "dev": true,
+      "dependencies": {
+        "@jest/schemas": "^29.4.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/react-native/node_modules/@jest/fake-timers": {
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.4.3.tgz",
+      "integrity": "sha512-4Hote2MGcCTWSD2gwl0dwbCpBRHhE6olYEuTj8FMowdg3oQWNKr2YuxenPQYZ7+PfqPY1k98wKDU4Z+Hvd4Tiw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^29.4.3",
+        "@sinonjs/fake-timers": "^10.0.2",
+        "@types/node": "*",
+        "jest-message-util": "^29.4.3",
+        "jest-mock": "^29.4.3",
+        "jest-util": "^29.4.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/react-native/node_modules/@jest/fake-timers/node_modules/@jest/types": {
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.4.3.tgz",
+      "integrity": "sha512-bPYfw8V65v17m2Od1cv44FH+SiKW7w2Xu7trhcdTLUmSv85rfKsP+qXSjO4KGJr4dtPSzl/gvslZBXctf1qGEA==",
+      "dev": true,
+      "dependencies": {
+        "@jest/schemas": "^29.4.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/react-native/node_modules/@sinonjs/commons": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
+      "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/react-native/node_modules/@sinonjs/fake-timers": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.0.2.tgz",
+      "integrity": "sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^2.0.0"
+      }
+    },
+    "node_modules/react-native/node_modules/@types/yargs": {
+      "version": "17.0.22",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.22.tgz",
+      "integrity": "sha512-pet5WJ9U8yPVRhkwuEIp5ktAeAqRZOq4UdAyWLWzxbtpyXnzbtLdKiXAjJzi/KLmPGS9wk86lUFWZFN6sISo4g==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
       }
     },
     "node_modules/react-native/node_modules/ansi-styles": {
@@ -13457,6 +13689,21 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/react-native/node_modules/ci-info": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.8.0.tgz",
+      "integrity": "sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/react-native/node_modules/color-convert": {
@@ -13476,6 +13723,174 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "node_modules/react-native/node_modules/jest-environment-node": {
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.4.3.tgz",
+      "integrity": "sha512-gAiEnSKF104fsGDXNkwk49jD/0N0Bqu2K9+aMQXA6avzsA9H3Fiv1PW2D+gzbOSR705bWd2wJZRFEFpV0tXISg==",
+      "dev": true,
+      "dependencies": {
+        "@jest/environment": "^29.4.3",
+        "@jest/fake-timers": "^29.4.3",
+        "@jest/types": "^29.4.3",
+        "@types/node": "*",
+        "jest-mock": "^29.4.3",
+        "jest-util": "^29.4.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/react-native/node_modules/jest-environment-node/node_modules/@jest/types": {
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.4.3.tgz",
+      "integrity": "sha512-bPYfw8V65v17m2Od1cv44FH+SiKW7w2Xu7trhcdTLUmSv85rfKsP+qXSjO4KGJr4dtPSzl/gvslZBXctf1qGEA==",
+      "dev": true,
+      "dependencies": {
+        "@jest/schemas": "^29.4.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/react-native/node_modules/jest-message-util": {
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.4.3.tgz",
+      "integrity": "sha512-1Y8Zd4ZCN7o/QnWdMmT76If8LuDv23Z1DRovBj/vcSFNlGCJGoO8D1nJDw1AdyAGUk0myDLFGN5RbNeJyCRGCw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.12.13",
+        "@jest/types": "^29.4.3",
+        "@types/stack-utils": "^2.0.0",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.4.3",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/react-native/node_modules/jest-message-util/node_modules/@jest/types": {
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.4.3.tgz",
+      "integrity": "sha512-bPYfw8V65v17m2Od1cv44FH+SiKW7w2Xu7trhcdTLUmSv85rfKsP+qXSjO4KGJr4dtPSzl/gvslZBXctf1qGEA==",
+      "dev": true,
+      "dependencies": {
+        "@jest/schemas": "^29.4.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/react-native/node_modules/jest-message-util/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/react-native/node_modules/jest-message-util/node_modules/pretty-format": {
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.4.3.tgz",
+      "integrity": "sha512-cvpcHTc42lcsvOOAzd3XuNWTcvk1Jmnzqeu+WsOuiPmxUJTnkbAcFNsRKvEpBEUFVUgy/GTZLulZDcDEi+CIlA==",
+      "dev": true,
+      "dependencies": {
+        "@jest/schemas": "^29.4.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/react-native/node_modules/jest-message-util/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+      "dev": true
+    },
+    "node_modules/react-native/node_modules/jest-mock": {
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.4.3.tgz",
+      "integrity": "sha512-LjFgMg+xed9BdkPMyIJh+r3KeHt1klXPJYBULXVVAkbTaaKjPX1o1uVCAZADMEp/kOxGTwy/Ot8XbvgItOrHEg==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^29.4.3",
+        "@types/node": "*",
+        "jest-util": "^29.4.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/react-native/node_modules/jest-mock/node_modules/@jest/types": {
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.4.3.tgz",
+      "integrity": "sha512-bPYfw8V65v17m2Od1cv44FH+SiKW7w2Xu7trhcdTLUmSv85rfKsP+qXSjO4KGJr4dtPSzl/gvslZBXctf1qGEA==",
+      "dev": true,
+      "dependencies": {
+        "@jest/schemas": "^29.4.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/react-native/node_modules/jest-util": {
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.4.3.tgz",
+      "integrity": "sha512-ToSGORAz4SSSoqxDSylWX8JzkOQR7zoBtNRsA7e+1WUX5F8jrOwaNpuh1YfJHJKDHXLHmObv5eOjejUd+/Ws+Q==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^29.4.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "graceful-fs": "^4.2.9",
+        "picomatch": "^2.2.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/react-native/node_modules/jest-util/node_modules/@jest/types": {
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.4.3.tgz",
+      "integrity": "sha512-bPYfw8V65v17m2Od1cv44FH+SiKW7w2Xu7trhcdTLUmSv85rfKsP+qXSjO4KGJr4dtPSzl/gvslZBXctf1qGEA==",
+      "dev": true,
+      "dependencies": {
+        "@jest/schemas": "^29.4.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
     },
     "node_modules/react-native/node_modules/pretty-format": {
       "version": "26.6.2",
@@ -13497,6 +13912,15 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
+    },
+    "node_modules/react-native/node_modules/scheduler": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+      "dev": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
     },
     "node_modules/react-native/node_modules/ws": {
       "version": "6.2.2",
@@ -13696,9 +14120,9 @@
       }
     },
     "node_modules/recast/node_modules/tslib": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
       "dev": true
     },
     "node_modules/redent": {
@@ -14540,9 +14964,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.4.tgz",
-      "integrity": "sha512-8o/QEhSSRb1a5i7TFR0iM4G16Z0vYB2OQVs4G3aAFXjn3T6yEx8AZxy1PgDF7I00LZHYA3WxaSYIf5e5sAX8Rw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.0.tgz",
+      "integrity": "sha512-QHsz8GgQIGKlRi24yFc6a6lN69Idnx634w49ay6+jA5yFh7a1UY+4Rp6HPx/L/1zcEDPEij8cIsiqR6bQsE5VQ==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -15370,14 +15794,14 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.13.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.13.1.tgz",
-      "integrity": "sha512-hn4WKOfwnwbYfe48NgrQjqNOH9jzLqRcIfbYytOXCOv46LBfWr9bDS17MQqOi+BWGD0sJK3Sj5NC/gJjiojaoA==",
+      "version": "5.16.3",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.3.tgz",
+      "integrity": "sha512-v8wWLaS/xt3nE9dgKEWhNUFP6q4kngO5B8eYFUuebsu7Dw/UNAnpUod6UHo04jSSkv8TzKHjZDSd7EXdDQAl8Q==",
       "dev": true,
       "dependencies": {
+        "@jridgewell/source-map": "^0.3.2",
         "acorn": "^8.5.0",
         "commander": "^2.20.0",
-        "source-map": "~0.8.0-beta.0",
         "source-map-support": "~0.5.20"
       },
       "bin": {
@@ -15481,44 +15905,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/terser/node_modules/source-map": {
-      "version": "0.8.0-beta.0",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
-      "integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
-      "dev": true,
-      "dependencies": {
-        "whatwg-url": "^7.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/terser/node_modules/tr46": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
-      "dev": true,
-      "dependencies": {
-        "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/terser/node_modules/webidl-conversions": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
-      "dev": true
-    },
-    "node_modules/terser/node_modules/whatwg-url": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
-      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
-      "dev": true,
-      "dependencies": {
-        "lodash.sortby": "^4.7.0",
-        "tr46": "^1.0.1",
-        "webidl-conversions": "^4.0.2"
       }
     },
     "node_modules/test-exclude": {
@@ -16890,52 +17276,43 @@
       }
     },
     "@babel/code-frame": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
-      "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
+      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.10.4"
+        "@babel/highlight": "^7.18.6"
       }
     },
     "@babel/compat-data": {
-      "version": "7.20.1",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.20.1.tgz",
-      "integrity": "sha512-EWZ4mE2diW3QALKvDMiXnbZpRvlj+nayZ112nK93SnhqOtpdsbVD4W+2tEoT3YNBAG9RBR0ISY758ZkOgsn6pQ==",
+      "version": "7.20.14",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.20.14.tgz",
+      "integrity": "sha512-0YpKHD6ImkWMEINCyDAD0HLLUH/lPCefG8ld9it8DJB2wnApraKuhgYTvTY1z7UFIfBTGy5LwncZ+5HWWGbhFw==",
       "dev": true
     },
     "@babel/core": {
-      "version": "7.17.10",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.10.tgz",
-      "integrity": "sha512-liKoppandF3ZcBnIYFjfSDHZLKdLHGJRkoWtG8zQyGJBQfIYobpnVGI5+pLBNtS6psFLDzyq8+h5HiVljW9PNA==",
+      "version": "7.20.12",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.20.12.tgz",
+      "integrity": "sha512-XsMfHovsUYHFMdrIHkZphTN/2Hzzi78R08NuHfDBehym2VsPDL6Zn/JAD/JQdnRvbSsbQc4mVaU1m6JgtTEElg==",
       "dev": true,
       "requires": {
         "@ampproject/remapping": "^2.1.0",
-        "@babel/code-frame": "^7.16.7",
-        "@babel/generator": "^7.17.10",
-        "@babel/helper-compilation-targets": "^7.17.10",
-        "@babel/helper-module-transforms": "^7.17.7",
-        "@babel/helpers": "^7.17.9",
-        "@babel/parser": "^7.17.10",
-        "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.17.10",
-        "@babel/types": "^7.17.10",
+        "@babel/code-frame": "^7.18.6",
+        "@babel/generator": "^7.20.7",
+        "@babel/helper-compilation-targets": "^7.20.7",
+        "@babel/helper-module-transforms": "^7.20.11",
+        "@babel/helpers": "^7.20.7",
+        "@babel/parser": "^7.20.7",
+        "@babel/template": "^7.20.7",
+        "@babel/traverse": "^7.20.12",
+        "@babel/types": "^7.20.7",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.1",
+        "json5": "^2.2.2",
         "semver": "^6.3.0"
       },
       "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
-          "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "^7.16.7"
-          }
-        },
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -16945,12 +17322,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.20.4",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.4.tgz",
-      "integrity": "sha512-luCf7yk/cm7yab6CAW1aiFnmEfBJplb/JojV56MYEK7ziWfGmFlTfmL9Ehwfy4gFhbjBfWO1wj7/TuSbVNEEtA==",
+      "version": "7.20.14",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.14.tgz",
+      "integrity": "sha512-AEmuXHdcD3A52HHXxaTmYlb8q/xMEhoRP67B3T4Oq7lbmSoqroMZzjnGj3+i1io3pdnF8iBYVu4Ilj+c4hBxYg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.20.2",
+        "@babel/types": "^7.20.7",
         "@jridgewell/gen-mapping": "^0.3.2",
         "jsesc": "^2.5.1"
       },
@@ -16988,21 +17365,37 @@
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.0.tgz",
-      "integrity": "sha512-0jp//vDGp9e8hZzBc6N/KwA5ZK3Wsm/pfm4CrY7vzegkVxc65SgSn6wYOnwHe9Js9HRQ1YTCKLGPzDtaS3RoLQ==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.7.tgz",
+      "integrity": "sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.20.0",
+        "@babel/compat-data": "^7.20.5",
         "@babel/helper-validator-option": "^7.18.6",
         "browserslist": "^4.21.3",
+        "lru-cache": "^5.1.1",
         "semver": "^6.3.0"
       },
       "dependencies": {
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "dev": true,
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        },
+        "yallist": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
           "dev": true
         }
       }
@@ -17107,9 +17500,9 @@
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.20.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.20.2.tgz",
-      "integrity": "sha512-zvBKyJXRbmK07XhMuujYoJ48B5yvvmM6+wcpv6Ivj4Yg6qO7NOZOSnvZN9CRl1zz1Z4cKf8YejmCMh8clOoOeA==",
+      "version": "7.20.11",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.20.11.tgz",
+      "integrity": "sha512-uRy78kN4psmji1s2QtbtcCSaj/LILFDp0f/ymhpQH5QY3nljUZCaNWz9X1dEj/8MBdBEFECs7yRhKn8i7NjZgg==",
       "dev": true,
       "requires": {
         "@babel/helper-environment-visitor": "^7.18.9",
@@ -17117,9 +17510,9 @@
         "@babel/helper-simple-access": "^7.20.2",
         "@babel/helper-split-export-declaration": "^7.18.6",
         "@babel/helper-validator-identifier": "^7.19.1",
-        "@babel/template": "^7.18.10",
-        "@babel/traverse": "^7.20.1",
-        "@babel/types": "^7.20.2"
+        "@babel/template": "^7.20.7",
+        "@babel/traverse": "^7.20.10",
+        "@babel/types": "^7.20.7"
       }
     },
     "@babel/helper-optimise-call-expression": {
@@ -17220,14 +17613,14 @@
       }
     },
     "@babel/helpers": {
-      "version": "7.17.9",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.9.tgz",
-      "integrity": "sha512-cPCt915ShDWUEzEp3+UNRktO2n6v49l5RSnG9M5pS24hA+2FAc5si+Pn1i4VVbQQ+jh+bIZhPFQOJOzbrOYY1Q==",
+      "version": "7.20.13",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.20.13.tgz",
+      "integrity": "sha512-nzJ0DWCL3gB5RCXbUO3KIMMsBY2Eqbx8mBpKGE/02PgyRQFcPQLbkQ1vyy596mZLaP+dAfD+R4ckASzNVmW3jg==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.17.9",
-        "@babel/types": "^7.17.0"
+        "@babel/template": "^7.20.7",
+        "@babel/traverse": "^7.20.13",
+        "@babel/types": "^7.20.7"
       }
     },
     "@babel/highlight": {
@@ -17255,9 +17648,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.20.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.3.tgz",
-      "integrity": "sha512-OP/s5a94frIPXwjzEcv5S/tpQfc6XhxYUnmWpgdqMWGgYCuErA3SzozaRAMQgSZWKeTJxht9aWAkUY+0UzvOFg==",
+      "version": "7.20.15",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.15.tgz",
+      "integrity": "sha512-DI4a1oZuf8wC+oAJA9RW6ga3Zbe8RZFt7kD9i4qAspz3I/yHet1VvC3DiSy/fsUvv5pvJuNPh0LPOdCcqinDPg==",
       "dev": true
     },
     "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
@@ -18251,54 +18644,34 @@
       }
     },
     "@babel/template": {
-      "version": "7.18.10",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.10.tgz",
-      "integrity": "sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.20.7.tgz",
+      "integrity": "sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.18.6",
-        "@babel/parser": "^7.18.10",
-        "@babel/types": "^7.18.10"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.18.6",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
-          "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "^7.18.6"
-          }
-        }
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7"
       }
     },
     "@babel/traverse": {
-      "version": "7.20.1",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.1.tgz",
-      "integrity": "sha512-d3tN8fkVJwFLkHkBN479SOsw4DMZnz8cdbL/gvuDuzy3TS6Nfw80HuQqhw1pITbIruHyh7d1fMA47kWzmcUEGA==",
+      "version": "7.20.13",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.13.tgz",
+      "integrity": "sha512-kMJXfF0T6DIS9E8cgdLCSAL+cuCK+YEZHWiLK0SXpTo8YRj5lpJu3CDNKiIBCne4m9hhTIqUg6SYTAI39tAiVQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.20.1",
+        "@babel/generator": "^7.20.7",
         "@babel/helper-environment-visitor": "^7.18.9",
         "@babel/helper-function-name": "^7.19.0",
         "@babel/helper-hoist-variables": "^7.18.6",
         "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/parser": "^7.20.1",
-        "@babel/types": "^7.20.0",
+        "@babel/parser": "^7.20.13",
+        "@babel/types": "^7.20.7",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
       "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.18.6",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
-          "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "^7.18.6"
-          }
-        },
         "globals": {
           "version": "11.12.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
@@ -18493,31 +18866,32 @@
       }
     },
     "@jest/create-cache-key-function": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-27.5.1.tgz",
-      "integrity": "sha512-dmH1yW+makpTSURTy8VzdUwFnfQh1G8R+DxO2Ho2FFmBbKFEVm+3jWdvFhE2VqB/LATCTokkP0dotjyQyw5/AQ==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-29.4.3.tgz",
+      "integrity": "sha512-AJVFQTTy6jnZAQiAZrdOaTAPzJUrvAE/4IMe+Foav6WPhypFszqg7a4lOTyuzYQEEiT5RSrGYg9IY+/ivxiyXw==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.5.1"
+        "@jest/types": "^29.4.3"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "27.5.1",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.5.1.tgz",
-          "integrity": "sha512-Cx46iJ9QpwQTjIdq5VJu2QTMMs3QlEjI0x1QbBP5W1+nMzyc2XmimiRR/CbX9TO0cPTeUlxWMOu8mslYsJ8DEw==",
+          "version": "29.4.3",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.4.3.tgz",
+          "integrity": "sha512-bPYfw8V65v17m2Od1cv44FH+SiKW7w2Xu7trhcdTLUmSv85rfKsP+qXSjO4KGJr4dtPSzl/gvslZBXctf1qGEA==",
           "dev": true,
           "requires": {
+            "@jest/schemas": "^29.4.3",
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^3.0.0",
             "@types/node": "*",
-            "@types/yargs": "^16.0.0",
+            "@types/yargs": "^17.0.8",
             "chalk": "^4.0.0"
           }
         },
         "@types/yargs": {
-          "version": "16.0.4",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
-          "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
+          "version": "17.0.22",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.22.tgz",
+          "integrity": "sha512-pet5WJ9U8yPVRhkwuEIp5ktAeAqRZOq4UdAyWLWzxbtpyXnzbtLdKiXAjJzi/KLmPGS9wk86lUFWZFN6sISo4g==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -18615,6 +18989,15 @@
         }
       }
     },
+    "@jest/schemas": {
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.4.3.tgz",
+      "integrity": "sha512-VLYKXQmtmuEz6IxJsrZwzG9NvtkQsWNnWMsKxqWNu3+CnfzJQhp0WDDKWLVV9hLKr0l3SLLFRqcYHjhtyuDVxg==",
+      "dev": true,
+      "requires": {
+        "@sinclair/typebox": "^0.25.16"
+      }
+    },
     "@jest/source-map": {
       "version": "26.6.2",
       "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-26.6.2.tgz",
@@ -18709,6 +19092,29 @@
       "integrity": "sha512-Ct5MqZkLGEXTVmQYbGtx9SVqD2fqwvdubdps5D3djjAkgkKwT918VNOz65pEHFaYTeWcukmJmH5SwsA9Tn2ObQ==",
       "dev": true
     },
+    "@jridgewell/source-map": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
+      "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/gen-mapping": "^0.3.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      },
+      "dependencies": {
+        "@jridgewell/gen-mapping": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+          "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/set-array": "^1.0.1",
+            "@jridgewell/sourcemap-codec": "^1.4.10",
+            "@jridgewell/trace-mapping": "^0.3.9"
+          }
+        }
+      }
+    },
     "@jridgewell/sourcemap-codec": {
       "version": "1.4.14",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
@@ -18744,22 +19150,22 @@
       }
     },
     "@react-native-community/cli": {
-      "version": "9.3.2",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-9.3.2.tgz",
-      "integrity": "sha512-IAW4X0vmX/xozNpp/JVZaX7MrC85KV0OP2DF4o7lNGOfpUhzJAEWqTfkxFYS+VsRjZHDve4wSTiGIuXwE7FG1w==",
+      "version": "10.1.3",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-10.1.3.tgz",
+      "integrity": "sha512-kzh6bYLGN1q1q0IiczKSP1LTrovFeVzppYRTKohPI9VdyZwp7b5JOgaQMB/Ijtwm3MxBDrZgV9AveH/eUmUcKQ==",
       "dev": true,
       "requires": {
-        "@react-native-community/cli-clean": "^9.2.1",
-        "@react-native-community/cli-config": "^9.2.1",
-        "@react-native-community/cli-debugger-ui": "^9.0.0",
-        "@react-native-community/cli-doctor": "^9.3.0",
-        "@react-native-community/cli-hermes": "^9.3.1",
-        "@react-native-community/cli-plugin-metro": "^9.2.1",
-        "@react-native-community/cli-server-api": "^9.2.1",
-        "@react-native-community/cli-tools": "^9.2.1",
-        "@react-native-community/cli-types": "^9.1.0",
+        "@react-native-community/cli-clean": "^10.1.1",
+        "@react-native-community/cli-config": "^10.1.1",
+        "@react-native-community/cli-debugger-ui": "^10.0.0",
+        "@react-native-community/cli-doctor": "^10.1.1",
+        "@react-native-community/cli-hermes": "^10.1.3",
+        "@react-native-community/cli-plugin-metro": "^10.1.1",
+        "@react-native-community/cli-server-api": "^10.1.1",
+        "@react-native-community/cli-tools": "^10.1.1",
+        "@react-native-community/cli-types": "^10.0.0",
         "chalk": "^4.1.2",
-        "commander": "^9.4.0",
+        "commander": "^9.4.1",
         "execa": "^1.0.0",
         "find-up": "^4.1.0",
         "fs-extra": "^8.1.0",
@@ -18769,9 +19175,9 @@
       },
       "dependencies": {
         "commander": {
-          "version": "9.4.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.1.tgz",
-          "integrity": "sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==",
+          "version": "9.5.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+          "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
           "dev": true
         },
         "find-up": {
@@ -18832,24 +19238,25 @@
       }
     },
     "@react-native-community/cli-clean": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-clean/-/cli-clean-9.2.1.tgz",
-      "integrity": "sha512-dyNWFrqRe31UEvNO+OFWmQ4hmqA07bR9Ief/6NnGwx67IO9q83D5PEAf/o96ML6jhSbDwCmpPKhPwwBbsyM3mQ==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-clean/-/cli-clean-10.1.1.tgz",
+      "integrity": "sha512-iNsrjzjIRv9yb5y309SWJ8NDHdwYtnCpmxZouQDyOljUdC9MwdZ4ChbtA4rwQyAwgOVfS9F/j56ML3Cslmvrxg==",
       "dev": true,
       "requires": {
-        "@react-native-community/cli-tools": "^9.2.1",
+        "@react-native-community/cli-tools": "^10.1.1",
         "chalk": "^4.1.2",
         "execa": "^1.0.0",
         "prompts": "^2.4.0"
       }
     },
     "@react-native-community/cli-config": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-config/-/cli-config-9.2.1.tgz",
-      "integrity": "sha512-gHJlBBXUgDN9vrr3aWkRqnYrPXZLztBDQoY97Mm5Yo6MidsEpYo2JIP6FH4N/N2p1TdjxJL4EFtdd/mBpiR2MQ==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-config/-/cli-config-10.1.1.tgz",
+      "integrity": "sha512-p4mHrjC+s/ayiNVG6T35GdEGdP6TuyBUg5plVGRJfTl8WT6LBfLYLk+fz/iETrEZ/YkhQIsQcEUQC47MqLNHog==",
       "dev": true,
       "requires": {
-        "@react-native-community/cli-tools": "^9.2.1",
+        "@react-native-community/cli-tools": "^10.1.1",
+        "chalk": "^4.1.2",
         "cosmiconfig": "^5.1.0",
         "deepmerge": "^3.2.0",
         "glob": "^7.1.3",
@@ -18865,23 +19272,23 @@
       }
     },
     "@react-native-community/cli-debugger-ui": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-9.0.0.tgz",
-      "integrity": "sha512-7hH05ZwU9Tp0yS6xJW0bqcZPVt0YCK7gwj7gnRu1jDNN2kughf6Lg0Ys29rAvtZ7VO1PK5c1O+zs7yFnylQDUA==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-10.0.0.tgz",
+      "integrity": "sha512-8UKLcvpSNxnUTRy8CkCl27GGLqZunQ9ncGYhSrWyKrU9SWBJJGeZwi2k2KaoJi5FvF2+cD0t8z8cU6lsq2ZZmA==",
       "dev": true,
       "requires": {
         "serve-static": "^1.13.1"
       }
     },
     "@react-native-community/cli-doctor": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-doctor/-/cli-doctor-9.3.0.tgz",
-      "integrity": "sha512-/fiuG2eDGC2/OrXMOWI5ifq4X1gdYTQhvW2m0TT5Lk1LuFiZsbTCp1lR+XILKekuTvmYNjEGdVpeDpdIWlXdEA==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-doctor/-/cli-doctor-10.1.1.tgz",
+      "integrity": "sha512-9uvUhr6aJu4C7pCTsD9iRS/38tx1mzIrWuEQoh2JffTXg9MOq4jesvobkyKFRD90nOvqunEvfpnWnRdWcZO0Wg==",
       "dev": true,
       "requires": {
-        "@react-native-community/cli-config": "^9.2.1",
-        "@react-native-community/cli-platform-ios": "^9.3.0",
-        "@react-native-community/cli-tools": "^9.2.1",
+        "@react-native-community/cli-config": "^10.1.1",
+        "@react-native-community/cli-platform-ios": "^10.1.1",
+        "@react-native-community/cli-tools": "^10.1.1",
         "chalk": "^4.1.2",
         "command-exists": "^1.2.8",
         "envinfo": "^7.7.2",
@@ -18921,40 +19328,38 @@
       }
     },
     "@react-native-community/cli-hermes": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-hermes/-/cli-hermes-9.3.1.tgz",
-      "integrity": "sha512-Mq4PK8m5YqIdaVq5IdRfp4qK09aVO+aiCtd6vjzjNUgk1+1X5cgUqV6L65h4N+TFJYJHcp2AnB+ik1FAYXvYPQ==",
+      "version": "10.1.3",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-hermes/-/cli-hermes-10.1.3.tgz",
+      "integrity": "sha512-uYl8MLBtuu6bj0tDUzVGf30nK5i9haBv7F0u+NCOq31+zVjcwiUplrCuLorb2dMLMF+Fno9wDxi66W9MxoW4nA==",
       "dev": true,
       "requires": {
-        "@react-native-community/cli-platform-android": "^9.3.1",
-        "@react-native-community/cli-tools": "^9.2.1",
+        "@react-native-community/cli-platform-android": "^10.1.3",
+        "@react-native-community/cli-tools": "^10.1.1",
         "chalk": "^4.1.2",
         "hermes-profile-transformer": "^0.0.6",
         "ip": "^1.1.5"
       }
     },
     "@react-native-community/cli-platform-android": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-android/-/cli-platform-android-9.3.1.tgz",
-      "integrity": "sha512-m0bQ6Twewl7OEZoVf79I2GZmsDqh+Gh0bxfxWgwxobsKDxLx8/RNItAo1lVtTCgzuCR75cX4EEO8idIF9jYhew==",
+      "version": "10.1.3",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-android/-/cli-platform-android-10.1.3.tgz",
+      "integrity": "sha512-8YZEpBL6yd9l4CIoFcLOgrV8x2GDujdqrdWrNsNERDAbsiFwqAQvfjyyb57GAZVuEPEJCoqUlGlMCwOh3XQb9A==",
       "dev": true,
       "requires": {
-        "@react-native-community/cli-tools": "^9.2.1",
+        "@react-native-community/cli-tools": "^10.1.1",
         "chalk": "^4.1.2",
         "execa": "^1.0.0",
-        "fs-extra": "^8.1.0",
         "glob": "^7.1.3",
-        "logkitty": "^0.7.1",
-        "slash": "^3.0.0"
+        "logkitty": "^0.7.1"
       }
     },
     "@react-native-community/cli-platform-ios": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-ios/-/cli-platform-ios-9.3.0.tgz",
-      "integrity": "sha512-nihTX53BhF2Q8p4B67oG3RGe1XwggoGBrMb6vXdcu2aN0WeXJOXdBLgR900DAA1O8g7oy1Sudu6we+JsVTKnjw==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-ios/-/cli-platform-ios-10.1.1.tgz",
+      "integrity": "sha512-EB9/L8j1LqrqyfJtLRixU+d8FIP6Pr83rEgUgXgya/u8wk3h/bvX70w+Ff2skwjdPLr5dLUQ/n5KFX4r3bsNmA==",
       "dev": true,
       "requires": {
-        "@react-native-community/cli-tools": "^9.2.1",
+        "@react-native-community/cli-tools": "^10.1.1",
         "chalk": "^4.1.2",
         "execa": "^1.0.0",
         "glob": "^7.1.3",
@@ -18962,86 +19367,32 @@
       }
     },
     "@react-native-community/cli-plugin-metro": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-plugin-metro/-/cli-plugin-metro-9.2.1.tgz",
-      "integrity": "sha512-byBGBH6jDfUvcHGFA45W/sDwMlliv7flJ8Ns9foCh3VsIeYYPoDjjK7SawE9cPqRdMAD4SY7EVwqJnOtRbwLiQ==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-plugin-metro/-/cli-plugin-metro-10.1.1.tgz",
+      "integrity": "sha512-wEp47le4mzlelDF5sfkaaujUDYcuLep5HZqlcMx7PkL7BA3/fSHdDo1SblqaLgZ1ca6vFU+kfbHueLDct+xwFg==",
       "dev": true,
       "requires": {
-        "@react-native-community/cli-server-api": "^9.2.1",
-        "@react-native-community/cli-tools": "^9.2.1",
+        "@react-native-community/cli-server-api": "^10.1.1",
+        "@react-native-community/cli-tools": "^10.1.1",
         "chalk": "^4.1.2",
-        "metro": "0.72.3",
-        "metro-config": "0.72.3",
-        "metro-core": "0.72.3",
-        "metro-react-native-babel-transformer": "0.72.3",
-        "metro-resolver": "0.72.3",
-        "metro-runtime": "0.72.3",
+        "execa": "^1.0.0",
+        "metro": "0.73.7",
+        "metro-config": "0.73.7",
+        "metro-core": "0.73.7",
+        "metro-react-native-babel-transformer": "0.73.7",
+        "metro-resolver": "0.73.7",
+        "metro-runtime": "0.73.7",
         "readline": "^1.3.0"
-      },
-      "dependencies": {
-        "metro-react-native-babel-transformer": {
-          "version": "0.72.3",
-          "resolved": "https://registry.npmjs.org/metro-react-native-babel-transformer/-/metro-react-native-babel-transformer-0.72.3.tgz",
-          "integrity": "sha512-Ogst/M6ujYrl/+9mpEWqE3zF7l2mTuftDTy3L8wZYwX1pWUQWQpfU1aJBeWiLxt1XlIq+uriRjKzKoRoIK57EA==",
-          "dev": true,
-          "requires": {
-            "@babel/core": "^7.14.0",
-            "babel-preset-fbjs": "^3.4.0",
-            "hermes-parser": "0.8.0",
-            "metro-babel-transformer": "0.72.3",
-            "metro-react-native-babel-preset": "0.72.3",
-            "metro-source-map": "0.72.3",
-            "nullthrows": "^1.1.1"
-          }
-        },
-        "metro-runtime": {
-          "version": "0.72.3",
-          "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.72.3.tgz",
-          "integrity": "sha512-3MhvDKfxMg2u7dmTdpFOfdR71NgNNo4tzAyJumDVQKwnHYHN44f2QFZQqpPBEmqhWlojNeOxsqFsjYgeyMx6VA==",
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "react-refresh": "^0.4.0"
-          }
-        },
-        "metro-source-map": {
-          "version": "0.72.3",
-          "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.72.3.tgz",
-          "integrity": "sha512-eNtpjbjxSheXu/jYCIDrbNEKzMGOvYW6/ePYpRM7gDdEagUOqKOCsi3St8NJIQJzZCsxD2JZ2pYOiomUSkT1yQ==",
-          "dev": true,
-          "requires": {
-            "@babel/traverse": "^7.14.0",
-            "@babel/types": "^7.0.0",
-            "invariant": "^2.2.4",
-            "metro-symbolicate": "0.72.3",
-            "nullthrows": "^1.1.1",
-            "ob1": "0.72.3",
-            "source-map": "^0.5.6",
-            "vlq": "^1.0.0"
-          }
-        },
-        "ob1": {
-          "version": "0.72.3",
-          "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.72.3.tgz",
-          "integrity": "sha512-OnVto25Sj7Ghp0vVm2THsngdze3tVq0LOg9LUHsAVXMecpqOP0Y8zaATW8M9gEgs2lNEAcCqV0P/hlmOPhVRvg==",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-          "dev": true
-        }
       }
     },
     "@react-native-community/cli-server-api": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-server-api/-/cli-server-api-9.2.1.tgz",
-      "integrity": "sha512-EI+9MUxEbWBQhWw2PkhejXfkcRqPl+58+whlXJvKHiiUd7oVbewFs0uLW0yZffUutt4FGx6Uh88JWEgwOzAdkw==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-server-api/-/cli-server-api-10.1.1.tgz",
+      "integrity": "sha512-NZDo/wh4zlm8as31UEBno2bui8+ufzsZV+KN7QjEJWEM0levzBtxaD+4je0OpfhRIIkhaRm2gl/vVf7OYAzg4g==",
       "dev": true,
       "requires": {
-        "@react-native-community/cli-debugger-ui": "^9.0.0",
-        "@react-native-community/cli-tools": "^9.2.1",
+        "@react-native-community/cli-debugger-ui": "^10.0.0",
+        "@react-native-community/cli-tools": "^10.1.1",
         "compression": "^1.7.1",
         "connect": "^3.6.5",
         "errorhandler": "^1.5.0",
@@ -19096,9 +19447,9 @@
       }
     },
     "@react-native-community/cli-tools": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-9.2.1.tgz",
-      "integrity": "sha512-bHmL/wrKmBphz25eMtoJQgwwmeCylbPxqFJnFSbkqJPXQz3ManQ6q/gVVMqFyz7D3v+riaus/VXz3sEDa97uiQ==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-10.1.1.tgz",
+      "integrity": "sha512-+FlwOnZBV+ailEzXjcD8afY2ogFEBeHOw/8+XXzMgPaquU2Zly9B+8W089tnnohO3yfiQiZqkQlElP423MY74g==",
       "dev": true,
       "requires": {
         "appdirsjs": "^1.2.4",
@@ -19164,9 +19515,9 @@
       }
     },
     "@react-native-community/cli-types": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-types/-/cli-types-9.1.0.tgz",
-      "integrity": "sha512-KDybF9XHvafLEILsbiKwz5Iobd+gxRaPyn4zSaAerBxedug4er5VUWa8Szy+2GeYKZzMh/gsb1o9lCToUwdT/g==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-types/-/cli-types-10.0.0.tgz",
+      "integrity": "sha512-31oUM6/rFBZQfSmDQsT1DX/5fjqfxg7sf2u8kTPJK7rXVya5SRpAMaCXsPAG0omsmJxXt+J9HxUi3Ic+5Ux5Iw==",
       "dev": true,
       "requires": {
         "joi": "^17.2.1"
@@ -19206,9 +19557,9 @@
       "dev": true
     },
     "@react-native/normalize-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@react-native/normalize-color/-/normalize-color-2.0.0.tgz",
-      "integrity": "sha512-Wip/xsc5lw8vsBlmY2MO/gFLp3MvuZ2baBZjDeTjjndMgM0h5sxz7AZR62RDPGgstp8Np7JzjvVqVT7tpFZqsw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@react-native/normalize-color/-/normalize-color-2.1.0.tgz",
+      "integrity": "sha512-Z1jQI2NpdFJCVgpY+8Dq/Bt3d+YUi1928Q+/CZm/oh66fzM0RUl54vvuXlPJKybH4pdCZey1eDTPaLHkMPNgWA==",
       "dev": true
     },
     "@react-native/polyfills": {
@@ -19227,15 +19578,21 @@
       }
     },
     "@sideway/formula": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
-      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==",
       "dev": true
     },
     "@sideway/pinpoint": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
+      "dev": true
+    },
+    "@sinclair/typebox": {
+      "version": "0.25.22",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.22.tgz",
+      "integrity": "sha512-6U6r2L7rnM7EG8G1tWzIjdB3QlsHF4slgcqXNN/SF0xJOAr0nDmT2GedlkyO3mrv8mDTJ24UuOMWR3diBrCvQQ==",
       "dev": true
     },
     "@sinonjs/commons": {
@@ -20048,7 +20405,7 @@
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true
     },
     "ascii-table": {
@@ -20072,9 +20429,9 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
           "dev": true
         }
       }
@@ -21262,9 +21619,9 @@
       }
     },
     "dayjs": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.6.tgz",
-      "integrity": "sha512-zZbY5giJAinCG+7AGaw0wIhNZ6J8AhWuSXKvuc1KAyMiRsvGQWqh4L+MomvhdAYjN+lqvVCMq1I41e3YHvXkyQ==",
+      "version": "1.11.7",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.7.tgz",
+      "integrity": "sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ==",
       "dev": true
     },
     "debug": {
@@ -21395,6 +21752,17 @@
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "dev": true
+    },
+    "deprecated-react-native-prop-types": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deprecated-react-native-prop-types/-/deprecated-react-native-prop-types-3.0.1.tgz",
+      "integrity": "sha512-J0jCJcsk4hMlIb7xwOZKLfMpuJn6l8UtrPEzzQV5ewz5gvKNYakhBuq9h2rWX7YwHHJZFhU5W8ye7dB9oN8VcQ==",
+      "dev": true,
+      "requires": {
+        "@react-native/normalize-color": "*",
+        "invariant": "*",
+        "prop-types": "*"
+      }
     },
     "destroy": {
       "version": "1.2.0",
@@ -23049,9 +23417,9 @@
       "dev": true
     },
     "flow-parser": {
-      "version": "0.121.0",
-      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.121.0.tgz",
-      "integrity": "sha512-1gIBiWJNR0tKUNv8gZuk7l9rVX06OuLzY9AoGio7y/JT4V1IZErEMEq2TJS+PFcw/y0RshZ1J/27VfK1UQzYVg==",
+      "version": "0.185.2",
+      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.185.2.tgz",
+      "integrity": "sha512-2hJ5ACYeJCzNtiVULov6pljKOLygy0zddoqSI1fFetM+XRPpRshFdGEijtqlamA1XwyZ+7rhryI6FQFzvtLWUQ==",
       "dev": true
     },
     "for-in": {
@@ -25002,15 +25370,15 @@
       }
     },
     "joi": {
-      "version": "17.7.0",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.7.0.tgz",
-      "integrity": "sha512-1/ugc8djfn93rTE3WRKdCzGGt/EtiYKxITMO4Wiv6q5JL1gl9ePt4kBsl1S499nbosspfctIQTpYIhSmHA3WAg==",
+      "version": "17.7.1",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.7.1.tgz",
+      "integrity": "sha512-teoLhIvWE298R6AeJywcjR4sX2hHjB3/xJX4qPjg+gTg+c0mzUDsziYlqPmLomq9gVsfaMcgPaGc7VxtD/9StA==",
       "dev": true,
       "requires": {
         "@hapi/hoek": "^9.0.0",
         "@hapi/topo": "^5.0.0",
         "@sideway/address": "^4.1.3",
-        "@sideway/formula": "^3.0.0",
+        "@sideway/formula": "^3.0.1",
         "@sideway/pinpoint": "^2.0.0"
       }
     },
@@ -25388,9 +25756,9 @@
       "dev": true
     },
     "json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true
     },
     "jsonfile": {
@@ -25417,15 +25785,6 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true
-    },
-    "klaw": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
-      "integrity": "sha512-TED5xi9gGQjGpNnvRWknrwAB1eL5GciPfVFOt3Vk1OJCVDQbzuSfrF3hkUQKlsgKrG1F+0t5W0m+Fje1jIt8rw==",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.9"
-      }
     },
     "kleur": {
       "version": "3.0.3",
@@ -25557,12 +25916,6 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
       "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=",
-      "dev": true
-    },
-    "lodash.sortby": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
     },
     "lodash.throttle": {
@@ -25705,18 +26058,18 @@
       "dev": true
     },
     "metro": {
-      "version": "0.72.3",
-      "resolved": "https://registry.npmjs.org/metro/-/metro-0.72.3.tgz",
-      "integrity": "sha512-Hb3xTvPqex8kJ1hutQNZhQadUKUwmns/Du9GikmWKBFrkiG3k3xstGAyO5t5rN9JSUEzQT6y9SWzSSOGogUKIg==",
+      "version": "0.73.7",
+      "resolved": "https://registry.npmjs.org/metro/-/metro-0.73.7.tgz",
+      "integrity": "sha512-pkRqFhuGUvkiu8HxKPUQelbCuyy6te6okMssTyLzQwsKilNLK4YMI2uD6PHnypg5SiMJ58lwfqkp/t5w72jEvw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
-        "@babel/core": "^7.14.0",
-        "@babel/generator": "^7.14.0",
-        "@babel/parser": "^7.14.0",
+        "@babel/core": "^7.20.0",
+        "@babel/generator": "^7.20.0",
+        "@babel/parser": "^7.20.0",
         "@babel/template": "^7.0.0",
-        "@babel/traverse": "^7.14.0",
-        "@babel/types": "^7.0.0",
+        "@babel/traverse": "^7.20.0",
+        "@babel/types": "^7.20.0",
         "absolute-path": "^0.0.0",
         "accepts": "^1.3.7",
         "async": "^3.2.2",
@@ -25726,42 +26079,77 @@
         "debug": "^2.2.0",
         "denodeify": "^1.2.1",
         "error-stack-parser": "^2.0.6",
-        "fs-extra": "^1.0.0",
         "graceful-fs": "^4.2.4",
         "hermes-parser": "0.8.0",
         "image-size": "^0.6.0",
         "invariant": "^2.2.4",
         "jest-worker": "^27.2.0",
         "lodash.throttle": "^4.1.1",
-        "metro-babel-transformer": "0.72.3",
-        "metro-cache": "0.72.3",
-        "metro-cache-key": "0.72.3",
-        "metro-config": "0.72.3",
-        "metro-core": "0.72.3",
-        "metro-file-map": "0.72.3",
-        "metro-hermes-compiler": "0.72.3",
-        "metro-inspector-proxy": "0.72.3",
-        "metro-minify-uglify": "0.72.3",
-        "metro-react-native-babel-preset": "0.72.3",
-        "metro-resolver": "0.72.3",
-        "metro-runtime": "0.72.3",
-        "metro-source-map": "0.72.3",
-        "metro-symbolicate": "0.72.3",
-        "metro-transform-plugins": "0.72.3",
-        "metro-transform-worker": "0.72.3",
+        "metro-babel-transformer": "0.73.7",
+        "metro-cache": "0.73.7",
+        "metro-cache-key": "0.73.7",
+        "metro-config": "0.73.7",
+        "metro-core": "0.73.7",
+        "metro-file-map": "0.73.7",
+        "metro-hermes-compiler": "0.73.7",
+        "metro-inspector-proxy": "0.73.7",
+        "metro-minify-terser": "0.73.7",
+        "metro-minify-uglify": "0.73.7",
+        "metro-react-native-babel-preset": "0.73.7",
+        "metro-resolver": "0.73.7",
+        "metro-runtime": "0.73.7",
+        "metro-source-map": "0.73.7",
+        "metro-symbolicate": "0.73.7",
+        "metro-transform-plugins": "0.73.7",
+        "metro-transform-worker": "0.73.7",
         "mime-types": "^2.1.27",
         "node-fetch": "^2.2.0",
         "nullthrows": "^1.1.1",
-        "rimraf": "^2.5.4",
+        "rimraf": "^3.0.2",
         "serialize-error": "^2.1.0",
         "source-map": "^0.5.6",
         "strip-ansi": "^6.0.0",
         "temp": "0.8.3",
         "throat": "^5.0.0",
         "ws": "^7.5.1",
-        "yargs": "^15.3.1"
+        "yargs": "^17.5.1"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "cliui": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+          "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.1",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -25771,21 +26159,22 @@
             "ms": "2.0.0"
           }
         },
-        "fs-extra": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
-          "integrity": "sha512-VerQV6vEKuhDWD2HGOybV6v5I73syoc/cXAbKlgTC7M/oFVEtklWlp9QH2Ijw3IaWDOQcMkldSPa7zXy79Z/UQ==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^2.1.0",
-            "klaw": "^1.0.0"
-          }
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
         },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
           "dev": true
         },
         "jest-worker": {
@@ -25799,39 +26188,50 @@
             "supports-color": "^8.0.0"
           }
         },
-        "jsonfile": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-          "integrity": "sha512-PKllAqbgLgxHaj8TElYymKCAgrASebJrWpTnEkOaTowt23VKXXN0sUeriJ+eh7y6ufb/CC5ap11pz71/cM0hUw==",
+        "metro-react-native-babel-preset": {
+          "version": "0.73.7",
+          "resolved": "https://registry.npmjs.org/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.73.7.tgz",
+          "integrity": "sha512-RKcmRZREjJCzHKP+JhC9QTCohkeb3xa/DtqHU14U5KWzJHdC0mMrkTZYNXhV0cryxsaVKVEw5873KhbZyZHMVw==",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.6"
-          }
-        },
-        "metro-runtime": {
-          "version": "0.72.3",
-          "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.72.3.tgz",
-          "integrity": "sha512-3MhvDKfxMg2u7dmTdpFOfdR71NgNNo4tzAyJumDVQKwnHYHN44f2QFZQqpPBEmqhWlojNeOxsqFsjYgeyMx6VA==",
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.0.0",
+            "@babel/core": "^7.20.0",
+            "@babel/plugin-proposal-async-generator-functions": "^7.0.0",
+            "@babel/plugin-proposal-class-properties": "^7.0.0",
+            "@babel/plugin-proposal-export-default-from": "^7.0.0",
+            "@babel/plugin-proposal-nullish-coalescing-operator": "^7.0.0",
+            "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+            "@babel/plugin-proposal-optional-catch-binding": "^7.0.0",
+            "@babel/plugin-proposal-optional-chaining": "^7.0.0",
+            "@babel/plugin-syntax-dynamic-import": "^7.0.0",
+            "@babel/plugin-syntax-export-default-from": "^7.0.0",
+            "@babel/plugin-syntax-flow": "^7.18.0",
+            "@babel/plugin-syntax-nullish-coalescing-operator": "^7.0.0",
+            "@babel/plugin-syntax-optional-chaining": "^7.0.0",
+            "@babel/plugin-transform-arrow-functions": "^7.0.0",
+            "@babel/plugin-transform-async-to-generator": "^7.0.0",
+            "@babel/plugin-transform-block-scoping": "^7.0.0",
+            "@babel/plugin-transform-classes": "^7.0.0",
+            "@babel/plugin-transform-computed-properties": "^7.0.0",
+            "@babel/plugin-transform-destructuring": "^7.0.0",
+            "@babel/plugin-transform-flow-strip-types": "^7.0.0",
+            "@babel/plugin-transform-function-name": "^7.0.0",
+            "@babel/plugin-transform-literals": "^7.0.0",
+            "@babel/plugin-transform-modules-commonjs": "^7.0.0",
+            "@babel/plugin-transform-named-capturing-groups-regex": "^7.0.0",
+            "@babel/plugin-transform-parameters": "^7.0.0",
+            "@babel/plugin-transform-react-display-name": "^7.0.0",
+            "@babel/plugin-transform-react-jsx": "^7.0.0",
+            "@babel/plugin-transform-react-jsx-self": "^7.0.0",
+            "@babel/plugin-transform-react-jsx-source": "^7.0.0",
+            "@babel/plugin-transform-runtime": "^7.0.0",
+            "@babel/plugin-transform-shorthand-properties": "^7.0.0",
+            "@babel/plugin-transform-spread": "^7.0.0",
+            "@babel/plugin-transform-sticky-regex": "^7.0.0",
+            "@babel/plugin-transform-template-literals": "^7.0.0",
+            "@babel/plugin-transform-typescript": "^7.5.0",
+            "@babel/plugin-transform-unicode-regex": "^7.0.0",
+            "@babel/template": "^7.0.0",
             "react-refresh": "^0.4.0"
-          }
-        },
-        "metro-source-map": {
-          "version": "0.72.3",
-          "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.72.3.tgz",
-          "integrity": "sha512-eNtpjbjxSheXu/jYCIDrbNEKzMGOvYW6/ePYpRM7gDdEagUOqKOCsi3St8NJIQJzZCsxD2JZ2pYOiomUSkT1yQ==",
-          "dev": true,
-          "requires": {
-            "@babel/traverse": "^7.14.0",
-            "@babel/types": "^7.0.0",
-            "invariant": "^2.2.4",
-            "metro-symbolicate": "0.72.3",
-            "nullthrows": "^1.1.1",
-            "ob1": "0.72.3",
-            "source-map": "^0.5.6",
-            "vlq": "^1.0.0"
           }
         },
         "ms": {
@@ -25840,17 +26240,31 @@
           "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
           "dev": true
         },
-        "ob1": {
-          "version": "0.72.3",
-          "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.72.3.tgz",
-          "integrity": "sha512-OnVto25Sj7Ghp0vVm2THsngdze3tVq0LOg9LUHsAVXMecpqOP0Y8zaATW8M9gEgs2lNEAcCqV0P/hlmOPhVRvg==",
-          "dev": true
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
         },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
           "dev": true
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
         },
         "supports-color": {
           "version": "8.1.1",
@@ -25860,114 +26274,121 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
+        },
+        "wrap-ansi": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "y18n": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+          "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "17.6.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
+          "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^8.0.1",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.3",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^21.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "21.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+          "dev": true
         }
       }
     },
     "metro-babel-transformer": {
-      "version": "0.72.3",
-      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.72.3.tgz",
-      "integrity": "sha512-PTOR2zww0vJbWeeM3qN90WKENxCLzv9xrwWaNtwVlhcV8/diNdNe82sE1xIxLFI6OQuAVwNMv1Y7VsO2I7Ejrw==",
+      "version": "0.73.7",
+      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.73.7.tgz",
+      "integrity": "sha512-s7UVkwovGTEXYEQrv5hcmSBbFJ9s9lhCRNMScn4Itgj3UMdqRr9lU8DXKEFlJ7osgRxN6n5+eXqcvhE4B1H1VQ==",
       "dev": true,
       "requires": {
-        "@babel/core": "^7.14.0",
+        "@babel/core": "^7.20.0",
         "hermes-parser": "0.8.0",
-        "metro-source-map": "0.72.3",
+        "metro-source-map": "0.73.7",
         "nullthrows": "^1.1.1"
-      },
-      "dependencies": {
-        "metro-source-map": {
-          "version": "0.72.3",
-          "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.72.3.tgz",
-          "integrity": "sha512-eNtpjbjxSheXu/jYCIDrbNEKzMGOvYW6/ePYpRM7gDdEagUOqKOCsi3St8NJIQJzZCsxD2JZ2pYOiomUSkT1yQ==",
-          "dev": true,
-          "requires": {
-            "@babel/traverse": "^7.14.0",
-            "@babel/types": "^7.0.0",
-            "invariant": "^2.2.4",
-            "metro-symbolicate": "0.72.3",
-            "nullthrows": "^1.1.1",
-            "ob1": "0.72.3",
-            "source-map": "^0.5.6",
-            "vlq": "^1.0.0"
-          }
-        },
-        "ob1": {
-          "version": "0.72.3",
-          "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.72.3.tgz",
-          "integrity": "sha512-OnVto25Sj7Ghp0vVm2THsngdze3tVq0LOg9LUHsAVXMecpqOP0Y8zaATW8M9gEgs2lNEAcCqV0P/hlmOPhVRvg==",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-          "dev": true
-        }
       }
     },
     "metro-cache": {
-      "version": "0.72.3",
-      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.72.3.tgz",
-      "integrity": "sha512-++eyZzwkXvijWRV3CkDbueaXXGlVzH9GA52QWqTgAOgSHYp5jWaDwLQ8qpsMkQzpwSyIF4LLK9aI3eA7Xa132A==",
+      "version": "0.73.7",
+      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.73.7.tgz",
+      "integrity": "sha512-CPPgI+i9yVzOEDCdmEEZ67JgOvZyNDs8kStmGUFgDuLSjj3//HhkqT5XyfWjGeH6KmyGiS8ip3cgLOVn3IsOSA==",
       "dev": true,
       "requires": {
-        "metro-core": "0.72.3",
-        "rimraf": "^2.5.4"
+        "metro-core": "0.73.7",
+        "rimraf": "^3.0.2"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "metro-cache-key": {
-      "version": "0.72.3",
-      "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.72.3.tgz",
-      "integrity": "sha512-kQzmF5s3qMlzqkQcDwDxrOaVxJ2Bh6WRXWdzPnnhsq9LcD3B3cYqQbRBS+3tSuXmathb4gsOdhWslOuIsYS8Rg==",
+      "version": "0.73.7",
+      "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.73.7.tgz",
+      "integrity": "sha512-GngYzrHwZU9U0Xl81H4aq9Tn5cjQyU12v9/flB0hzpeiYO5A89TIeilb4Kg8jtfC6JcmmsdK9nxYIGEq7odHhQ==",
       "dev": true
     },
     "metro-config": {
-      "version": "0.72.3",
-      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.72.3.tgz",
-      "integrity": "sha512-VEsAIVDkrIhgCByq8HKTWMBjJG6RlYwWSu1Gnv3PpHa0IyTjKJtB7wC02rbTjSaemcr82scldf2R+h6ygMEvsw==",
+      "version": "0.73.7",
+      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.73.7.tgz",
+      "integrity": "sha512-pD/F+vK3u37cbj1skYmI6cUsEEscqNRtW2KlDKu1m+n8nooDB2oGTOZatlS5WQa7Ga6jYQRydftlq4CLDexAfA==",
       "dev": true,
       "requires": {
         "cosmiconfig": "^5.0.5",
         "jest-validate": "^26.5.2",
-        "metro": "0.72.3",
-        "metro-cache": "0.72.3",
-        "metro-core": "0.72.3",
-        "metro-runtime": "0.72.3"
-      },
-      "dependencies": {
-        "metro-runtime": {
-          "version": "0.72.3",
-          "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.72.3.tgz",
-          "integrity": "sha512-3MhvDKfxMg2u7dmTdpFOfdR71NgNNo4tzAyJumDVQKwnHYHN44f2QFZQqpPBEmqhWlojNeOxsqFsjYgeyMx6VA==",
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "react-refresh": "^0.4.0"
-          }
-        }
+        "metro": "0.73.7",
+        "metro-cache": "0.73.7",
+        "metro-core": "0.73.7",
+        "metro-runtime": "0.73.7"
       }
     },
     "metro-core": {
-      "version": "0.72.3",
-      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.72.3.tgz",
-      "integrity": "sha512-KuYWBMmLB4+LxSMcZ1dmWabVExNCjZe3KysgoECAIV+wyIc2r4xANq15GhS94xYvX1+RqZrxU1pa0jQ5OK+/6A==",
+      "version": "0.73.7",
+      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.73.7.tgz",
+      "integrity": "sha512-H7j1Egj1VnNnsSYf9ZKv0SRwijgtRKIcaGNQq/T+er73vqqb4kR9H+2VIJYPXi6R8lT+QLIMfs6CWSUHAJUgtg==",
       "dev": true,
       "requires": {
         "lodash.throttle": "^4.1.1",
-        "metro-resolver": "0.72.3"
+        "metro-resolver": "0.73.7"
       }
     },
     "metro-file-map": {
-      "version": "0.72.3",
-      "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.72.3.tgz",
-      "integrity": "sha512-LhuRnuZ2i2uxkpFsz1XCDIQSixxBkBG7oICAFyLyEMDGbcfeY6/NexphfLdJLTghkaoJR5ARFMiIxUg9fIY/pA==",
+      "version": "0.73.7",
+      "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.73.7.tgz",
+      "integrity": "sha512-BYaCo2e/4FMN4nOajeN+Za5cPfecfikzUYuFWWMyLAmHU6dj7B+PFkaJ4OEJO3vmRoeq5vMOmhpKXgysYbNXJg==",
       "dev": true,
       "requires": {
         "abort-controller": "^3.0.0",
         "anymatch": "^3.0.3",
         "debug": "^2.2.0",
         "fb-watchman": "^2.0.0",
-        "fsevents": "^2.1.2",
+        "fsevents": "^2.3.2",
         "graceful-fs": "^4.2.4",
         "invariant": "^2.2.4",
         "jest-regex-util": "^27.0.6",
@@ -25975,6 +26396,7 @@
         "jest-util": "^27.2.0",
         "jest-worker": "^27.2.0",
         "micromatch": "^4.0.4",
+        "nullthrows": "^1.1.1",
         "walker": "^1.0.7"
       },
       "dependencies": {
@@ -25992,18 +26414,18 @@
           }
         },
         "@types/yargs": {
-          "version": "16.0.4",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
-          "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
+          "version": "16.0.5",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.5.tgz",
+          "integrity": "sha512-AxO/ADJOBFJScHbWhq2xAhlWP24rY4aCEG/NFaMvbT3X2MgRsLjhjQwsn0Zi5zn0LG9jUhCCZMeX9Dkuw6k+vQ==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
           }
         },
         "ci-info": {
-          "version": "3.6.1",
-          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.6.1.tgz",
-          "integrity": "sha512-up5ggbaDqOqJ4UqLKZ2naVkyqSJQgJi5lwD6b6mM748ysrghDBX0bx/qJTUHzw7zu6Mq4gycviSF5hJnwceD8w==",
+          "version": "3.8.0",
+          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.8.0.tgz",
+          "integrity": "sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==",
           "dev": true
         },
         "debug": {
@@ -26080,23 +26502,58 @@
       }
     },
     "metro-hermes-compiler": {
-      "version": "0.72.3",
-      "resolved": "https://registry.npmjs.org/metro-hermes-compiler/-/metro-hermes-compiler-0.72.3.tgz",
-      "integrity": "sha512-QWDQASMiXNW3j8uIQbzIzCdGYv5PpAX/ZiF4/lTWqKRWuhlkP4auhVY4eqdAKj5syPx45ggpjkVE0p8hAPDZYg==",
+      "version": "0.73.7",
+      "resolved": "https://registry.npmjs.org/metro-hermes-compiler/-/metro-hermes-compiler-0.73.7.tgz",
+      "integrity": "sha512-F8PlJ8mWEEumGNH3eMRA3gjgP70ZvH4Ex5F1KY6ofD/gpn7w5HJHSPTeVw8gtUb1pYLN4nevptpyXGg04Jfcog==",
       "dev": true
     },
     "metro-inspector-proxy": {
-      "version": "0.72.3",
-      "resolved": "https://registry.npmjs.org/metro-inspector-proxy/-/metro-inspector-proxy-0.72.3.tgz",
-      "integrity": "sha512-UPFkaq2k93RaOi+eqqt7UUmqy2ywCkuxJLasQ55+xavTUS+TQSyeTnTczaYn+YKw+izLTLllGcvqnQcZiWYhGw==",
+      "version": "0.73.7",
+      "resolved": "https://registry.npmjs.org/metro-inspector-proxy/-/metro-inspector-proxy-0.73.7.tgz",
+      "integrity": "sha512-TsAtQeKr9X7NaQHlpshu+ZkGWlPi5fFKNqieLkfqvT1oXN4PQF/4q38INyiZtWLPvoUzTR6PRnm4pcUbJ7+Nzg==",
       "dev": true,
       "requires": {
         "connect": "^3.6.5",
         "debug": "^2.2.0",
         "ws": "^7.5.1",
-        "yargs": "^15.3.1"
+        "yargs": "^17.5.1"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "cliui": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+          "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.1",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -26106,18 +26563,88 @@
             "ms": "2.0.0"
           }
         },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
           "dev": true
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "wrap-ansi": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "y18n": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+          "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "17.6.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
+          "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^8.0.1",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.3",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^21.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "21.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+          "dev": true
         }
       }
     },
+    "metro-minify-terser": {
+      "version": "0.73.7",
+      "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.73.7.tgz",
+      "integrity": "sha512-gbv1fmMOZm6gJ6dQoD+QktlCi2wk6nlTR8j8lQCjeeXGbs6O9e5XLWNPOexHqo7S69bdbohEnfZnLJFcxgHeNw==",
+      "dev": true,
+      "requires": {
+        "terser": "^5.15.0"
+      }
+    },
     "metro-minify-uglify": {
-      "version": "0.72.3",
-      "resolved": "https://registry.npmjs.org/metro-minify-uglify/-/metro-minify-uglify-0.72.3.tgz",
-      "integrity": "sha512-dPXqtMI8TQcj0g7ZrdhC8X3mx3m3rtjtMuHKGIiEXH9CMBvrET8IwrgujQw2rkPcXiSiX8vFDbGMIlfxefDsKA==",
+      "version": "0.73.7",
+      "resolved": "https://registry.npmjs.org/metro-minify-uglify/-/metro-minify-uglify-0.73.7.tgz",
+      "integrity": "sha512-DmDCzfdbaPExQuQ7NQozCNOSOAgp5Ux9kWzmKAT8seQ38/3NtUepW+PTgxXIHmwNjJV4oHsHwlBlTwJmYihKXg==",
       "dev": true,
       "requires": {
         "uglify-es": "^3.1.9"
@@ -26171,39 +26698,27 @@
       }
     },
     "metro-react-native-babel-transformer": {
-      "version": "0.72.1",
-      "resolved": "https://registry.npmjs.org/metro-react-native-babel-transformer/-/metro-react-native-babel-transformer-0.72.1.tgz",
-      "integrity": "sha512-hMnN0MOgVloAk94YuXN7sLeDaZ51Y6xIcJXxIU1s/KaygAGXk6o7VAdwf2MY/IV1SIct5lkW4Gn71u/9/EvfXA==",
+      "version": "0.73.7",
+      "resolved": "https://registry.npmjs.org/metro-react-native-babel-transformer/-/metro-react-native-babel-transformer-0.73.7.tgz",
+      "integrity": "sha512-73HW8betjX+VPm3iqsMBe8F/F2Tt+hONO6YJwcF7FonTqQYW1oTz0dOp0dClZGfHUXxpJBz6Vuo7J6TpdzDD+w==",
       "dev": true,
       "requires": {
-        "@babel/core": "^7.14.0",
+        "@babel/core": "^7.20.0",
         "babel-preset-fbjs": "^3.4.0",
         "hermes-parser": "0.8.0",
-        "metro-babel-transformer": "0.72.1",
-        "metro-react-native-babel-preset": "0.72.1",
-        "metro-source-map": "0.72.1",
+        "metro-babel-transformer": "0.73.7",
+        "metro-react-native-babel-preset": "0.73.7",
+        "metro-source-map": "0.73.7",
         "nullthrows": "^1.1.1"
       },
       "dependencies": {
-        "metro-babel-transformer": {
-          "version": "0.72.1",
-          "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.72.1.tgz",
-          "integrity": "sha512-VK7A9gepnhrKC0DMoxtPjYYHjkkfNwzLMYJgeL6Il6IaX/K/VHTILSEqgpxfNDos2jrXazuR5+rXDLE/RCzqmw==",
-          "dev": true,
-          "requires": {
-            "@babel/core": "^7.14.0",
-            "hermes-parser": "0.8.0",
-            "metro-source-map": "0.72.1",
-            "nullthrows": "^1.1.1"
-          }
-        },
         "metro-react-native-babel-preset": {
-          "version": "0.72.1",
-          "resolved": "https://registry.npmjs.org/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.72.1.tgz",
-          "integrity": "sha512-DlvMw2tFrCqD9OXBoN11fPM09kHC22FZpnkTmG4Pr4kecV+aDmEGxwakjUcjELrX1JCXz2MLPvqeJkbiP1f5CA==",
+          "version": "0.73.7",
+          "resolved": "https://registry.npmjs.org/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.73.7.tgz",
+          "integrity": "sha512-RKcmRZREjJCzHKP+JhC9QTCohkeb3xa/DtqHU14U5KWzJHdC0mMrkTZYNXhV0cryxsaVKVEw5873KhbZyZHMVw==",
           "dev": true,
           "requires": {
-            "@babel/core": "^7.14.0",
+            "@babel/core": "^7.20.0",
             "@babel/plugin-proposal-async-generator-functions": "^7.0.0",
             "@babel/plugin-proposal-class-properties": "^7.0.0",
             "@babel/plugin-proposal-export-default-from": "^7.0.0",
@@ -26213,7 +26728,7 @@
             "@babel/plugin-proposal-optional-chaining": "^7.0.0",
             "@babel/plugin-syntax-dynamic-import": "^7.0.0",
             "@babel/plugin-syntax-export-default-from": "^7.0.0",
-            "@babel/plugin-syntax-flow": "^7.2.0",
+            "@babel/plugin-syntax-flow": "^7.18.0",
             "@babel/plugin-syntax-nullish-coalescing-operator": "^7.0.0",
             "@babel/plugin-syntax-optional-chaining": "^7.0.0",
             "@babel/plugin-transform-arrow-functions": "^7.0.0",
@@ -26222,7 +26737,6 @@
             "@babel/plugin-transform-classes": "^7.0.0",
             "@babel/plugin-transform-computed-properties": "^7.0.0",
             "@babel/plugin-transform-destructuring": "^7.0.0",
-            "@babel/plugin-transform-exponentiation-operator": "^7.0.0",
             "@babel/plugin-transform-flow-strip-types": "^7.0.0",
             "@babel/plugin-transform-function-name": "^7.0.0",
             "@babel/plugin-transform-literals": "^7.0.0",
@@ -26247,18 +26761,18 @@
       }
     },
     "metro-resolver": {
-      "version": "0.72.3",
-      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.72.3.tgz",
-      "integrity": "sha512-wu9zSMGdxpKmfECE7FtCdpfC+vrWGTdVr57lDA0piKhZV6VN6acZIvqQ1yZKtS2WfKsngncv5VbB8Y5eHRQP3w==",
+      "version": "0.73.7",
+      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.73.7.tgz",
+      "integrity": "sha512-mGW3XPeKBCwZnkHcKo1dhFa9olcx7SyNzG1vb5kjzJYe4Qs3yx04r/qFXIJLcIgLItB69TIGvosznUhpeOOXzg==",
       "dev": true,
       "requires": {
         "absolute-path": "^0.0.0"
       }
     },
     "metro-runtime": {
-      "version": "0.72.1",
-      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.72.1.tgz",
-      "integrity": "sha512-CO+fvJKYHKuR2vo7kjsegQ2oF3FMwa4YhnUInQ+xPVxWoy8DbOpmruKBoTsQVgHwyIziXzvJa+mze/6CFvT+3A==",
+      "version": "0.73.7",
+      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.73.7.tgz",
+      "integrity": "sha512-2fxRGrF8FyrwwHY0TCitdUljzutfW6CWEpdvPilfrs8p0PI5X8xOWg8ficeYtw+DldHtHIAL2phT59PqzHTyVA==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.0.0",
@@ -26266,35 +26780,21 @@
       }
     },
     "metro-source-map": {
-      "version": "0.72.1",
-      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.72.1.tgz",
-      "integrity": "sha512-77TZuf10Ru+USo97HwDT8UceSzOGBZB8EYTObOsR0n1sjQHjvKsMflLA9Pco13o9NsIYAG6c6P/0vIpiHKqaKA==",
+      "version": "0.73.7",
+      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.73.7.tgz",
+      "integrity": "sha512-gbC/lfUN52TtQhEsTTA+987MaFUpQlufuCI05blLGLosDcFCsARikHsxa65Gtslm/rG2MqvFLiPA5hviONNv9g==",
       "dev": true,
       "requires": {
-        "@babel/traverse": "^7.14.0",
-        "@babel/types": "^7.0.0",
+        "@babel/traverse": "^7.20.0",
+        "@babel/types": "^7.20.0",
         "invariant": "^2.2.4",
-        "metro-symbolicate": "0.72.1",
+        "metro-symbolicate": "0.73.7",
         "nullthrows": "^1.1.1",
-        "ob1": "0.72.1",
+        "ob1": "0.73.7",
         "source-map": "^0.5.6",
         "vlq": "^1.0.0"
       },
       "dependencies": {
-        "metro-symbolicate": {
-          "version": "0.72.1",
-          "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.72.1.tgz",
-          "integrity": "sha512-ScC3dVd2XrfZSd6kubOw7EJNp2oHdjrqOjGpFohtcXGjhqkzDosp7Fg84VgwQGN8g720xvUyEBfSMmUCXcicOQ==",
-          "dev": true,
-          "requires": {
-            "invariant": "^2.2.4",
-            "metro-source-map": "0.72.1",
-            "nullthrows": "^1.1.1",
-            "source-map": "^0.5.6",
-            "through2": "^2.0.1",
-            "vlq": "^1.0.0"
-          }
-        },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -26304,41 +26804,19 @@
       }
     },
     "metro-symbolicate": {
-      "version": "0.72.3",
-      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.72.3.tgz",
-      "integrity": "sha512-eXG0NX2PJzJ/jTG4q5yyYeN2dr1cUqUaY7worBB0SP5bRWRc3besfb+rXwfh49wTFiL5qR0oOawkU4ZiD4eHXw==",
+      "version": "0.73.7",
+      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.73.7.tgz",
+      "integrity": "sha512-571ThWmX5o8yGNzoXjlcdhmXqpByHU/bSZtWKhtgV2TyIAzYCYt4hawJAS5+/qDazUvjHdm8BbdqFUheM0EKNQ==",
       "dev": true,
       "requires": {
         "invariant": "^2.2.4",
-        "metro-source-map": "0.72.3",
+        "metro-source-map": "0.73.7",
         "nullthrows": "^1.1.1",
         "source-map": "^0.5.6",
         "through2": "^2.0.1",
         "vlq": "^1.0.0"
       },
       "dependencies": {
-        "metro-source-map": {
-          "version": "0.72.3",
-          "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.72.3.tgz",
-          "integrity": "sha512-eNtpjbjxSheXu/jYCIDrbNEKzMGOvYW6/ePYpRM7gDdEagUOqKOCsi3St8NJIQJzZCsxD2JZ2pYOiomUSkT1yQ==",
-          "dev": true,
-          "requires": {
-            "@babel/traverse": "^7.14.0",
-            "@babel/types": "^7.0.0",
-            "invariant": "^2.2.4",
-            "metro-symbolicate": "0.72.3",
-            "nullthrows": "^1.1.1",
-            "ob1": "0.72.3",
-            "source-map": "^0.5.6",
-            "vlq": "^1.0.0"
-          }
-        },
-        "ob1": {
-          "version": "0.72.3",
-          "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.72.3.tgz",
-          "integrity": "sha512-OnVto25Sj7Ghp0vVm2THsngdze3tVq0LOg9LUHsAVXMecpqOP0Y8zaATW8M9gEgs2lNEAcCqV0P/hlmOPhVRvg==",
-          "dev": true
-        },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -26348,67 +26826,37 @@
       }
     },
     "metro-transform-plugins": {
-      "version": "0.72.3",
-      "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.72.3.tgz",
-      "integrity": "sha512-D+TcUvCKZbRua1+qujE0wV1onZvslW6cVTs7dLCyC2pv20lNHjFr1GtW01jN2fyKR2PcRyMjDCppFd9VwDKnSg==",
+      "version": "0.73.7",
+      "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.73.7.tgz",
+      "integrity": "sha512-M5isiWEau0jMudb5ezaNBZnYqXxcATMqnAYc+Cu25IahT1NHi5aWwLok9EBmBpN5641IZUZXScf+KnS7fPxPCQ==",
       "dev": true,
       "requires": {
-        "@babel/core": "^7.14.0",
-        "@babel/generator": "^7.14.0",
+        "@babel/core": "^7.20.0",
+        "@babel/generator": "^7.20.0",
         "@babel/template": "^7.0.0",
-        "@babel/traverse": "^7.14.0",
+        "@babel/traverse": "^7.20.0",
         "nullthrows": "^1.1.1"
       }
     },
     "metro-transform-worker": {
-      "version": "0.72.3",
-      "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.72.3.tgz",
-      "integrity": "sha512-WsuWj9H7i6cHuJuy+BgbWht9DK5FOgJxHLGAyULD5FJdTG9rSMFaHDO5WfC0OwQU5h4w6cPT40iDuEGksM7+YQ==",
+      "version": "0.73.7",
+      "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.73.7.tgz",
+      "integrity": "sha512-gZYIu9JAqEI9Rxi0xGMuMW6QsHGbMSptozlTOwOd7T7yXX3WwYS/I3yLPbLhbZTjOhwMHkTt8Nhm2qBo8nh14g==",
       "dev": true,
       "requires": {
-        "@babel/core": "^7.14.0",
-        "@babel/generator": "^7.14.0",
-        "@babel/parser": "^7.14.0",
-        "@babel/types": "^7.0.0",
+        "@babel/core": "^7.20.0",
+        "@babel/generator": "^7.20.0",
+        "@babel/parser": "^7.20.0",
+        "@babel/types": "^7.20.0",
         "babel-preset-fbjs": "^3.4.0",
-        "metro": "0.72.3",
-        "metro-babel-transformer": "0.72.3",
-        "metro-cache": "0.72.3",
-        "metro-cache-key": "0.72.3",
-        "metro-hermes-compiler": "0.72.3",
-        "metro-source-map": "0.72.3",
-        "metro-transform-plugins": "0.72.3",
+        "metro": "0.73.7",
+        "metro-babel-transformer": "0.73.7",
+        "metro-cache": "0.73.7",
+        "metro-cache-key": "0.73.7",
+        "metro-hermes-compiler": "0.73.7",
+        "metro-source-map": "0.73.7",
+        "metro-transform-plugins": "0.73.7",
         "nullthrows": "^1.1.1"
-      },
-      "dependencies": {
-        "metro-source-map": {
-          "version": "0.72.3",
-          "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.72.3.tgz",
-          "integrity": "sha512-eNtpjbjxSheXu/jYCIDrbNEKzMGOvYW6/ePYpRM7gDdEagUOqKOCsi3St8NJIQJzZCsxD2JZ2pYOiomUSkT1yQ==",
-          "dev": true,
-          "requires": {
-            "@babel/traverse": "^7.14.0",
-            "@babel/types": "^7.0.0",
-            "invariant": "^2.2.4",
-            "metro-symbolicate": "0.72.3",
-            "nullthrows": "^1.1.1",
-            "ob1": "0.72.3",
-            "source-map": "^0.5.6",
-            "vlq": "^1.0.0"
-          }
-        },
-        "ob1": {
-          "version": "0.72.3",
-          "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.72.3.tgz",
-          "integrity": "sha512-OnVto25Sj7Ghp0vVm2THsngdze3tVq0LOg9LUHsAVXMecpqOP0Y8zaATW8M9gEgs2lNEAcCqV0P/hlmOPhVRvg==",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-          "dev": true
-        }
       }
     },
     "micromatch": {
@@ -26570,9 +27018,9 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
+      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
       "dev": true,
       "requires": {
         "whatwg-url": "^5.0.0"
@@ -26679,9 +27127,9 @@
       "dev": true
     },
     "ob1": {
-      "version": "0.72.1",
-      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.72.1.tgz",
-      "integrity": "sha512-TyQX2gO08klGTMuzD+xm3iVrzXiIygCB7t+NWeicOR05hkzgeWOiAZ8q40uMfIDRfEAc6hd66sJdIEhU/yUZZA==",
+      "version": "0.73.7",
+      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.73.7.tgz",
+      "integrity": "sha512-DfelfvR843KADhSUATGGhuepVMRcf5VQX+6MQLy5AW0BKDLlO7Usj6YZeAAZP7P86QwsoTxB0RXCFiA7t6S1IQ==",
       "dev": true
     },
     "object-assign": {
@@ -27164,9 +27612,9 @@
       "dev": true
     },
     "promise": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-8.1.0.tgz",
-      "integrity": "sha512-W04AqnILOL/sPRXziNicCjSNRruLAuIHEOVBazepu0545DDNGYHz7ar9ZgZ1fMU8/MA4mVxp5rkBWRi6OXIy3Q==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-8.3.0.tgz",
+      "integrity": "sha512-rZPNPKTOYVNEEKFaq1HqTgOwZD+4/YHS5ukLzQCypkj+OkYx7iv0mA91lJlpPPZ8vMau3IIGj5Qlwrx+8iiSmg==",
       "dev": true,
       "requires": {
         "asap": "~2.0.6"
@@ -27243,18 +27691,18 @@
       "dev": true
     },
     "react": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.1.0.tgz",
-      "integrity": "sha512-4oL8ivCz5ZEPyclFQXaNksK3adutVS8l2xzZU0cqEFrE9Sb7fC0EFK5uEk74wIreL1DERyjvsU915j1pcT2uEQ==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
       "dev": true,
       "requires": {
         "loose-envify": "^1.1.0"
       }
     },
     "react-devtools-core": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-4.24.0.tgz",
-      "integrity": "sha512-Rw7FzYOOzcfyUPaAm9P3g0tFdGqGq2LLiAI+wjYcp6CsF3DeeMrRS3HZAho4s273C29G/DJhx0e8BpRE/QZNGg==",
+      "version": "4.27.2",
+      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-4.27.2.tgz",
+      "integrity": "sha512-8SzmIkpO87alD7Xr6gWIEa1jHkMjawOZ+6egjazlnjB4UUcbnzGDf/vBJ4BzGuWWEM+pzrxuzsPpcMqlQkYK2g==",
       "dev": true,
       "requires": {
         "shell-quote": "^1.6.1",
@@ -27268,45 +27716,132 @@
       "dev": true
     },
     "react-native": {
-      "version": "0.70.0",
-      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.70.0.tgz",
-      "integrity": "sha512-QjXLbrK9f+/B2eCzn6kAvglLV/8nwPuFGaFv7ggPpAzFRyx5bVN1dwQLHL3MrP7iXR/M7Jc6Nnid7tmRSic6vA==",
+      "version": "0.71.2",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.71.2.tgz",
+      "integrity": "sha512-ZSianM+j+09LoEdVIhrAP/uP8sQhT7dH6olCqM2xlpxmfCgA5NubsK6NABIuZiBlmmqjigyijm5Y/GhBIHDvEg==",
       "dev": true,
       "requires": {
-        "@jest/create-cache-key-function": "^27.0.1",
-        "@react-native-community/cli": "^9.0.0",
-        "@react-native-community/cli-platform-android": "^9.0.0",
-        "@react-native-community/cli-platform-ios": "^9.0.0",
+        "@jest/create-cache-key-function": "^29.2.1",
+        "@react-native-community/cli": "10.1.3",
+        "@react-native-community/cli-platform-android": "10.1.3",
+        "@react-native-community/cli-platform-ios": "10.1.1",
         "@react-native/assets": "1.0.0",
-        "@react-native/normalize-color": "2.0.0",
+        "@react-native/normalize-color": "2.1.0",
         "@react-native/polyfills": "2.0.0",
         "abort-controller": "^3.0.0",
         "anser": "^1.4.9",
         "base64-js": "^1.1.2",
+        "deprecated-react-native-prop-types": "^3.0.1",
         "event-target-shim": "^5.0.1",
         "invariant": "^2.2.4",
+        "jest-environment-node": "^29.2.1",
         "jsc-android": "^250230.2.1",
         "memoize-one": "^5.0.0",
-        "metro-react-native-babel-transformer": "0.72.1",
-        "metro-runtime": "0.72.1",
-        "metro-source-map": "0.72.1",
+        "metro-react-native-babel-transformer": "0.73.7",
+        "metro-runtime": "0.73.7",
+        "metro-source-map": "0.73.7",
         "mkdirp": "^0.5.1",
         "nullthrows": "^1.1.1",
         "pretty-format": "^26.5.2",
-        "promise": "^8.0.3",
-        "react-devtools-core": "4.24.0",
-        "react-native-codegen": "^0.70.4",
-        "react-native-gradle-plugin": "^0.70.2",
+        "promise": "^8.3.0",
+        "react-devtools-core": "^4.26.1",
+        "react-native-codegen": "^0.71.3",
+        "react-native-gradle-plugin": "^0.71.14",
         "react-refresh": "^0.4.0",
         "react-shallow-renderer": "^16.15.0",
         "regenerator-runtime": "^0.13.2",
-        "scheduler": "^0.22.0",
+        "scheduler": "^0.23.0",
         "stacktrace-parser": "^0.1.3",
         "use-sync-external-store": "^1.0.0",
         "whatwg-fetch": "^3.0.0",
-        "ws": "^6.1.4"
+        "ws": "^6.2.2"
       },
       "dependencies": {
+        "@jest/environment": {
+          "version": "29.4.3",
+          "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.4.3.tgz",
+          "integrity": "sha512-dq5S6408IxIa+lr54zeqce+QgI+CJT4nmmA+1yzFgtcsGK8c/EyiUb9XQOgz3BMKrRDfKseeOaxj2eO8LlD3lA==",
+          "dev": true,
+          "requires": {
+            "@jest/fake-timers": "^29.4.3",
+            "@jest/types": "^29.4.3",
+            "@types/node": "*",
+            "jest-mock": "^29.4.3"
+          },
+          "dependencies": {
+            "@jest/types": {
+              "version": "29.4.3",
+              "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.4.3.tgz",
+              "integrity": "sha512-bPYfw8V65v17m2Od1cv44FH+SiKW7w2Xu7trhcdTLUmSv85rfKsP+qXSjO4KGJr4dtPSzl/gvslZBXctf1qGEA==",
+              "dev": true,
+              "requires": {
+                "@jest/schemas": "^29.4.3",
+                "@types/istanbul-lib-coverage": "^2.0.0",
+                "@types/istanbul-reports": "^3.0.0",
+                "@types/node": "*",
+                "@types/yargs": "^17.0.8",
+                "chalk": "^4.0.0"
+              }
+            }
+          }
+        },
+        "@jest/fake-timers": {
+          "version": "29.4.3",
+          "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.4.3.tgz",
+          "integrity": "sha512-4Hote2MGcCTWSD2gwl0dwbCpBRHhE6olYEuTj8FMowdg3oQWNKr2YuxenPQYZ7+PfqPY1k98wKDU4Z+Hvd4Tiw==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^29.4.3",
+            "@sinonjs/fake-timers": "^10.0.2",
+            "@types/node": "*",
+            "jest-message-util": "^29.4.3",
+            "jest-mock": "^29.4.3",
+            "jest-util": "^29.4.3"
+          },
+          "dependencies": {
+            "@jest/types": {
+              "version": "29.4.3",
+              "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.4.3.tgz",
+              "integrity": "sha512-bPYfw8V65v17m2Od1cv44FH+SiKW7w2Xu7trhcdTLUmSv85rfKsP+qXSjO4KGJr4dtPSzl/gvslZBXctf1qGEA==",
+              "dev": true,
+              "requires": {
+                "@jest/schemas": "^29.4.3",
+                "@types/istanbul-lib-coverage": "^2.0.0",
+                "@types/istanbul-reports": "^3.0.0",
+                "@types/node": "*",
+                "@types/yargs": "^17.0.8",
+                "chalk": "^4.0.0"
+              }
+            }
+          }
+        },
+        "@sinonjs/commons": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
+          "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+          "dev": true,
+          "requires": {
+            "type-detect": "4.0.8"
+          }
+        },
+        "@sinonjs/fake-timers": {
+          "version": "10.0.2",
+          "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.0.2.tgz",
+          "integrity": "sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==",
+          "dev": true,
+          "requires": {
+            "@sinonjs/commons": "^2.0.0"
+          }
+        },
+        "@types/yargs": {
+          "version": "17.0.22",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.22.tgz",
+          "integrity": "sha512-pet5WJ9U8yPVRhkwuEIp5ktAeAqRZOq4UdAyWLWzxbtpyXnzbtLdKiXAjJzi/KLmPGS9wk86lUFWZFN6sISo4g==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -27315,6 +27850,12 @@
           "requires": {
             "color-convert": "^2.0.1"
           }
+        },
+        "ci-info": {
+          "version": "3.8.0",
+          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.8.0.tgz",
+          "integrity": "sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==",
+          "dev": true
         },
         "color-convert": {
           "version": "2.0.1",
@@ -27330,6 +27871,149 @@
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
+        },
+        "jest-environment-node": {
+          "version": "29.4.3",
+          "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.4.3.tgz",
+          "integrity": "sha512-gAiEnSKF104fsGDXNkwk49jD/0N0Bqu2K9+aMQXA6avzsA9H3Fiv1PW2D+gzbOSR705bWd2wJZRFEFpV0tXISg==",
+          "dev": true,
+          "requires": {
+            "@jest/environment": "^29.4.3",
+            "@jest/fake-timers": "^29.4.3",
+            "@jest/types": "^29.4.3",
+            "@types/node": "*",
+            "jest-mock": "^29.4.3",
+            "jest-util": "^29.4.3"
+          },
+          "dependencies": {
+            "@jest/types": {
+              "version": "29.4.3",
+              "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.4.3.tgz",
+              "integrity": "sha512-bPYfw8V65v17m2Od1cv44FH+SiKW7w2Xu7trhcdTLUmSv85rfKsP+qXSjO4KGJr4dtPSzl/gvslZBXctf1qGEA==",
+              "dev": true,
+              "requires": {
+                "@jest/schemas": "^29.4.3",
+                "@types/istanbul-lib-coverage": "^2.0.0",
+                "@types/istanbul-reports": "^3.0.0",
+                "@types/node": "*",
+                "@types/yargs": "^17.0.8",
+                "chalk": "^4.0.0"
+              }
+            }
+          }
+        },
+        "jest-message-util": {
+          "version": "29.4.3",
+          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.4.3.tgz",
+          "integrity": "sha512-1Y8Zd4ZCN7o/QnWdMmT76If8LuDv23Z1DRovBj/vcSFNlGCJGoO8D1nJDw1AdyAGUk0myDLFGN5RbNeJyCRGCw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.12.13",
+            "@jest/types": "^29.4.3",
+            "@types/stack-utils": "^2.0.0",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.9",
+            "micromatch": "^4.0.4",
+            "pretty-format": "^29.4.3",
+            "slash": "^3.0.0",
+            "stack-utils": "^2.0.3"
+          },
+          "dependencies": {
+            "@jest/types": {
+              "version": "29.4.3",
+              "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.4.3.tgz",
+              "integrity": "sha512-bPYfw8V65v17m2Od1cv44FH+SiKW7w2Xu7trhcdTLUmSv85rfKsP+qXSjO4KGJr4dtPSzl/gvslZBXctf1qGEA==",
+              "dev": true,
+              "requires": {
+                "@jest/schemas": "^29.4.3",
+                "@types/istanbul-lib-coverage": "^2.0.0",
+                "@types/istanbul-reports": "^3.0.0",
+                "@types/node": "*",
+                "@types/yargs": "^17.0.8",
+                "chalk": "^4.0.0"
+              }
+            },
+            "ansi-styles": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+              "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+              "dev": true
+            },
+            "pretty-format": {
+              "version": "29.4.3",
+              "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.4.3.tgz",
+              "integrity": "sha512-cvpcHTc42lcsvOOAzd3XuNWTcvk1Jmnzqeu+WsOuiPmxUJTnkbAcFNsRKvEpBEUFVUgy/GTZLulZDcDEi+CIlA==",
+              "dev": true,
+              "requires": {
+                "@jest/schemas": "^29.4.3",
+                "ansi-styles": "^5.0.0",
+                "react-is": "^18.0.0"
+              }
+            },
+            "react-is": {
+              "version": "18.2.0",
+              "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+              "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+              "dev": true
+            }
+          }
+        },
+        "jest-mock": {
+          "version": "29.4.3",
+          "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.4.3.tgz",
+          "integrity": "sha512-LjFgMg+xed9BdkPMyIJh+r3KeHt1klXPJYBULXVVAkbTaaKjPX1o1uVCAZADMEp/kOxGTwy/Ot8XbvgItOrHEg==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^29.4.3",
+            "@types/node": "*",
+            "jest-util": "^29.4.3"
+          },
+          "dependencies": {
+            "@jest/types": {
+              "version": "29.4.3",
+              "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.4.3.tgz",
+              "integrity": "sha512-bPYfw8V65v17m2Od1cv44FH+SiKW7w2Xu7trhcdTLUmSv85rfKsP+qXSjO4KGJr4dtPSzl/gvslZBXctf1qGEA==",
+              "dev": true,
+              "requires": {
+                "@jest/schemas": "^29.4.3",
+                "@types/istanbul-lib-coverage": "^2.0.0",
+                "@types/istanbul-reports": "^3.0.0",
+                "@types/node": "*",
+                "@types/yargs": "^17.0.8",
+                "chalk": "^4.0.0"
+              }
+            }
+          }
+        },
+        "jest-util": {
+          "version": "29.4.3",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.4.3.tgz",
+          "integrity": "sha512-ToSGORAz4SSSoqxDSylWX8JzkOQR7zoBtNRsA7e+1WUX5F8jrOwaNpuh1YfJHJKDHXLHmObv5eOjejUd+/Ws+Q==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^29.4.3",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "ci-info": "^3.2.0",
+            "graceful-fs": "^4.2.9",
+            "picomatch": "^2.2.3"
+          },
+          "dependencies": {
+            "@jest/types": {
+              "version": "29.4.3",
+              "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.4.3.tgz",
+              "integrity": "sha512-bPYfw8V65v17m2Od1cv44FH+SiKW7w2Xu7trhcdTLUmSv85rfKsP+qXSjO4KGJr4dtPSzl/gvslZBXctf1qGEA==",
+              "dev": true,
+              "requires": {
+                "@jest/schemas": "^29.4.3",
+                "@types/istanbul-lib-coverage": "^2.0.0",
+                "@types/istanbul-reports": "^3.0.0",
+                "@types/node": "*",
+                "@types/yargs": "^17.0.8",
+                "chalk": "^4.0.0"
+              }
+            }
+          }
         },
         "pretty-format": {
           "version": "26.6.2",
@@ -27349,6 +28033,15 @@
           "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
           "dev": true
         },
+        "scheduler": {
+          "version": "0.23.0",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+          "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.1.0"
+          }
+        },
         "ws": {
           "version": "6.2.2",
           "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.2.tgz",
@@ -27361,21 +28054,21 @@
       }
     },
     "react-native-codegen": {
-      "version": "0.70.6",
-      "resolved": "https://registry.npmjs.org/react-native-codegen/-/react-native-codegen-0.70.6.tgz",
-      "integrity": "sha512-kdwIhH2hi+cFnG5Nb8Ji2JwmcCxnaOOo9440ov7XDzSvGfmUStnCzl+MCW8jLjqHcE4icT7N9y+xx4f50vfBTw==",
+      "version": "0.71.5",
+      "resolved": "https://registry.npmjs.org/react-native-codegen/-/react-native-codegen-0.71.5.tgz",
+      "integrity": "sha512-rfsuc0zkuUuMjFnrT55I1mDZ+pBRp2zAiRwxck3m6qeGJBGK5OV5JH66eDQ4aa+3m0of316CqrJDRzVlYufzIg==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.14.0",
-        "flow-parser": "^0.121.0",
+        "flow-parser": "^0.185.0",
         "jscodeshift": "^0.13.1",
         "nullthrows": "^1.1.1"
       }
     },
     "react-native-gradle-plugin": {
-      "version": "0.70.3",
-      "resolved": "https://registry.npmjs.org/react-native-gradle-plugin/-/react-native-gradle-plugin-0.70.3.tgz",
-      "integrity": "sha512-oOanj84fJEXUg9FoEAQomA8ISG+DVIrTZ3qF7m69VQUJyOGYyDZmPqKcjvRku4KXlEH6hWO9i4ACLzNBh8gC0A==",
+      "version": "0.71.15",
+      "resolved": "https://registry.npmjs.org/react-native-gradle-plugin/-/react-native-gradle-plugin-0.71.15.tgz",
+      "integrity": "sha512-7S3pAuPaQJlhax6EZ4JMsDNpj05TfuzX9gPgWLrFfAIWIFLuJ6aDQYAZy2TEI9QJALPoWrj8LWaqP/DGYh14pw==",
       "dev": true
     },
     "react-native-performance": {
@@ -27386,9 +28079,9 @@
       "requires": {}
     },
     "react-native-quick-sqlite": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/react-native-quick-sqlite/-/react-native-quick-sqlite-5.0.3.tgz",
-      "integrity": "sha512-xaVPpVwFw0IB4+Tw63MhZJtUNr+CEF68grg2TWQMKK71oNjBffnL5uMMmVEmOgLKe6Wxto0JOPx/aWcgOeK9bQ==",
+      "version": "8.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/react-native-quick-sqlite/-/react-native-quick-sqlite-8.0.0-beta.2.tgz",
+      "integrity": "sha512-B7makWA5GrlkUSRderWGuuEg83QDfRPjKYdBXiGx6L1hm2BhJ4u+sv6q+bTGoXAieEKcIPh+qeA/hhEat+dC2g==",
       "dev": true,
       "requires": {}
     },
@@ -27539,9 +28232,9 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
           "dev": true
         }
       }
@@ -28221,9 +28914,9 @@
       "dev": true
     },
     "shell-quote": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.4.tgz",
-      "integrity": "sha512-8o/QEhSSRb1a5i7TFR0iM4G16Z0vYB2OQVs4G3aAFXjn3T6yEx8AZxy1PgDF7I00LZHYA3WxaSYIf5e5sAX8Rw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.0.tgz",
+      "integrity": "sha512-QHsz8GgQIGKlRi24yFc6a6lN69Idnx634w49ay6+jA5yFh7a1UY+4Rp6HPx/L/1zcEDPEij8cIsiqR6bQsE5VQ==",
       "dev": true
     },
     "shellwords": {
@@ -28883,52 +29576,15 @@
       }
     },
     "terser": {
-      "version": "5.13.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.13.1.tgz",
-      "integrity": "sha512-hn4WKOfwnwbYfe48NgrQjqNOH9jzLqRcIfbYytOXCOv46LBfWr9bDS17MQqOi+BWGD0sJK3Sj5NC/gJjiojaoA==",
+      "version": "5.16.3",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.3.tgz",
+      "integrity": "sha512-v8wWLaS/xt3nE9dgKEWhNUFP6q4kngO5B8eYFUuebsu7Dw/UNAnpUod6UHo04jSSkv8TzKHjZDSd7EXdDQAl8Q==",
       "dev": true,
       "requires": {
+        "@jridgewell/source-map": "^0.3.2",
         "acorn": "^8.5.0",
         "commander": "^2.20.0",
-        "source-map": "~0.8.0-beta.0",
         "source-map-support": "~0.5.20"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.8.0-beta.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
-          "integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
-          "dev": true,
-          "requires": {
-            "whatwg-url": "^7.0.0"
-          }
-        },
-        "tr46": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-          "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
-          "dev": true,
-          "requires": {
-            "punycode": "^2.1.0"
-          }
-        },
-        "webidl-conversions": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-          "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
-          "dev": true
-        },
-        "whatwg-url": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
-          "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
-          "dev": true,
-          "requires": {
-            "lodash.sortby": "^4.7.0",
-            "tr46": "^1.0.1",
-            "webidl-conversions": "^4.0.2"
-          }
-        }
       }
     },
     "terser-webpack-plugin": {

--- a/package.json
+++ b/package.json
@@ -66,10 +66,10 @@
     "localforage": "^1.10.0",
     "metro-react-native-babel-preset": "^0.72.3",
     "prop-types": "^15.7.2",
-    "react": "18.1.0",
-    "react-native": "0.70.0",
+    "react": "18.2.0",
+    "react-native": "0.71.2",
     "react-native-performance": "^2.0.0",
-    "react-native-quick-sqlite": "^5.0.3",
+    "react-native-quick-sqlite": "^8.0.0-beta.2",
     "react-test-renderer": "18.1.0",
     "webpack": "^5.72.1",
     "webpack-cli": "^4.9.2",
@@ -81,7 +81,7 @@
     "localforage": "^1.10.0",
     "react": ">=18.1.0",
     "react-native-performance": "^4.0.0",
-    "react-native-quick-sqlite": "^5.0.3"
+    "react-native-quick-sqlite": "^8.0.0-beta.2"
   },
   "peerDependenciesMeta": {
     "react-native-performance": {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
This PR upgrades the `react-native` version to v0.71.2 & also upgrades the `react-native-quick-sqlite` to v8.0.0-beta.2 as that includes the v0.71.2 upgrade.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/App/issues/15124

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
No tests have been added as just upgrading the dependancy versions

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->
https://github.com/Expensify/App/pull/15130 is dependent on this PR
