### PR TITLE
Disable cache key drop when in "memory only" mode

### DIFF
--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -1222,6 +1222,9 @@ function update(data) {
  */
 function setMemoryOnlyKeys(keyList) {
     Storage.setMemoryOnlyKeys(keyList);
+
+    // When in memory only mode for certain keys we do not want to ever drop items from the cache
+    cache.setRecentKeysLimit(Infinity);
 }
 
 /**

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -1223,7 +1223,7 @@ function update(data) {
 function setMemoryOnlyKeys(keyList) {
     Storage.setMemoryOnlyKeys(keyList);
 
-    // When in memory only mode for certain keys we do not want to ever drop items from the cache
+    // When in memory only mode for certain keys we do not want to ever drop items from the cache as the user will have no way to recover them again via storage.
     cache.setRecentKeysLimit(Infinity);
 }
 


### PR DESCRIPTION
### Details

cc @fedirjh h/t for catching this

### Related Issues

https://github.com/Expensify/App/issues/21766

### Automated Tests

❌ 

### Linked PRs

TBD