### PR TITLE
Use GitHub native concurrency in react-native-onyx

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,10 @@ on:
     push:
         branches: [main]
 
+# Ensure that only once instance of this workflow executes at a time.
+# If multiple PRs are merged in quick succession, there will only ever be one running publish job and one pending.
+concurrency: ${{ github.workflow }}
+
 jobs:
     version:
         runs-on: ubuntu-latest
@@ -13,14 +17,6 @@ jobs:
         if: ${{ github.actor != 'OSBotify' }}
 
         steps:
-            # Running this action ensures that only one instance of this job will run at a time.
-            # This is important to prevent race conditions when multiple pull requests are merged in quick succession
-            - uses: softprops/turnstyle@8db075d65b19bf94e6e8687b504db69938dc3c65
-              with:
-                  poll-interval-seconds: 10
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
             - uses: actions/checkout@v3
 
             - name: Decrypt & Import OSBotify GPG key

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
         branches: [main]
 
 # Ensure that only once instance of this workflow executes at a time.
-# If multiple PRs are merged in quick succession, there will only ever be one running publish job and one pending.
+# If multiple PRs are merged in quick succession, there will only ever be one publish workflow running and one pending.
 concurrency: ${{ github.workflow }}
 
 jobs:


### PR DESCRIPTION
### Details
This PR is a bit of an experiment so that we can get some hands-on experience using GitHub's native concurrency feature.

To test this PR, we need to:

1. Merge it
1. Merge another two test PRs in quick succession.

and we should expect that:

1. A publishing workflow starts when this PR is merged
1. When the first test PR is merged, another publishing workflow is queued but does not start.
1. When the second test PR is merged, the previously queued publishing workflow is cancelled and a new publishing workflow is queued.

### Related Issues
n/a

### Automated Tests
None

### Linked PRs
None.
