### PR TITLE
Gracefully handle bad mergeCollection

### DIFF
--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -1129,13 +1129,19 @@ function mergeCollection(collectionKey, collection) {
     }
 
     // Confirm all the collection keys belong to the same parent
+    let hasCollectionKeyCheckFailed = false;
     _.each(collection, (_data, dataKey) => {
         if (isKeyMatch(collectionKey, dataKey)) {
             return;
         }
-
-        throw new Error(`Provided collection doesn't have all its data belonging to the same parent. CollectionKey: ${collectionKey}, DataKey: ${dataKey}`);
+        hasCollectionKeyCheckFailed = true;
+        Logger.logError(`Provided collection doesn't have all its data belonging to the same parent. CollectionKey: ${collectionKey}, DataKey: ${dataKey}`);
     });
+
+    // Gracefully handle bad mergeCollection updates so it doesn't block the merge queue
+    if (hasCollectionKeyCheckFailed) {
+        return Promise.resolve();
+    }
 
     return getAllKeys()
         .then((persistedKeys) => {

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -1135,7 +1135,7 @@ function mergeCollection(collectionKey, collection) {
             return;
         }
         hasCollectionKeyCheckFailed = true;
-        Logger.logError(`Provided collection doesn't have all its data belonging to the same parent. CollectionKey: ${collectionKey}, DataKey: ${dataKey}`);
+        Logger.logAlert(`Provided collection doesn't have all its data belonging to the same parent. CollectionKey: ${collectionKey}, DataKey: ${dataKey}`);
     });
 
     // Gracefully handle bad mergeCollection updates so it doesn't block the merge queue

--- a/tests/unit/onyxTest.js
+++ b/tests/unit/onyxTest.js
@@ -306,12 +306,18 @@ describe('Onyx', () => {
             });
     });
 
-    it('should throw error when a key not belonging to collection key is present in mergeCollection', () => {
-        try {
-            Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {test_1: {ID: 123}, notMyTest: {beep: 'boop'}});
-        } catch (error) {
-            expect(error.message).toEqual(`Provided collection doesn't have all its data belonging to the same parent. CollectionKey: ${ONYX_KEYS.COLLECTION.TEST_KEY}, DataKey: notMyTest`);
-        }
+    it('should skip the update when a key not belonging to collection key is present in mergeCollection', () => {
+        const valuesReceived = {};
+        connectionID = Onyx.connect({
+            key: ONYX_KEYS.COLLECTION.TEST_KEY,
+            initWithStoredValues: false,
+            callback: (data, key) => valuesReceived[key] = data,
+        });
+
+        return Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {test_1: {ID: 123}, notMyTest: {beep: 'boop'}})
+            .then(() => {
+                expect(valuesReceived).toEqual({});
+            });
     });
 
     it('should return full object to callback when calling mergeCollection()', () => {


### PR DESCRIPTION
Gracefully handle bad mergeCollection updates so it doesn't block the merge queue

### Details
Coming from https://expensify.slack.com/archives/C049HHMV9SM/p1689120594593919, bad merge updates can block Onyx's merge queue and cause issues in App. We should gracefully handle these.

### Related Issues
Related to https://github.com/Expensify/Expensify/issues/290894

### Automated Tests
N/A

### Linked PRs

