### PR TITLE
Throw in dev if collection keys don't belong to the same parent

### DIFF
--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -1134,6 +1134,11 @@ function mergeCollection(collectionKey, collection) {
         if (isKeyMatch(collectionKey, dataKey)) {
             return;
         }
+
+        if (process.env.NODE_ENV === 'development') {
+            throw new Error(`Provided collection doesn't have all its data belonging to the same parent. CollectionKey: ${collectionKey}, DataKey: ${dataKey}`);
+        }
+
         hasCollectionKeyCheckFailed = true;
         Logger.logAlert(`Provided collection doesn't have all its data belonging to the same parent. CollectionKey: ${collectionKey}, DataKey: ${dataKey}`);
     });


### PR DESCRIPTION
### Details
Coming from [this comment](https://github.com/Expensify/react-native-onyx/pull/272/files#r1261673744), we should make the error easier to catch on dev by throwing it, instead of logging.

cc @marcaaron @mountiny 

### Related Issues
https://github.com/Expensify/react-native-onyx/pull/272/files#r1261673744

### Automated Tests
N/A

### Linked PRs
TBD