### PR TITLE
Don't call selector with selector results

### DIFF
--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -364,7 +364,7 @@ function keysChanged(collectionKey, partialCollection) {
                 // returned by the selector.
                 if (subscriber.selector) {
                     subscriber.withOnyxInstance.setState((prevState) => {
-                        const previousData = reduceCollectionWithSelector(prevState[subscriber.statePropertyName], subscriber.selector, subscriber.withOnyxInstance.state);
+                        const previousData = prevState[subscriber.statePropertyName];
                         const newData = reduceCollectionWithSelector(cachedCollection, subscriber.selector, subscriber.withOnyxInstance.state);
 
                         if (!deepEqual(previousData, newData)) {

--- a/tests/unit/subscribeToPropertiesTest.js
+++ b/tests/unit/subscribeToPropertiesTest.js
@@ -190,6 +190,14 @@ describe('Only the specific property changes when using withOnyx() and ', () => 
         })(ViewWithObject);
         return runAllAssertionsForCollection(TestComponentWithOnyx)
             .then(() => {
+                // Expect that the selector always gets called with the full object
+                // from the onyx state, and not with the selector result value (string in this case).
+                for (let i = 0; i < mockedSelector.mock.calls.length; i++) {
+                    const firstArg = mockedSelector.mock.calls[i][0];
+                    expect(firstArg).toBeDefined();
+                    expect(firstArg).toBeInstanceOf(Object);
+                }
+
                 // Check to make sure that the selector was called with the props that are passed to the rendered component
                 expect(mockedSelector).toHaveBeenNthCalledWith(5, {a: 'two', b: 'two'}, {loading: false, collectionWithPropertyA: {test_1: 'one', test_2: undefined}});
             });


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

While investigating an issue in the Expensify app, I found a case where a onyx selector seemed to get called with the previous selector's return value, instead with the value from onyx.
I added a test and was able to verify the buggy behaviour. After some debugging I found that we put the state of the component into the selector function (which feels just wrong, because the selector is supposed to receive the real onyx data). This explained why I was seeing calls of the selector with the previous computed selector value.

This PR fixes this behaviour and thus the `deepEqual` check can run correctly.


### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/App/issues/21022

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

I updated the tests to check for that case.

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->

I don't understand this one?
