### PR TITLE
Checkout main branch instead of ref that triggered workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,8 @@ jobs:
 
         steps:
             - uses: actions/checkout@v3
+              with:
+                ref: main
 
             - name: Decrypt & Import OSBotify GPG key
               run: |


### PR DESCRIPTION
Following-up on https://github.com/Expensify/react-native-onyx/pull/252, we need to checkout the main branch, not the ref that triggered the workflow, for this to work as expected.