### PR TITLE
[No QA] Use built-in cache from setup-node

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,17 +10,12 @@ jobs:
         steps:
             - uses: actions/checkout@v2
 
-            - uses: actions/cache@v2
-              with:
-                  path: ~/.npm
-                  key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-                  restore-keys: |
-                      ${{ runner.os }}-node-
-
             - name: Setup Node
-              uses: actions/setup-node@v1
+              uses: actions/setup-node@v3
               with:
                   node-version: "16.x"
+                  cache: npm
+                  cache-dependency-path: package-lock.json
 
             - run: npm ci
 


### PR DESCRIPTION
This PR sets up built-in caching for setup-node like we do in E/App, but really it's main purpose is as a dummy PR to help test https://github.com/Expensify/react-native-onyx/pull/252