### PR TITLE
Add `memoryOnlyKeys` setter option to Onyx

### DIFF
--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -1216,12 +1216,22 @@ function update(data) {
     return clearPromise.then(() => Promise.all(_.map(promises, p => p())));
 }
 
+let memoryOnlyKeysEnabled = false;
+
 /**
  * When set these keys will not be persisted to storage
  * @param {string[]} keyList
  */
 function setMemoryOnlyKeys(keyList) {
     Storage.setMemoryOnlyKeys(keyList);
+    memoryOnlyKeysEnabled = true;
+}
+
+/**
+ * @returns {boolean}
+ */
+function hasMemoryOnlyKeys() {
+    return memoryOnlyKeysEnabled;
 }
 
 /**
@@ -1313,6 +1323,7 @@ const Onyx = {
     isSafeEvictionKey,
     METHOD,
     setMemoryOnlyKeys,
+    hasMemoryOnlyKeys,
 };
 
 /**

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -1217,6 +1217,14 @@ function update(data) {
 }
 
 /**
+ * When set these keys will not be persisted to storage
+ * @param {string[]} keyList
+ */
+function setMemoryOnlyKeys(keyList) {
+    Storage.setMemoryOnlyKeys(keyList);
+}
+
+/**
  * Initialize the store with actions and listening for storage events
  *
  * @param {Object} [options={}] config object
@@ -1304,6 +1312,7 @@ const Onyx = {
     removeFromEvictionBlockList,
     isSafeEvictionKey,
     METHOD,
+    setMemoryOnlyKeys,
 };
 
 /**

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -1216,22 +1216,12 @@ function update(data) {
     return clearPromise.then(() => Promise.all(_.map(promises, p => p())));
 }
 
-let memoryOnlyKeysEnabled = false;
-
 /**
  * When set these keys will not be persisted to storage
  * @param {string[]} keyList
  */
 function setMemoryOnlyKeys(keyList) {
     Storage.setMemoryOnlyKeys(keyList);
-    memoryOnlyKeysEnabled = true;
-}
-
-/**
- * @returns {boolean}
- */
-function hasMemoryOnlyKeys() {
-    return memoryOnlyKeysEnabled;
 }
 
 /**
@@ -1323,7 +1313,6 @@ const Onyx = {
     isSafeEvictionKey,
     METHOD,
     setMemoryOnlyKeys,
-    hasMemoryOnlyKeys,
 };
 
 /**

--- a/lib/storage/providers/LocalForage.js
+++ b/lib/storage/providers/LocalForage.js
@@ -8,6 +8,7 @@ import localforage from 'localforage';
 import _ from 'underscore';
 import {extendPrototype} from 'localforage-removeitems';
 import SyncQueue from '../../SyncQueue';
+import * as Str from '../../Str';
 import fastMerge from '../../fastMerge';
 
 extendPrototype(localforage);
@@ -16,6 +17,11 @@ localforage.config({
     name: 'OnyxDB',
 });
 
+/**
+ * Keys that will not ever be persisted to disk.
+ */
+let memoryOnlyKeys = [];
+
 const provider = {
     /**
      * Writing very quickly to IndexedDB causes performance issues and can lock up the page and lead to jank.
@@ -23,6 +29,10 @@ const provider = {
      * to the next.
      */
     setItemQueue: new SyncQueue(({key, value, shouldMerge}) => {
+        if (_.find(memoryOnlyKeys, noCacheKey => Str.startsWith(key, noCacheKey))) {
+            return Promise.resolve();
+        }
+
         if (shouldMerge) {
             return localforage.getItem(key)
                 .then((existingValue) => {
@@ -124,6 +134,13 @@ const provider = {
      */
     setItem(key, value) {
         return this.setItemQueue.push({key, value});
+    },
+
+    /**
+     * @param {string[]} keyList
+     */
+    setMemoryOnlyKeys(keyList) {
+        memoryOnlyKeys = keyList;
     },
 };
 

--- a/lib/storage/providers/SQLiteStorage.js
+++ b/lib/storage/providers/SQLiteStorage.js
@@ -128,6 +128,11 @@ const provider = {
     * @returns {Promise<void>}
     */
     clear: () => db.executeAsync('DELETE FROM keyvaluepairs;', []),
+
+    /**
+     * Noop on mobile for now.
+     */
+    setMemoryOnlyKeys: () => {},
 };
 
 export default provider;


### PR DESCRIPTION
### Details

Guides continue to experience really bad performance that we now know is in part related to the IndexedDB code and the synchronous setting of each key one at a time. This is a performance improvement with smaller data sets, but ends up creating a ton of blocking time when these datasets are large.

### Related Issues

https://github.com/Expensify/App/issues/21766

### Automated Tests

Since this is an opt-in behavior and bandaid solution for now I didn't write any tests.

### Linked PRs

https://github.com/Expensify/App/pull/22729