### PR TITLE
Remove expensify-common library from project

### DIFF
--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -1,14 +1,14 @@
 /* eslint-disable no-continue */
-import _ from 'underscore';
-import Str from 'expensify-common/lib/str';
 import {deepEqual} from 'fast-equals';
 import lodashGet from 'lodash/get';
-import Storage from './storage';
+import _ from 'underscore';
 import * as Logger from './Logger';
 import cache from './OnyxCache';
+import Str from './Str';
 import createDeferredTask from './createDeferredTask';
 import fastMerge from './fastMerge';
 import * as PerformanceUtils from './metrics/PerformanceUtils';
+import Storage from './storage';
 
 // Method constants
 const METHOD = {

--- a/lib/Str.js
+++ b/lib/Str.js
@@ -1,0 +1,30 @@
+import _ from 'underscore';
+
+const Str = {
+    /**
+     * Returns true if the haystack begins with the needle
+     *
+     * @param {String} haystack  The full string to be searched
+     * @param {String} needle    The case-sensitive string to search for
+     * @return {Boolean} Retruns true if the haystack starts with the needle.
+     */
+    startsWith(haystack, needle) {
+        return _.isString(haystack)
+                && _.isString(needle)
+                && haystack.substring(0, needle.length) === needle;
+    },
+
+    /**
+     * Checks if parameter is a string or function
+     * if it is a function then we will call it with
+     * any additional arguments.
+     *
+     * @param {String|Function} parameter
+     * @returns {String}
+     */
+    result(parameter, ...args) {
+        return _.isFunction(parameter) ? parameter(...args) : parameter;
+    },
+};
+
+export default Str;

--- a/lib/withOnyx.js
+++ b/lib/withOnyx.js
@@ -3,11 +3,11 @@
  * something in Onyx (a key/value store). That way, as soon as data in Onyx changes, the state will be set and the view
  * will automatically change to reflect the new data.
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import _ from 'underscore';
-import PropTypes from 'prop-types';
-import Str from 'expensify-common/lib/str';
 import Onyx from './Onyx';
+import Str from './Str';
 
 /**
  * Returns the display name of a component

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
         "eslint-config-expensify": "^2.0.24",
         "eslint-plugin-jsx-a11y": "^6.6.1",
         "eslint-plugin-react": "^7.31.10",
-        "expensify-common": "git+https://github.com/Expensify/expensify-common.git#427295da130a4eacc184d38693664280d020dffd",
         "jest": "^26.5.2",
         "jest-cli": "^26.5.2",
         "jsdoc-to-markdown": "^7.1.0",
@@ -49,7 +48,6 @@
         "npm": "8.11.0"
       },
       "peerDependencies": {
-        "expensify-common": ">=1",
         "localforage": "^1.10.0",
         "localforage-removeitems": "^1.4.0",
         "react": ">=18.1.0",
@@ -5133,12 +5131,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/classnames": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
-      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==",
-      "dev": true
-    },
     "node_modules/cli-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
@@ -5170,17 +5162,6 @@
       "dev": true,
       "engines": {
         "node": ">= 10"
-      }
-    },
-    "node_modules/clipboard": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.4.tgz",
-      "integrity": "sha512-Vw26VSLRpJfBofiVaFb/I8PVfdI1OxKcYShe6fm0sP/DtmiWQNCjhM/okTvdCo0G+lMMm1rMYbk4IK4x1X+kgQ==",
-      "dev": true,
-      "dependencies": {
-        "good-listener": "^1.2.2",
-        "select": "^1.1.2",
-        "tiny-emitter": "^2.0.0"
       }
     },
     "node_modules/cliui": {
@@ -5897,12 +5878,6 @@
       "engines": {
         "node": ">=0.4.0"
       }
-    },
-    "node_modules/delegate": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
-      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
-      "dev": true
     },
     "node_modules/denodeify": {
       "version": "1.2.1",
@@ -7621,80 +7596,6 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
     },
-    "node_modules/expensify-common": {
-      "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/Expensify/expensify-common.git#427295da130a4eacc184d38693664280d020dffd",
-      "integrity": "sha512-87c3wys2ZuOnfwe5TnNupAyKVZG8QghDAB0J7VlMXZJaIZaCNm9rLKAiTX8TrW8WATaCKXx0VdBYJl49hiCuZg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "classnames": "2.3.1",
-        "clipboard": "2.0.4",
-        "html-entities": "^1.3.1",
-        "jquery": "3.6.0",
-        "lodash": "4.17.21",
-        "prop-types": "15.7.2",
-        "react": "16.12.0",
-        "react-dom": "16.12.0",
-        "semver": "^7.3.5",
-        "simply-deferred": "git+https://github.com/Expensify/simply-deferred.git#77a08a95754660c7bd6e0b6979fdf84e8e831bf5",
-        "underscore": "1.13.1"
-      }
-    },
-    "node_modules/expensify-common/node_modules/react": {
-      "version": "16.12.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.12.0.tgz",
-      "integrity": "sha512-fglqy3k5E+81pA8s+7K0/T3DBCF0ZDOher1elBFzF7O6arXJgzyu/FW+COxFvAWXJoJN9KIZbT2LXlukwphYTA==",
-      "dev": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/expensify-common/node_modules/react-dom": {
-      "version": "16.12.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.12.0.tgz",
-      "integrity": "sha512-LMxFfAGrcS3kETtQaCkTKjMiifahaMySFDn71fZUNpPHZQEzmk/GiAeIT8JSOrHB23fnuCOMruL2a8NYlw+8Gw==",
-      "dev": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.18.0"
-      },
-      "peerDependencies": {
-        "react": "^16.0.0"
-      }
-    },
-    "node_modules/expensify-common/node_modules/scheduler": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.18.0.tgz",
-      "integrity": "sha512-agTSHR1Nbfi6ulI0kYNK0203joW2Y5W4po4l+v03tOoiJKpTBbxpNhWDvqc/4IcOw+KLmSiQLTasZ4cab2/UWQ==",
-      "dev": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      }
-    },
-    "node_modules/expensify-common/node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/extend-shallow": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
@@ -8317,15 +8218,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/good-listener": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
-      "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
-      "dev": true,
-      "dependencies": {
-        "delegate": "^3.1.2"
-      }
-    },
     "node_modules/graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
@@ -8558,12 +8450,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/html-entities": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.4.0.tgz",
-      "integrity": "sha512-8nxjcBcd8wovbeKx7h3wTji4e6+rhaVuPNpMqwWgnHh+N9ToqsCs6XztWRBPQ+UtzsoMAdKZtUENoVzU/EMtZA==",
-      "dev": true
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -10610,12 +10496,6 @@
         "@hapi/topo": "^6.0.1"
       }
     },
-    "node_modules/jquery": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
-      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==",
-      "dev": true
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -11309,18 +11189,6 @@
       },
       "bin": {
         "loose-envify": "cli.js"
-      }
-    },
-    "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/make-dir": {
@@ -14754,12 +14622,6 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/select": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
-      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
-      "dev": true
-    },
     "node_modules/semver": {
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
@@ -14990,15 +14852,6 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
-    },
-    "node_modules/simply-deferred": {
-      "version": "3.0.0",
-      "resolved": "git+ssh://git@github.com/Expensify/simply-deferred.git#77a08a95754660c7bd6e0b6979fdf84e8e831bf5",
-      "integrity": "sha512-DSHaVm+6KduK2+cOnaA+choq8CowotOpFhmHDCL36Cb/CM4f++TumOhcdWCknMwI3IbZbf3u2fzVPvb4UVf8UA==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
@@ -15989,12 +15842,6 @@
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
-    },
-    "node_modules/tiny-emitter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
-      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
-      "dev": true
     },
     "node_modules/tmp": {
       "version": "0.0.33",
@@ -17101,12 +16948,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
       "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
-      "dev": true
-    },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
     "node_modules/yargs": {
@@ -21100,12 +20941,6 @@
         }
       }
     },
-    "classnames": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
-      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==",
-      "dev": true
-    },
     "cli-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
@@ -21126,17 +20961,6 @@
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
       "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
       "dev": true
-    },
-    "clipboard": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.4.tgz",
-      "integrity": "sha512-Vw26VSLRpJfBofiVaFb/I8PVfdI1OxKcYShe6fm0sP/DtmiWQNCjhM/okTvdCo0G+lMMm1rMYbk4IK4x1X+kgQ==",
-      "dev": true,
-      "requires": {
-        "good-listener": "^1.2.2",
-        "select": "^1.1.2",
-        "tiny-emitter": "^2.0.0"
-      }
     },
     "cliui": {
       "version": "6.0.0",
@@ -21725,12 +21549,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true
-    },
-    "delegate": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
-      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
       "dev": true
     },
     "denodeify": {
@@ -23055,69 +22873,6 @@
         }
       }
     },
-    "expensify-common": {
-      "version": "git+ssh://git@github.com/Expensify/expensify-common.git#427295da130a4eacc184d38693664280d020dffd",
-      "integrity": "sha512-87c3wys2ZuOnfwe5TnNupAyKVZG8QghDAB0J7VlMXZJaIZaCNm9rLKAiTX8TrW8WATaCKXx0VdBYJl49hiCuZg==",
-      "dev": true,
-      "from": "expensify-common@git+https://github.com/Expensify/expensify-common.git#427295da130a4eacc184d38693664280d020dffd",
-      "requires": {
-        "classnames": "2.3.1",
-        "clipboard": "2.0.4",
-        "html-entities": "^1.3.1",
-        "jquery": "3.6.0",
-        "lodash": "4.17.21",
-        "prop-types": "15.7.2",
-        "react": "16.12.0",
-        "react-dom": "16.12.0",
-        "semver": "^7.3.5",
-        "simply-deferred": "git+https://github.com/Expensify/simply-deferred.git#77a08a95754660c7bd6e0b6979fdf84e8e831bf5",
-        "underscore": "1.13.1"
-      },
-      "dependencies": {
-        "react": {
-          "version": "16.12.0",
-          "resolved": "https://registry.npmjs.org/react/-/react-16.12.0.tgz",
-          "integrity": "sha512-fglqy3k5E+81pA8s+7K0/T3DBCF0ZDOher1elBFzF7O6arXJgzyu/FW+COxFvAWXJoJN9KIZbT2LXlukwphYTA==",
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "react-dom": {
-          "version": "16.12.0",
-          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.12.0.tgz",
-          "integrity": "sha512-LMxFfAGrcS3kETtQaCkTKjMiifahaMySFDn71fZUNpPHZQEzmk/GiAeIT8JSOrHB23fnuCOMruL2a8NYlw+8Gw==",
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "scheduler": "^0.18.0"
-          }
-        },
-        "scheduler": {
-          "version": "0.18.0",
-          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.18.0.tgz",
-          "integrity": "sha512-agTSHR1Nbfi6ulI0kYNK0203joW2Y5W4po4l+v03tOoiJKpTBbxpNhWDvqc/4IcOw+KLmSiQLTasZ4cab2/UWQ==",
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1"
-          }
-        },
-        "semver": {
-          "version": "7.3.7",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
-      }
-    },
     "extend-shallow": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
@@ -23604,15 +23359,6 @@
         "type-fest": "^0.8.1"
       }
     },
-    "good-listener": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
-      "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
-      "dev": true,
-      "requires": {
-        "delegate": "^3.1.2"
-      }
-    },
     "graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
@@ -23791,12 +23537,6 @@
       "requires": {
         "whatwg-encoding": "^1.0.5"
       }
-    },
-    "html-entities": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.4.0.tgz",
-      "integrity": "sha512-8nxjcBcd8wovbeKx7h3wTji4e6+rhaVuPNpMqwWgnHh+N9ToqsCs6XztWRBPQ+UtzsoMAdKZtUENoVzU/EMtZA==",
-      "dev": true
     },
     "html-escaper": {
       "version": "2.0.2",
@@ -25369,12 +25109,6 @@
         "@hapi/topo": "^6.0.1"
       }
     },
-    "jquery": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
-      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==",
-      "dev": true
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -25949,15 +25683,6 @@
       "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
-      }
-    },
-    "lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "requires": {
-        "yallist": "^4.0.0"
       }
     },
     "make-dir": {
@@ -28736,12 +28461,6 @@
         "ajv-keywords": "^3.5.2"
       }
     },
-    "select": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
-      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
-      "dev": true
-    },
     "semver": {
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
@@ -28930,12 +28649,6 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
-    },
-    "simply-deferred": {
-      "version": "git+ssh://git@github.com/Expensify/simply-deferred.git#77a08a95754660c7bd6e0b6979fdf84e8e831bf5",
-      "integrity": "sha512-DSHaVm+6KduK2+cOnaA+choq8CowotOpFhmHDCL36Cb/CM4f++TumOhcdWCknMwI3IbZbf3u2fzVPvb4UVf8UA==",
-      "dev": true,
-      "from": "simply-deferred@git+https://github.com/Expensify/simply-deferred.git#77a08a95754660c7bd6e0b6979fdf84e8e831bf5"
     },
     "sisteransi": {
       "version": "1.0.5",
@@ -29718,12 +29431,6 @@
           }
         }
       }
-    },
-    "tiny-emitter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
-      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
-      "dev": true
     },
     "tmp": {
       "version": "0.0.33",
@@ -30574,12 +30281,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
       "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
-      "dev": true
-    },
-    "yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
     "yargs": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "eslint-config-expensify": "^2.0.24",
     "eslint-plugin-jsx-a11y": "^6.6.1",
     "eslint-plugin-react": "^7.31.10",
-    "expensify-common": "git+https://github.com/Expensify/expensify-common.git#427295da130a4eacc184d38693664280d020dffd",
     "jest": "^26.5.2",
     "jest-cli": "^26.5.2",
     "jsdoc-to-markdown": "^7.1.0",
@@ -75,7 +74,6 @@
     "webpack-merge": "^5.8.0"
   },
   "peerDependencies": {
-    "expensify-common": ">=1",
     "localforage": "^1.10.0",
     "localforage-removeitems": "^1.4.0",
     "react": ">=18.1.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,7 +33,6 @@ const commonConfig = {
     },
     externals: [
         'react-native',
-        /^expensify-common\/.+$/,
         /^lodash\/.+$/,
         ..._.keys(pkg.peerDependencies),
         ..._.keys(pkg.dependencies),


### PR DESCRIPTION
### Details

This PR extracts the two methods from `expensify-common` library that are being used in this project, and remove `expensify-common` as it's not necessary anymore.

### Related Issues

https://github.com/Expensify/react-native-onyx/issues/260

### Automated Tests

Not applicable as this PR is only extracting some methods from `expensify-common`.

### Linked PRs

Not applicable.
