### PR TITLE
Clear cache in Onyx.clear()

### DIFF
--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -1100,6 +1100,8 @@ function clear(keysToPreserve = []) {
             const defaultKeyValuePairs = _.pairs(_.omit(defaultKeyStates, keysToPreserve));
 
             // Remove only the items that we want cleared from storage, and reset others to default
+            _.each(keysToBeClearedFromStorage, key => cache.drop(key));
+            _.each(defaultKeyValuePairs, ([key, value]) => cache.set(key, value));
             return Storage.removeItems(keysToBeClearedFromStorage).then(() => Storage.multiSet(defaultKeyValuePairs));
         });
 }


### PR DESCRIPTION
### Details
We recently updated `Onyx.clear` such that it actually removes items we don't want to keep from storage, rather than just setting them to null. However, we did not update `Onyx.clear()` to update the cache accordingly.

cc @tienifr

### Related Issues
https://github.com/Expensify/Expensify/issues/277227 – related to tests

### Automated Tests
I was testing this in https://github.com/Expensify/App/pull/17718 – there are currently some `TODOs` above code that filters out null items from Onyx because they're making it harder to make assertions about things like the number of reports in Onyx.

After updating Onyx to use v39 which includes the new version of `Onyx.clear` and removing the filters, I found that the test was still failing and showed reports that should have been cleared as `null` in Onyx. After debugging, I discovered that the problem was that the cache was not being updated correctly.

### Linked PRs
https://github.com/Expensify/App/pull/17718