### PR TITLE
[Fix #269] use cached data

### DIFF
--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -154,18 +154,6 @@ function isCollectionMemberKey(collectionKey, key) {
     return Str.startsWith(key, collectionKey) && key.length > collectionKey.length;
 }
 
-function isCollectionKeyAndNoMember(key) {
-    const keys = _.keys(onyxKeys.COLLECTION);
-    // eslint-disable-next-line no-restricted-syntax
-    for (const collectionKeyCandidate in keys) {
-        if (Str.contains(key, collectionKeyCandidate)) {
-            return !isCollectionMemberKey(collectionKeyCandidate, key);
-        }
-    }
-
-    return false;
-}
-
 /**
  * Checks to see if a provided key is the exact configured key of our connected subscriber
  * or if the provided key is a collection member key (in case our configured key is a "collection key")

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -154,6 +154,18 @@ function isCollectionMemberKey(collectionKey, key) {
     return Str.startsWith(key, collectionKey) && key.length > collectionKey.length;
 }
 
+function isCollectionKeyAndNoMember(key) {
+    const keys = _.keys(onyxKeys.COLLECTION);
+    // eslint-disable-next-line no-restricted-syntax
+    for (const collectionKeyCandidate in keys) {
+        if (Str.contains(key, collectionKeyCandidate)) {
+            return !isCollectionMemberKey(collectionKeyCandidate, key);
+        }
+    }
+
+    return false;
+}
+
 /**
  * Checks to see if a provided key is the exact configured key of our connected subscriber
  * or if the provided key is a collection member key (in case our configured key is a "collection key")
@@ -193,25 +205,25 @@ function isSafeEvictionKey(testKey) {
  * @returns {string}
  */
 function tryGetCachedValue(key, mapping = {}) {
+    let val = cache.hasCacheForKey(key) ? cache.getValue(key) : defaultKeyStates[key];
+
     if (isCollectionKey(key)) {
         const allKeys = cache.getAllKeys();
         const matchingKeys = _.filter(allKeys, k => k.startsWith(key));
         const values = _.reduce(matchingKeys, (finalObject, matchedKey) => {
-            const val = cache.getValue(matchedKey);
-            if (val) {
+            const cachedValue = cache.getValue(matchedKey);
+            if (cachedValue) {
                 // This is permissible because we're in the process of constructing the final object in a reduce function.
                 // eslint-disable-next-line no-param-reassign
-                finalObject[matchedKey] = val;
+                finalObject[matchedKey] = cachedValue;
             }
             return finalObject;
         }, {});
         if (_.keys(values).length === 0) {
             return undefined;
         }
-        return values;
+        val = values;
     }
-
-    const val = cache.hasCacheForKey(key) ? cache.getValue(key) : defaultKeyStates[key];
 
     if (mapping.selector) {
         const state = mapping.withOnyxInstance ? mapping.withOnyxInstance.state : undefined;

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -410,13 +410,12 @@ function keysChanged(collectionKey, partialCollection) {
                         const previousData = prevState[subscriber.statePropertyName];
                         const newData = reduceCollectionWithSelector(cachedCollection, subscriber.selector, subscriber.withOnyxInstance.state);
 
-                        if (deepEqual(previousData, newData)) {
-                            return null;
+                        if (!deepEqual(previousData, newData)) {
+                            return {
+                                [subscriber.statePropertyName]: newData,
+                            };
                         }
-
-                        return {
-                            [subscriber.statePropertyName]: newData,
-                        };
+                        return null;
                     });
                     continue;
                 }
@@ -454,18 +453,32 @@ function keysChanged(collectionKey, partialCollection) {
                 // If the subscriber has a selector, then the component's state must only be updated with the data
                 // returned by the selector and the state should only change when the subset of data changes from what
                 // it was previously.
-                subscriber.withOnyxInstance.setState((prevState) => {
-                    const prevData = prevState[subscriber.statePropertyName];
-                    const data = cachedCollection[subscriber.key];
-                    const newData = subscriber.selector ? getSubsetOfData(data, subscriber.selector, subscriber.withOnyxInstance.state) : data;
+                if (subscriber.selector) {
+                    subscriber.withOnyxInstance.setState((prevState) => {
+                        const prevData = prevState[subscriber.statePropertyName];
+                        const newData = getSubsetOfData(cachedCollection[subscriber.key], subscriber.selector, subscriber.withOnyxInstance.state);
+                        if (!deepEqual(prevData, newData)) {
+                            PerformanceUtils.logSetStateCall(subscriber, prevData, newData, 'keysChanged', collectionKey);
+                            return {
+                                [subscriber.statePropertyName]: newData,
+                            };
+                        }
 
-                    if (deepEqual(prevData, newData)) {
+                        return null;
+                    });
+                    continue;
+                }
+
+                subscriber.withOnyxInstance.setState((prevState) => {
+                    const data = cachedCollection[subscriber.key];
+                    const previousData = prevState[subscriber.statePropertyName];
+                    if (deepEqual(data, previousData)) {
                         return null;
                     }
 
-                    PerformanceUtils.logSetStateCall(subscriber, prevData, newData, 'keysChanged', collectionKey);
+                    PerformanceUtils.logSetStateCall(subscriber, previousData, data, 'keysChanged', collectionKey);
                     return {
-                        [subscriber.statePropertyName]: newData,
+                        [subscriber.statePropertyName]: data,
                     };
                 });
             }
@@ -521,40 +534,70 @@ function keyChanged(key, data, canUpdateSubscriber) {
             if (isCollectionKey(subscriber.key)) {
                 // If the subscriber has a selector, then the consumer of this data must only be given the data
                 // returned by the selector and only when the selected data has changed.
-                subscriber.withOnyxInstance.setState((prevState) => {
-                    const prevData = prevState[subscriber.statePropertyName] || {};
-                    const newData = {
-                        [key]: subscriber.selector ? getSubsetOfData(data, subscriber.selector, subscriber.withOnyxInstance.state) : data,
-                    };
-                    const newCollection = {
-                        ...prevData,
-                        ...newData,
-                    };
-
-                    if (deepEqual(prevData, newCollection)) {
+                if (subscriber.selector) {
+                    subscriber.withOnyxInstance.setState((prevState) => {
+                        const prevData = prevState[subscriber.statePropertyName];
+                        const newData = {
+                            [key]: getSubsetOfData(data, subscriber.selector, subscriber.withOnyxInstance.state),
+                        };
+                        const prevDataWithNewData = {
+                            ...prevData,
+                            ...newData,
+                        };
+                        if (!deepEqual(prevData, prevDataWithNewData)) {
+                            PerformanceUtils.logSetStateCall(subscriber, prevData, newData, 'keyChanged', key);
+                            return {
+                                [subscriber.statePropertyName]: prevDataWithNewData,
+                            };
+                        }
                         return null;
-                    }
+                    });
+                    continue;
+                }
 
-                    PerformanceUtils.logSetStateCall(subscriber, prevData, newCollection, 'keyChanged', key);
-                    return {
-                        [subscriber.statePropertyName]: newCollection,
+                subscriber.withOnyxInstance.setState((prevState) => {
+                    const collection = prevState[subscriber.statePropertyName] || {};
+                    const newCollection = {
+                        ...collection,
+                        [key]: data,
                     };
+                    if (!deepEqual(collection, newCollection)) {
+                        PerformanceUtils.logSetStateCall(subscriber, collection, newCollection, 'keyChanged', key);
+                        return {
+                            [subscriber.statePropertyName]: newCollection,
+                        };
+                    }
+                    return null;
                 });
                 continue;
             }
 
             // If the subscriber has a selector, then the component's state must only be updated with the data
             // returned by the selector and only if the selected data has changed.
+            if (subscriber.selector) {
+                subscriber.withOnyxInstance.setState((prevState) => {
+                    const previousValue = getSubsetOfData(prevState[subscriber.statePropertyName], subscriber.selector, subscriber.withOnyxInstance.state);
+                    const newValue = getSubsetOfData(data, subscriber.selector, subscriber.withOnyxInstance.state);
+                    if (!deepEqual(previousValue, newValue)) {
+                        return {
+                            [subscriber.statePropertyName]: newValue,
+                        };
+                    }
+                    return null;
+                });
+                continue;
+            }
+
+            // If we did not match on a collection key then we just set the new data to the state property
             subscriber.withOnyxInstance.setState((prevState) => {
-                const previousValue = prevState[subscriber.statePropertyName];
-                const newValue = subscriber.selector ? getSubsetOfData(data, subscriber.selector, subscriber.withOnyxInstance.state) : data;
-                if (deepEqual(previousValue, newValue)) {
+                const previousData = prevState[subscriber.statePropertyName];
+                if (previousData === data) {
                     return null;
                 }
 
-                PerformanceUtils.logSetStateCall(subscriber, previousValue, newValue, 'keyChanged', key);
+                PerformanceUtils.logSetStateCall(subscriber, previousData, data, 'keyChanged', key);
                 return {
-                    [subscriber.statePropertyName]: newValue,
+                    [subscriber.statePropertyName]: data,
                 };
             });
             continue;

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -193,7 +193,7 @@ function isSafeEvictionKey(testKey) {
  * @returns {Mixed}
  */
 function tryGetCachedValue(key, mapping = {}) {
-    let val = cache.hasCacheForKey(key) ? cache.getValue(key) : defaultKeyStates[key];
+    let val = cache.getValue(key);
 
     if (isCollectionKey(key)) {
         const allKeys = cache.getAllKeys();

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -561,13 +561,10 @@ function keyChanged(key, data, canUpdateSubscriber) {
                         ...collection,
                         [key]: data,
                     };
-                    if (!deepEqual(collection, newCollection)) {
-                        PerformanceUtils.logSetStateCall(subscriber, collection, newCollection, 'keyChanged', key);
-                        return {
-                            [subscriber.statePropertyName]: newCollection,
-                        };
-                    }
-                    return null;
+                    PerformanceUtils.logSetStateCall(subscriber, collection, newCollection, 'keyChanged', key);
+                    return {
+                        [subscriber.statePropertyName]: newCollection,
+                    };
                 });
                 continue;
             }

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -213,8 +213,6 @@ function tryGetCachedValue(key, mapping = {}) {
 
     const val = cache.hasCacheForKey(key) ? cache.getValue(key) : defaultKeyStates[key];
 
-    // If the mapping has a selector, then the component's state must only be updated with the data
-    // returned by the selector.
     if (mapping.selector) {
         const state = mapping.withOnyxInstance ? mapping.withOnyxInstance.state : undefined;
         if (isCollectionKey(key)) {

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -184,12 +184,24 @@ function isSafeEvictionKey(testKey) {
 /**
  * Tries to return all keys
  * from the current cache.
+ * (internal)
  * @returns {Array<string>}
  */
 function getAllKeysSync() {
     return cache.getAllKeys();
 }
 
+/**
+ * Tries to get a value from the cache.
+ * If the value is not present in cache it will
+ * return the default value or undefined.
+ * If the requested key is a collection, it will
+ * return an object with all the collection members.
+ *
+ * @param {string} key
+ * @param {Object} mapping
+ * @returns {string}
+ */
 function tryGetCachedValue(key, mapping = {}) {
     if (isCollectionKey(key)) {
         const allKeys = getAllKeysSync();

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -210,11 +210,7 @@ function tryGetCachedValue(key, mapping = {}) {
         }
     }
 
-    if (!cache.hasCacheForKey(key)) {
-        return defaultKeyStates[key]; // We might have the value in the default key state
-    }
-
-    const val = cache.getValue(key);
+    const val = cache.hasCacheForKey(key) ? cache.getValue(key) : defaultKeyStates[key];
 
     // If the mapping has a selector, then the component's state must only be updated with the data
     // returned by the selector.

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -185,15 +185,12 @@ function isSafeEvictionKey(testKey) {
 }
 
 /**
- * Tries to get a value from the cache.
- * If the value is not present in cache it will
- * return the default value or undefined.
- * If the requested key is a collection, it will
- * return an object with all the collection members.
+ * Tries to get a value from the cache. If the value is not present in cache it will return the default value or undefined.
+ * If the requested key is a collection, it will return an object with all the collection members.
  *
- * @param {string} key
+ * @param {String} key
  * @param {Object} mapping
- * @returns {string}
+ * @returns {Mixed}
  */
 function tryGetCachedValue(key, mapping = {}) {
     let val = cache.hasCacheForKey(key) ? cache.getValue(key) : defaultKeyStates[key];

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -210,7 +210,7 @@ function tryGetCachedValue(key, mapping = {}) {
             }
             return finalObject;
         }, {});
-        if (_.keys(values).length === 0) {
+        if (_.size(values) === 0) {
             return;
         }
         val = values;

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -643,7 +643,7 @@ function sendDataToConnection(mapping, val, matchedKey) {
             }
         }
 
-        // sendDataToConnection only get's called in the connect code.
+        // sendDataToConnection only gets called in the connect code.
         // withOnyx is already setting data from cache initially. If we now
         // want to call sendDataToConnection, we want to make sure, we
         // are not sending again the same data from cache, if the component

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -612,8 +612,6 @@ function keyChanged(key, data, canUpdateSubscriber) {
  *     - sets state on the withOnyxInstances
  *     - triggers the callback function
  *
- * Note: This is only invoked from Onyx.connect
- *
  * @private
  * @param {Object} mapping
  * @param {Object} [mapping.withOnyxInstance]

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -182,6 +182,51 @@ function isSafeEvictionKey(testKey) {
 }
 
 /**
+ * Tries to return all keys
+ * from the current cache.
+ * @returns {Array<string>}
+ */
+function getAllKeysSync() {
+    return cache.getAllKeys();
+}
+
+function tryGetCachedValue(key, mapping = {}) {
+    if (isCollectionKey(key)) {
+        const allKeys = getAllKeysSync();
+        const matchingKeys = _.filter(allKeys, k => k.startsWith(key));
+        const values = _.reduce(matchingKeys, (finalObject, matchedKey) => {
+            const val = cache.getValue(matchedKey);
+            if (val) {
+                // We know a 100% where the object is coming from, so its fine
+                // eslint-disable-next-line no-param-reassign
+                finalObject[matchedKey] = val;
+            }
+            return finalObject;
+        }, {});
+        if (_.keys(values).length > 0) {
+            return values;
+        }
+    }
+
+    if (!cache.hasCacheForKey(key)) {
+        return defaultKeyStates[key]; // We might have the value in the default key state
+    }
+
+    const val = cache.getValue(key);
+
+    // If the mapping has a selector, then the component's state must only be updated with the data
+    // returned by the selector.
+    if (mapping.selector) {
+        if (isCollectionKey(key)) {
+            return reduceCollectionWithSelector(val, mapping.selector, mapping.withOnyxInstance?.state);
+        }
+        return getSubsetOfData(val, mapping.selector, mapping.withOnyxInstance?.state);
+    }
+
+    return val;
+}
+
+/**
  * Remove a key from the recently accessed key list.
  *
  * @private
@@ -367,22 +412,28 @@ function keysChanged(collectionKey, partialCollection) {
                         const previousData = prevState[subscriber.statePropertyName];
                         const newData = reduceCollectionWithSelector(cachedCollection, subscriber.selector, subscriber.withOnyxInstance.state);
 
-                        if (!deepEqual(previousData, newData)) {
-                            return {
-                                [subscriber.statePropertyName]: newData,
-                            };
+                        if (deepEqual(previousData, newData)) {
+                            return null;
                         }
-                        return null;
+
+                        return {
+                            [subscriber.statePropertyName]: newData,
+                        };
                     });
                     continue;
                 }
 
                 subscriber.withOnyxInstance.setState((prevState) => {
-                    const finalCollection = _.clone(prevState[subscriber.statePropertyName] || {});
+                    const prevCollection = prevState[subscriber.statePropertyName];
+                    const finalCollection = _.clone(prevCollection || {});
                     const dataKeys = _.keys(partialCollection);
                     for (let j = 0; j < dataKeys.length; j++) {
                         const dataKey = dataKeys[j];
                         finalCollection[dataKey] = cachedCollection[dataKey];
+                    }
+
+                    if (deepEqual(prevCollection, finalCollection)) {
+                        return null;
                     }
 
                     PerformanceUtils.logSetStateCall(subscriber, prevState[subscriber.statePropertyName], finalCollection, 'keysChanged', collectionKey);
@@ -405,32 +456,18 @@ function keysChanged(collectionKey, partialCollection) {
                 // If the subscriber has a selector, then the component's state must only be updated with the data
                 // returned by the selector and the state should only change when the subset of data changes from what
                 // it was previously.
-                if (subscriber.selector) {
-                    subscriber.withOnyxInstance.setState((prevState) => {
-                        const prevData = prevState[subscriber.statePropertyName];
-                        const newData = getSubsetOfData(cachedCollection[subscriber.key], subscriber.selector, subscriber.withOnyxInstance.state);
-                        if (!deepEqual(prevData, newData)) {
-                            PerformanceUtils.logSetStateCall(subscriber, prevData, newData, 'keysChanged', collectionKey);
-                            return {
-                                [subscriber.statePropertyName]: newData,
-                            };
-                        }
-
-                        return null;
-                    });
-                    continue;
-                }
-
                 subscriber.withOnyxInstance.setState((prevState) => {
+                    const prevData = prevState[subscriber.statePropertyName];
                     const data = cachedCollection[subscriber.key];
-                    const previousData = prevState[subscriber.statePropertyName];
-                    if (data === previousData) {
+                    const newData = subscriber.selector ? getSubsetOfData(data, subscriber.selector, subscriber.withOnyxInstance.state) : data;
+
+                    if (deepEqual(prevData, newData)) {
                         return null;
                     }
 
-                    PerformanceUtils.logSetStateCall(subscriber, previousData, data, 'keysChanged', collectionKey);
+                    PerformanceUtils.logSetStateCall(subscriber, prevData, newData, 'keysChanged', collectionKey);
                     return {
-                        [subscriber.statePropertyName]: data,
+                        [subscriber.statePropertyName]: newData,
                     };
                 });
             }
@@ -486,34 +523,21 @@ function keyChanged(key, data, canUpdateSubscriber) {
             if (isCollectionKey(subscriber.key)) {
                 // If the subscriber has a selector, then the consumer of this data must only be given the data
                 // returned by the selector and only when the selected data has changed.
-                if (subscriber.selector) {
-                    subscriber.withOnyxInstance.setState((prevState) => {
-                        const prevData = prevState[subscriber.statePropertyName];
-                        const newData = {
-                            [key]: getSubsetOfData(data, subscriber.selector, subscriber.withOnyxInstance.state),
-                        };
-                        const prevDataWithNewData = {
-                            ...prevData,
-                            ...newData,
-                        };
-                        if (!deepEqual(prevData, prevDataWithNewData)) {
-                            PerformanceUtils.logSetStateCall(subscriber, prevData, newData, 'keyChanged', key);
-                            return {
-                                [subscriber.statePropertyName]: prevDataWithNewData,
-                            };
-                        }
-                        return null;
-                    });
-                    continue;
-                }
-
                 subscriber.withOnyxInstance.setState((prevState) => {
-                    const collection = prevState[subscriber.statePropertyName] || {};
-                    const newCollection = {
-                        ...collection,
-                        [key]: data,
+                    const prevData = prevState[subscriber.statePropertyName] || {};
+                    const newData = {
+                        [key]: subscriber.selector ? getSubsetOfData(data, subscriber.selector, subscriber.withOnyxInstance.state) : data,
                     };
-                    PerformanceUtils.logSetStateCall(subscriber, collection, newCollection, 'keyChanged', key);
+                    const newCollection = {
+                        ...prevData,
+                        ...newData,
+                    };
+
+                    if (deepEqual(prevData, newCollection)) {
+                        return null;
+                    }
+
+                    PerformanceUtils.logSetStateCall(subscriber, prevData, newCollection, 'keyChanged', key);
                     return {
                         [subscriber.statePropertyName]: newCollection,
                     };
@@ -523,30 +547,16 @@ function keyChanged(key, data, canUpdateSubscriber) {
 
             // If the subscriber has a selector, then the component's state must only be updated with the data
             // returned by the selector and only if the selected data has changed.
-            if (subscriber.selector) {
-                subscriber.withOnyxInstance.setState((prevState) => {
-                    const previousValue = getSubsetOfData(prevState[subscriber.statePropertyName], subscriber.selector, subscriber.withOnyxInstance.state);
-                    const newValue = getSubsetOfData(data, subscriber.selector, subscriber.withOnyxInstance.state);
-                    if (!deepEqual(previousValue, newValue)) {
-                        return {
-                            [subscriber.statePropertyName]: newValue,
-                        };
-                    }
-                    return null;
-                });
-                continue;
-            }
-
-            // If we did not match on a collection key then we just set the new data to the state property
             subscriber.withOnyxInstance.setState((prevState) => {
-                const previousData = prevState[subscriber.statePropertyName];
-                if (previousData === data) {
+                const previousValue = prevState[subscriber.statePropertyName];
+                const newValue = subscriber.selector ? getSubsetOfData(data, subscriber.selector, subscriber.withOnyxInstance.state) : data;
+                if (deepEqual(previousValue, newValue)) {
                     return null;
                 }
 
-                PerformanceUtils.logSetStateCall(subscriber, previousData, data, 'keyChanged', key);
+                PerformanceUtils.logSetStateCall(subscriber, previousValue, newValue, 'keyChanged', key);
                 return {
-                    [subscriber.statePropertyName]: data,
+                    [subscriber.statePropertyName]: newValue,
                 };
             });
             continue;
@@ -560,6 +570,8 @@ function keyChanged(key, data, canUpdateSubscriber) {
  * Sends the data obtained from the keys to the connection. It either:
  *     - sets state on the withOnyxInstances
  *     - triggers the callback function
+ *
+ * Note: This is only invoked from Onyx.connect
  *
  * @private
  * @param {Object} mapping
@@ -588,6 +600,15 @@ function sendDataToConnection(mapping, val, matchedKey) {
             } else {
                 newData = getSubsetOfData(val, mapping.selector, mapping.withOnyxInstance.state);
             }
+        }
+
+        // sendDataToConnection only get's called in the connect code.
+        // withOnyx is already setting data from cache initially. If we now
+        // want to call sendDataToConnection, we want to make sure, we
+        // are not sending again the same data from cache, if the component
+        // already has the cached data.
+        if (deepEqual(mapping.withOnyxInstance.state[mapping.statePropertyName], newData)) {
+            return;
         }
 
         PerformanceUtils.logSetStateCall(mapping, null, newData, 'sendDataToConnection');
@@ -1327,6 +1348,7 @@ const Onyx = {
     isSafeEvictionKey,
     METHOD,
     setMemoryOnlyKeys,
+    tryGetCachedValue,
 };
 
 /**

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -208,7 +208,7 @@ function tryGetCachedValue(key, mapping = {}) {
             return finalObject;
         }, {});
         if (_.keys(values).length === 0) {
-            return undefined;
+            return;
         }
         val = values;
     }

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -421,16 +421,11 @@ function keysChanged(collectionKey, partialCollection) {
                 }
 
                 subscriber.withOnyxInstance.setState((prevState) => {
-                    const prevCollection = prevState[subscriber.statePropertyName];
-                    const finalCollection = _.clone(prevCollection || {});
+                    const finalCollection = _.clone(prevState[subscriber.statePropertyName] || {});
                     const dataKeys = _.keys(partialCollection);
                     for (let j = 0; j < dataKeys.length; j++) {
                         const dataKey = dataKeys[j];
                         finalCollection[dataKey] = cachedCollection[dataKey];
-                    }
-
-                    if (deepEqual(prevCollection, finalCollection)) {
-                        return null;
                     }
 
                     PerformanceUtils.logSetStateCall(subscriber, prevState[subscriber.statePropertyName], finalCollection, 'keysChanged', collectionKey);
@@ -472,7 +467,7 @@ function keysChanged(collectionKey, partialCollection) {
                 subscriber.withOnyxInstance.setState((prevState) => {
                     const data = cachedCollection[subscriber.key];
                     const previousData = prevState[subscriber.statePropertyName];
-                    if (deepEqual(data, previousData)) {
+                    if (data === previousData) {
                         return null;
                     }
 

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -648,7 +648,7 @@ function sendDataToConnection(mapping, val, matchedKey) {
 
         // The data might have been loaded from cache alrady,
         // in which case we want to avoid triggering a re-render.
-        if (mapping.withOnyxInstance.state[mapping.statePropertyName] === newData) {
+        if (prevData === newData) {
             return;
         }
 

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -182,16 +182,6 @@ function isSafeEvictionKey(testKey) {
 }
 
 /**
- * Tries to return all keys
- * from the current cache.
- * (internal)
- * @returns {Array<string>}
- */
-function getAllKeysSync() {
-    return cache.getAllKeys();
-}
-
-/**
  * Tries to get a value from the cache.
  * If the value is not present in cache it will
  * return the default value or undefined.
@@ -204,7 +194,7 @@ function getAllKeysSync() {
  */
 function tryGetCachedValue(key, mapping = {}) {
     if (isCollectionKey(key)) {
-        const allKeys = getAllKeysSync();
+        const allKeys = cache.getAllKeys();
         const matchingKeys = _.filter(allKeys, k => k.startsWith(key));
         const values = _.reduce(matchingKeys, (finalObject, matchedKey) => {
             const val = cache.getValue(matchedKey);

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -229,10 +229,11 @@ function tryGetCachedValue(key, mapping = {}) {
     // If the mapping has a selector, then the component's state must only be updated with the data
     // returned by the selector.
     if (mapping.selector) {
+        const state = mapping.withOnyxInstance ? mapping.withOnyxInstance.state : undefined;
         if (isCollectionKey(key)) {
-            return reduceCollectionWithSelector(val, mapping.selector, mapping.withOnyxInstance?.state);
+            return reduceCollectionWithSelector(val, mapping.selector, state);
         }
-        return getSubsetOfData(val, mapping.selector, mapping.withOnyxInstance?.state);
+        return getSubsetOfData(val, mapping.selector, state);
     }
 
     return val;

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -207,7 +207,7 @@ function tryGetCachedValue(key, mapping = {}) {
             }
             return finalObject;
         }, {});
-        if (_.size(values) === 0) {
+        if (_.isEmpty(values)) {
             return;
         }
         val = values;

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -629,6 +629,7 @@ function sendDataToConnection(mapping, val, matchedKey) {
     }
 
     if (mapping.withOnyxInstance) {
+        const prevData = mapping.withOnyxInstance.state[mapping.statePropertyName];
         let newData = val;
 
         // If the mapping has a selector, then the component's state must only be updated with the data
@@ -639,14 +640,18 @@ function sendDataToConnection(mapping, val, matchedKey) {
             } else {
                 newData = getSubsetOfData(val, mapping.selector, mapping.withOnyxInstance.state);
             }
+
+            // The data might have been loaded from cache alrady,
+            // in which case we want to avoid triggering a re-render.
+            // As the data is coming from a selector, we need to use deepEqual.
+            if (deepEqual(prevData, newData)) {
+                return;
+            }
         }
 
-        // sendDataToConnection only gets called in the connect code.
-        // withOnyx is already setting data from cache initially. If we now
-        // want to call sendDataToConnection, we want to make sure, we
-        // are not sending again the same data from cache, if the component
-        // already has the cached data.
-        if (deepEqual(mapping.withOnyxInstance.state[mapping.statePropertyName], newData)) {
+        // The data might have been loaded from cache alrady,
+        // in which case we want to avoid triggering a re-render.
+        if (mapping.withOnyxInstance.state[mapping.statePropertyName] === newData) {
             return;
         }
 

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -205,9 +205,10 @@ function tryGetCachedValue(key, mapping = {}) {
             }
             return finalObject;
         }, {});
-        if (_.keys(values).length > 0) {
-            return values;
+        if (_.keys(values).length === 0) {
+            return undefined;
         }
+        return values;
     }
 
     const val = cache.hasCacheForKey(key) ? cache.getValue(key) : defaultKeyStates[key];

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -621,7 +621,6 @@ function sendDataToConnection(mapping, val, matchedKey) {
     }
 
     if (mapping.withOnyxInstance) {
-        const prevData = mapping.withOnyxInstance.state[mapping.statePropertyName];
         let newData = val;
 
         // If the mapping has a selector, then the component's state must only be updated with the data
@@ -632,19 +631,6 @@ function sendDataToConnection(mapping, val, matchedKey) {
             } else {
                 newData = getSubsetOfData(val, mapping.selector, mapping.withOnyxInstance.state);
             }
-
-            // The data might have been loaded from cache alrady,
-            // in which case we want to avoid triggering a re-render.
-            // As the data is coming from a selector, we need to use deepEqual.
-            if (deepEqual(prevData, newData)) {
-                return;
-            }
-        }
-
-        // The data might have been loaded from cache alrady,
-        // in which case we want to avoid triggering a re-render.
-        if (prevData === newData) {
-            return;
         }
 
         PerformanceUtils.logSetStateCall(mapping, null, newData, 'sendDataToConnection');

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -199,7 +199,7 @@ function tryGetCachedValue(key, mapping = {}) {
         const values = _.reduce(matchingKeys, (finalObject, matchedKey) => {
             const val = cache.getValue(matchedKey);
             if (val) {
-                // We know a 100% where the object is coming from, so its fine
+                // This is permissible because we're in the process of constructing the final object in a reduce function.
                 // eslint-disable-next-line no-param-reassign
                 finalObject[matchedKey] = val;
             }

--- a/lib/withOnyx.js
+++ b/lib/withOnyx.js
@@ -37,7 +37,6 @@ export default function (mapOnyxToState) {
                 // disconnected. It is a key value store with the format {[mapping.key]: connectionID}.
                 this.activeConnectionIDs = {};
 
-                let cachedAssigments = 0;
                 const cachedState = {};
 
                 // Check if we can get all the data synchronously from cache
@@ -47,12 +46,11 @@ export default function (mapOnyxToState) {
 
                     if (value !== undefined) {
                         cachedState[propertyName] = value;
-                        cachedAssigments++;
                     }
                 });
 
-                // If there are no required keys for init then we can render the wrapped component immediately
-                const loading = cachedAssigments < requiredKeysForInit.length;
+                // If we have all the data we need, then we can render the component immediately
+                const loading = _.keys(cachedState).length < requiredKeysForInit.length;
 
                 // Object holding the temporary initial state for the component while we load the various Onyx keys
                 this.tempState = cachedState;

--- a/lib/withOnyx.js
+++ b/lib/withOnyx.js
@@ -37,17 +37,17 @@ export default function (mapOnyxToState) {
                 // disconnected. It is a key value store with the format {[mapping.key]: connectionID}.
                 this.activeConnectionIDs = {};
 
-                const cachedState = {};
-
-                // Check if we can get all the data synchronously from cache
-                _.each(mapOnyxToState, (mapping, propertyName) => {
+                const cachedState = _.reduce(mapOnyxToState, (resultObj, mapping, propertyName) => {
                     const key = Str.result(mapping.key, props);
                     const value = Onyx.tryGetCachedValue(key, mapping);
 
                     if (value !== undefined) {
-                        cachedState[propertyName] = value;
+                        // eslint-disable-next-line no-param-reassign
+                        resultObj[propertyName] = value;
                     }
-                });
+
+                    return resultObj;
+                }, {});
 
                 // If we have all the data we need, then we can render the component immediately
                 cachedState.loading = _.size(cachedState) < requiredKeysForInit.length;

--- a/lib/withOnyx.js
+++ b/lib/withOnyx.js
@@ -37,12 +37,29 @@ export default function (mapOnyxToState) {
                 // disconnected. It is a key value store with the format {[mapping.key]: connectionID}.
                 this.activeConnectionIDs = {};
 
+                let cachedAssigments = 0;
+                this.cachedState = {};
+
+                // Check if we can get all the data synchronously from cache
+                _.each(mapOnyxToState, (mapping, propertyName) => {
+                    const key = Str.result(mapping.key, props);
+                    const value = Onyx.tryGetCachedValue(key, mapping);
+
+                    if (value !== undefined) {
+                        this.cachedState[propertyName] = value;
+                        cachedAssigments++;
+                    }
+                });
+
+                // If there are no required keys for init then we can render the wrapped component immediately
+                const loading = cachedAssigments < requiredKeysForInit.length;
+
                 // Object holding the temporary initial state for the component while we load the various Onyx keys
-                this.tempState = {};
+                this.tempState = this.cachedState;
 
                 this.state = {
-                    // If there are no required keys for init then we can render the wrapped component immediately
-                    loading: requiredKeysForInit.length > 0,
+                    loading,
+                    ...(loading ? {} : this.cachedState),
                 };
             }
 

--- a/lib/withOnyx.js
+++ b/lib/withOnyx.js
@@ -58,6 +58,7 @@ export default function (mapOnyxToState) {
                 this.state = cachedState;
             }
 
+            // TODO: I think we don't have to wait until mount to subscribe to Onyx keys. We can do it in the constructor as well.
             componentDidMount() {
                 // Subscribe each of the state properties to the proper Onyx key
                 _.each(mapOnyxToState, (mapping, propertyName) => {
@@ -101,7 +102,6 @@ export default function (mapOnyxToState) {
              */
             setWithOnyxState(statePropertyName, val) {
                 if (!this.state.loading) {
-                    this.setState({[statePropertyName]: val});
                     return;
                 }
 

--- a/lib/withOnyx.js
+++ b/lib/withOnyx.js
@@ -55,10 +55,8 @@ export default function (mapOnyxToState) {
                 // Object holding the temporary initial state for the component while we load the various Onyx keys
                 this.tempState = cachedState;
 
-                this.state = {
-                    loading,
-                    ...(loading ? {} : cachedState),
-                };
+                cachedState.loading = loading;
+                this.state = cachedState;
             }
 
             componentDidMount() {

--- a/lib/withOnyx.js
+++ b/lib/withOnyx.js
@@ -119,7 +119,17 @@ export default function (mapOnyxToState) {
                     return;
                 }
 
-                this.setState({...this.tempState, loading: false});
+                const stateUpdate = {...this.tempState, loading: false};
+
+                // Why are we setting the state here manually, instead of just using setState?
+                // Explanation: setState is a async operation, meaning it might execute on the next task,
+                // or to a later point in the microtask queue. That means, that there is a chance that
+                // setWithOnyxState is called again before the state is actually set. This causes issues
+                // with the above checks for the loading state.
+                // Note: This behaviour has been mainly observed on fabric.
+                this.state = stateUpdate;
+
+                this.setState(stateUpdate); // Trigger a render
                 delete this.tempState;
             }
 

--- a/lib/withOnyx.js
+++ b/lib/withOnyx.js
@@ -58,7 +58,6 @@ export default function (mapOnyxToState) {
                 this.state = cachedState;
             }
 
-            // TODO: I think we don't have to wait until mount to subscribe to Onyx keys. We can do it in the constructor as well.
             componentDidMount() {
                 // Subscribe each of the state properties to the proper Onyx key
                 _.each(mapOnyxToState, (mapping, propertyName) => {
@@ -71,7 +70,6 @@ export default function (mapOnyxToState) {
                 // If any of the mappings use data from the props, then when the props change, all the
                 // connections need to be reconnected with the new props
                 _.each(mapOnyxToState, (mapping, propertyName) => {
-                    // Check if we can update from cache already
                     const previousKey = Str.result(mapping.key, prevProps);
                     const newKey = Str.result(mapping.key, this.props);
                     if (previousKey !== newKey) {

--- a/lib/withOnyx.js
+++ b/lib/withOnyx.js
@@ -72,8 +72,6 @@ export default function (mapOnyxToState) {
             }
 
             componentDidUpdate(prevProps) {
-                const stateUpdates = {};
-
                 // If any of the mappings use data from the props, then when the props change, all the
                 // connections need to be reconnected with the new props
                 _.each(mapOnyxToState, (mapping, propertyName) => {
@@ -81,24 +79,12 @@ export default function (mapOnyxToState) {
                     const previousKey = Str.result(mapping.key, prevProps);
                     const newKey = Str.result(mapping.key, this.props);
                     if (previousKey !== newKey) {
-                        // Check if we can update the state synchronously from cache
-                        const value = Onyx.tryGetCachedValue(newKey, mapping);
-                        if (value !== undefined && value !== this.state[propertyName]) {
-                            stateUpdates[propertyName] = value;
-                        }
-
-                        // Renew the connection with the new key
                         Onyx.disconnect(this.activeConnectionIDs[previousKey], previousKey);
                         delete this.activeConnectionIDs[previousKey];
                         this.connectMappingToOnyx(mapping, propertyName);
                     }
                 });
                 this.checkEvictableKeys();
-
-                // TODO: i am bothered by the extra render that happens here.
-                if (!_.isEmpty(stateUpdates)) {
-                    this.setState(stateUpdates);
-                }
             }
 
             componentWillUnmount() {

--- a/lib/withOnyx.js
+++ b/lib/withOnyx.js
@@ -50,7 +50,7 @@ export default function (mapOnyxToState) {
                 });
 
                 // If we have all the data we need, then we can render the component immediately
-                cachedState.loading = _.keys(cachedState).length < requiredKeysForInit.length;
+                cachedState.loading = _.size(cachedState) < requiredKeysForInit.length;
 
                 // Object holding the temporary initial state for the component while we load the various Onyx keys
                 this.tempState = cachedState;

--- a/lib/withOnyx.js
+++ b/lib/withOnyx.js
@@ -101,7 +101,7 @@ export default function (mapOnyxToState) {
              * @param {*} val
              */
             setWithOnyxState(statePropertyName, val) {
-                if (!this.state.loading && this.state[statePropertyName] !== val) {
+                if (!this.state.loading) {
                     this.setState({[statePropertyName]: val});
                     return;
                 }

--- a/lib/withOnyx.js
+++ b/lib/withOnyx.js
@@ -101,7 +101,7 @@ export default function (mapOnyxToState) {
             setWithOnyxState(statePropertyName, val) {
                 // We might have loaded the values for the onyx keys/mappings already from the cache.
                 // In case we were able to load all the values upfront, the loading state will be false.
-                // However, Onyx.js will always call setWithOnyxState, as it doesn't now that this implementation
+                // However, Onyx.js will always call setWithOnyxState, as it doesn't know that this implementation
                 // already loaded the values from cache. Thus we have to check whether the value has changed
                 // before we set the state to prevent unnecessary renders.
                 const prevValue = this.state[statePropertyName];

--- a/lib/withOnyx.js
+++ b/lib/withOnyx.js
@@ -99,9 +99,11 @@ export default function (mapOnyxToState) {
              * @param {*} val
              */
             setWithOnyxState(statePropertyName, val) {
-                // This method gets called by Onyx.connect no matter if the cached
-                // data is already there or not. Thus we have to check whether
-                // the data has changed or not before we set the state.
+                // We might have loaded the values for the onyx keys/mappings already from the cache.
+                // In case we were able to load all the values upfront, the loading state will be false.
+                // However, Onyx.js will always call setWithOnyxState, as it doesn't now that this implementation
+                // already loaded the values from cache. Thus we have to check whether the value has changed
+                // before we set the state to prevent unnecessary renders.
                 const prevValue = this.state[statePropertyName];
                 if (!this.state.loading && prevValue === val) {
                     return;

--- a/lib/withOnyx.js
+++ b/lib/withOnyx.js
@@ -101,7 +101,16 @@ export default function (mapOnyxToState) {
              * @param {*} val
              */
             setWithOnyxState(statePropertyName, val) {
+                // This method gets called by Onyx.connect no matter if the cached
+                // data is already there or not. Thus we have to check whether
+                // the data has changed or not before we set the state.
+                const prevValue = this.state[statePropertyName];
+                if (!this.state.loading && prevValue === val) {
+                    return;
+                }
+
                 if (!this.state.loading) {
+                    this.setState({[statePropertyName]: val});
                     return;
                 }
 

--- a/lib/withOnyx.js
+++ b/lib/withOnyx.js
@@ -50,12 +50,11 @@ export default function (mapOnyxToState) {
                 });
 
                 // If we have all the data we need, then we can render the component immediately
-                const loading = _.keys(cachedState).length < requiredKeysForInit.length;
+                cachedState.loading = _.keys(cachedState).length < requiredKeysForInit.length;
 
                 // Object holding the temporary initial state for the component while we load the various Onyx keys
                 this.tempState = cachedState;
 
-                cachedState.loading = loading;
                 this.state = cachedState;
             }
 

--- a/lib/withOnyx.js
+++ b/lib/withOnyx.js
@@ -121,12 +121,9 @@ export default function (mapOnyxToState) {
 
                 const stateUpdate = {...this.tempState, loading: false};
 
-                // Why are we setting the state here manually, instead of just using setState?
-                // Explanation: setState is a async operation, meaning it might execute on the next task,
-                // or to a later point in the microtask queue. That means, that there is a chance that
-                // setWithOnyxState is called again before the state is actually set. This causes issues
-                // with the above checks for the loading state.
-                // Note: This behaviour has been mainly observed on fabric.
+                // The state is set here manually, instead of using setState because setState is an async operation, meaning it might execute on the next tick,
+                // or at a later point in the microtask queue. That can lead to a race condition where
+                // setWithOnyxState is called before the state is actually set. This results in unreliable behavior when checking the loading state and has been mainly observed on fabric.
                 this.state = stateUpdate;
 
                 this.setState(stateUpdate); // Trigger a render

--- a/lib/withOnyx.js
+++ b/lib/withOnyx.js
@@ -38,7 +38,7 @@ export default function (mapOnyxToState) {
                 this.activeConnectionIDs = {};
 
                 let cachedAssigments = 0;
-                this.cachedState = {};
+                const cachedState = {};
 
                 // Check if we can get all the data synchronously from cache
                 _.each(mapOnyxToState, (mapping, propertyName) => {
@@ -46,7 +46,7 @@ export default function (mapOnyxToState) {
                     const value = Onyx.tryGetCachedValue(key, mapping);
 
                     if (value !== undefined) {
-                        this.cachedState[propertyName] = value;
+                        cachedState[propertyName] = value;
                         cachedAssigments++;
                     }
                 });
@@ -55,11 +55,11 @@ export default function (mapOnyxToState) {
                 const loading = cachedAssigments < requiredKeysForInit.length;
 
                 // Object holding the temporary initial state for the component while we load the various Onyx keys
-                this.tempState = this.cachedState;
+                this.tempState = cachedState;
 
                 this.state = {
                     loading,
-                    ...(loading ? {} : this.cachedState),
+                    ...(loading ? {} : cachedState),
                 };
             }
 
@@ -72,19 +72,33 @@ export default function (mapOnyxToState) {
             }
 
             componentDidUpdate(prevProps) {
+                const stateUpdates = {};
+
                 // If any of the mappings use data from the props, then when the props change, all the
                 // connections need to be reconnected with the new props
                 _.each(mapOnyxToState, (mapping, propertyName) => {
+                    // Check if we can update from cache already
                     const previousKey = Str.result(mapping.key, prevProps);
                     const newKey = Str.result(mapping.key, this.props);
-
                     if (previousKey !== newKey) {
+                        // Check if we can update the state synchronously from cache
+                        const value = Onyx.tryGetCachedValue(newKey, mapping);
+                        if (value !== undefined && value !== this.state[propertyName]) {
+                            stateUpdates[propertyName] = value;
+                        }
+
+                        // Renew the connection with the new key
                         Onyx.disconnect(this.activeConnectionIDs[previousKey], previousKey);
                         delete this.activeConnectionIDs[previousKey];
                         this.connectMappingToOnyx(mapping, propertyName);
                     }
                 });
                 this.checkEvictableKeys();
+
+                // TODO: i am bothered by the extra render that happens here.
+                if (!_.isEmpty(stateUpdates)) {
+                    this.setState(stateUpdates);
+                }
             }
 
             componentWillUnmount() {
@@ -105,7 +119,7 @@ export default function (mapOnyxToState) {
              * @param {*} val
              */
             setWithOnyxState(statePropertyName, val) {
-                if (!this.state.loading) {
+                if (!this.state.loading && this.state[statePropertyName] !== val) {
                     this.setState({[statePropertyName]: val});
                     return;
                 }

--- a/tests/components/ViewWithText.js
+++ b/tests/components/ViewWithText.js
@@ -12,7 +12,7 @@ const defaultProps = {
     onRender: () => {},
 };
 
-const ViewWithText = (props) => {
+function ViewWithText(props) {
     props.onRender();
 
     return (
@@ -20,7 +20,7 @@ const ViewWithText = (props) => {
             <Text testID="text-element">{props.text}</Text>
         </View>
     );
-};
+}
 
 ViewWithText.propTypes = propTypes;
 ViewWithText.defaultProps = defaultProps;

--- a/tests/components/ViewWithText.js
+++ b/tests/components/ViewWithText.js
@@ -5,13 +5,23 @@ import {View, Text} from 'react-native';
 
 const propTypes = {
     text: PropTypes.string.isRequired,
+    onRender: PropTypes.func,
 };
 
-const ViewWithText = props => (
-    <View>
-        <Text testID="text-element">{props.text}</Text>
-    </View>
-);
+const defaultProps = {
+    onRender: () => {},
+};
+
+const ViewWithText = (props) => {
+    props.onRender();
+
+    return (
+        <View>
+            <Text testID="text-element">{props.text}</Text>
+        </View>
+    );
+};
 
 ViewWithText.propTypes = propTypes;
+ViewWithText.defaultProps = defaultProps;
 export default ViewWithText;

--- a/tests/unit/onyxCacheTest.js
+++ b/tests/unit/onyxCacheTest.js
@@ -1,3 +1,4 @@
+/* eslint-disable rulesdir/onyx-props-must-have-default */
 import React from 'react';
 import {render} from '@testing-library/react-native';
 import _ from 'underscore';

--- a/tests/unit/onyxCacheTest.js
+++ b/tests/unit/onyxCacheTest.js
@@ -1,4 +1,3 @@
-/* eslint-disable rulesdir/onyx-props-must-have-default */
 import React from 'react';
 import {render} from '@testing-library/react-native';
 import _ from 'underscore';

--- a/tests/unit/subscribeToPropertiesTest.js
+++ b/tests/unit/subscribeToPropertiesTest.js
@@ -56,7 +56,6 @@ describe('Only the specific property changes when using withOnyx() and ', () => 
             .then(() => Onyx.merge(ONYX_KEYS.TEST_KEY, {a: 'one', b: 'two'}))
             .then(() => {
                 renderedComponent = render(<ErrorBoundary><TestComponentWithOnyx /></ErrorBoundary>);
-                return waitForPromisesToResolve();
             })
 
             // Then the props passed to the component should only include the property "a" that was specified
@@ -68,7 +67,6 @@ describe('Only the specific property changes when using withOnyx() and ', () => 
             .then(() => Onyx.merge(ONYX_KEYS.TEST_KEY, {a: 'two'}))
             .then(() => {
                 renderedComponent = render(<ErrorBoundary><TestComponentWithOnyx /></ErrorBoundary>);
-                return waitForPromisesToResolve();
             })
 
             // Then the props passed should have the new value of property "a"
@@ -80,7 +78,6 @@ describe('Only the specific property changes when using withOnyx() and ', () => 
             .then(() => Onyx.merge(ONYX_KEYS.TEST_KEY, {b: 'two'}))
             .then(() => {
                 renderedComponent = render(<ErrorBoundary><TestComponentWithOnyx /></ErrorBoundary>);
-                return waitForPromisesToResolve();
             })
 
             // Then the props passed should not have changed
@@ -126,16 +123,12 @@ describe('Only the specific property changes when using withOnyx() and ', () => 
         return waitForPromisesToResolve()
 
             // When Onyx is updated with an object that has multiple properties
-            .then(() => {
-                Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
-                    [`${ONYX_KEYS.COLLECTION.TEST_KEY}1`]: {a: 'one', b: 'two'},
-                    [`${ONYX_KEYS.COLLECTION.TEST_KEY}2`]: {c: 'three', d: 'four'},
-                });
-                return waitForPromisesToResolve();
-            })
+            .then(() => Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
+                [`${ONYX_KEYS.COLLECTION.TEST_KEY}1`]: {a: 'one', b: 'two'},
+                [`${ONYX_KEYS.COLLECTION.TEST_KEY}2`]: {c: 'three', d: 'four'},
+            }))
             .then(() => {
                 renderedComponent = render(<ErrorBoundary><TestComponentWithOnyx /></ErrorBoundary>);
-                return waitForPromisesToResolve();
             })
 
             // Then the props passed to the component should only include the property "a" that was specified
@@ -146,10 +139,7 @@ describe('Only the specific property changes when using withOnyx() and ', () => 
             // When Onyx is updated with a change to property a using merge()
             // This uses merge() just to make sure that everything works as expected when mixing merge()
             // and mergeCollection()
-            .then(() => {
-                Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_KEY}1`, {a: 'two'});
-                return waitForPromisesToResolve();
-            })
+            .then(() => Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_KEY}1`, {a: 'two'}))
 
             // Then the props passed should have the new value of property "a"
             .then(() => {
@@ -157,12 +147,9 @@ describe('Only the specific property changes when using withOnyx() and ', () => 
             })
 
             // When Onyx is updated with a change to property b using mergeCollection()
-            .then(() => {
-                Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
-                    [`${ONYX_KEYS.COLLECTION.TEST_KEY}1`]: {b: 'three'},
-                });
-                return waitForPromisesToResolve();
-            })
+            .then(() => Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
+                [`${ONYX_KEYS.COLLECTION.TEST_KEY}1`]: {b: 'three'},
+            }))
 
             // Then the props passed should not have changed
             .then(() => {
@@ -214,16 +201,12 @@ describe('Only the specific property changes when using withOnyx() and ', () => 
         return waitForPromisesToResolve()
 
             // When Onyx is updated with an object that has multiple properties
-            .then(() => {
-                Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
-                    [`${ONYX_KEYS.COLLECTION.TEST_KEY}1`]: {a: 'one', b: 'two'},
-                    [`${ONYX_KEYS.COLLECTION.TEST_KEY}2`]: {c: 'three', d: 'four'},
-                });
-                return waitForPromisesToResolve();
-            })
+            .then(() => Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
+                [`${ONYX_KEYS.COLLECTION.TEST_KEY}1`]: {a: 'one', b: 'two'},
+                [`${ONYX_KEYS.COLLECTION.TEST_KEY}2`]: {c: 'three', d: 'four'},
+            }))
             .then(() => {
                 renderedComponent = render(<ErrorBoundary><TestComponentWithOnyx /></ErrorBoundary>);
-                return waitForPromisesToResolve();
             })
 
             // Then the props passed to the component should only include the property "a" that was specified
@@ -234,10 +217,7 @@ describe('Only the specific property changes when using withOnyx() and ', () => 
             // When Onyx is updated with a change to property a using merge()
             // This uses merge() just to make sure that everything works as expected when mixing merge()
             // and mergeCollection()
-            .then(() => {
-                Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_KEY}1`, {a: 'two'});
-                return waitForPromisesToResolve();
-            })
+            .then(() => Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_KEY}1`, {a: 'two'}))
 
             // Then the props passed should have the new value of property "a"
             .then(() => {
@@ -245,12 +225,9 @@ describe('Only the specific property changes when using withOnyx() and ', () => 
             })
 
             // When Onyx is updated with a change to property b using mergeCollection()
-            .then(() => {
-                Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
-                    [`${ONYX_KEYS.COLLECTION.TEST_KEY}1`]: {b: 'three'},
-                });
-                return waitForPromisesToResolve();
-            })
+            .then(() => Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
+                [`${ONYX_KEYS.COLLECTION.TEST_KEY}1`]: {b: 'three'},
+            }))
 
             // Then the props passed should not have changed
             .then(() => {

--- a/tests/unit/subscribeToPropertiesTest.js
+++ b/tests/unit/subscribeToPropertiesTest.js
@@ -1,3 +1,4 @@
+/* eslint-disable rulesdir/onyx-props-must-have-default */
 import React from 'react';
 import {render, cleanup} from '@testing-library/react-native';
 import Onyx, {withOnyx} from '../../lib';

--- a/tests/unit/subscribeToPropertiesTest.js
+++ b/tests/unit/subscribeToPropertiesTest.js
@@ -1,4 +1,3 @@
-/* eslint-disable rulesdir/onyx-props-must-have-default */
 import React from 'react';
 import {render, cleanup} from '@testing-library/react-native';
 import Onyx, {withOnyx} from '../../lib';

--- a/tests/unit/withOnyxTest.js
+++ b/tests/unit/withOnyxTest.js
@@ -24,6 +24,8 @@ beforeEach(() => Onyx.clear());
 
 describe('withOnyx', () => {
     it('should render immediately with the test data when using withOnyx', () => {
+        const onRender = jest.fn();
+
         // Note: earlier, after rendering a component we had to do another
         // waitForPromisesToResolve() to wait for Onyx's next tick updating
         // the component from {loading: true} to {loading:false, ...data}.
@@ -37,9 +39,19 @@ describe('withOnyx', () => {
                     },
                 })(ViewWithText);
 
-                const result = render(<TestComponentWithOnyx />);
+                const result = render(<TestComponentWithOnyx onRender={onRender} />);
                 const textComponent = result.getByText('test1');
                 expect(textComponent).not.toBeNull();
+
+                jest.runAllTimers();
+                return waitForPromisesToResolve();
+            })
+            .then(() => {
+                // As the component immediately rendered from cache, we want to make
+                // sure it wasn't updated a second time with the same value (the connect
+                // calls gets the data another time and tries to forward it to the component,
+                // which could cause a re-render if the right checks aren't in place):
+                expect(onRender).toHaveBeenCalledTimes(1);
             });
     });
 

--- a/tests/unit/withOnyxTest.js
+++ b/tests/unit/withOnyxTest.js
@@ -56,9 +56,8 @@ describe('withOnyx', () => {
             .then(() => {
                 Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_KEY}1`, {ID: 123});
                 Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_KEY}2`, {ID: 234});
-                Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_KEY}3`, {ID: 345});
+                return Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_KEY}3`, {ID: 345});
             })
-            .then(waitForPromisesToResolve)
             .then(() => {
                 expect(onRender).toHaveBeenCalledTimes(4);
             });
@@ -73,12 +72,9 @@ describe('withOnyx', () => {
         const onRender = jest.fn();
         render(<TestComponentWithOnyx onRender={onRender} />);
         return waitForPromisesToResolve()
-            .then(() => {
-                Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
-                    test_1: {ID: 123}, test_2: {ID: 234}, test_3: {ID: 345},
-                });
-                return waitForPromisesToResolve();
-            })
+            .then(() => Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
+                test_1: {ID: 123}, test_2: {ID: 234}, test_3: {ID: 345},
+            }))
             .then(() => {
                 expect(onRender).toHaveBeenCalledTimes(2);
             });
@@ -94,12 +90,9 @@ describe('withOnyx', () => {
         const onRender = jest.fn();
         render(<TestComponentWithOnyx onRender={onRender} />);
         return waitForPromisesToResolve()
-            .then(() => {
-                Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
-                    test_1: {ID: 123}, test_2: {ID: 234}, test_3: {ID: 345},
-                });
-                return waitForPromisesToResolve();
-            })
+            .then(() => Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
+                test_1: {ID: 123}, test_2: {ID: 234}, test_3: {ID: 345},
+            }))
             .then(() => {
                 expect(onRender).toHaveBeenCalledTimes(2);
             });
@@ -115,18 +108,12 @@ describe('withOnyx', () => {
         const onRender = jest.fn();
         render(<TestComponentWithOnyx onRender={onRender} />);
         return waitForPromisesToResolve()
-            .then(() => {
-                Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
-                    test_1: {list: [1, 2]},
-                });
-                return waitForPromisesToResolve();
-            })
-            .then(() => {
-                Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
-                    test_1: {list: [7]},
-                });
-                return waitForPromisesToResolve();
-            })
+            .then(() => Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
+                test_1: {list: [1, 2]},
+            }))
+            .then(() => Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
+                test_1: {list: [7]},
+            }))
             .then(() => {
                 expect(onRender).toHaveBeenCalledTimes(3);
                 expect(onRender).toHaveBeenLastCalledWith({
@@ -147,12 +134,11 @@ describe('withOnyx', () => {
         return waitForPromisesToResolve()
             .then(() => {
                 Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {test_4: {ID: 456}, test_5: {ID: 567}});
-                Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
+                return Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
                     test_4: {Name: 'Test4'},
                     test_5: {Name: 'Test5'},
                     test_6: {ID: 678, Name: 'Test6'},
                 });
-                return waitForPromisesToResolve();
             })
             .then(() => {
                 expect(onRender).toHaveBeenCalledTimes(3);
@@ -178,14 +164,13 @@ describe('withOnyx', () => {
                 const result = render(<TestComponentWithOnyx onRender={onRender} collectionID="1" />);
                 rerender = result.rerender;
                 getByTestId = result.getByTestId;
-                return waitForPromisesToResolve();
             })
             .then(() => {
                 expect(getByTestId('text-element').props.children).toEqual('test_1');
             })
             .then(() => {
                 rerender(<TestComponentWithOnyx collectionID="2" />);
-                return waitForPromisesToResolve();
+                return waitForPromisesToResolve(); // TODO: interesting, here we need to await. Why?
             })
             .then(() => {
                 expect(getByTestId('text-element').props.children).toEqual('test_2');
@@ -231,7 +216,6 @@ describe('withOnyx', () => {
                     }),
                 )(ViewWithCollections);
                 render(<TestComponentWithOnyx onRender={onRender} />);
-                return waitForPromisesToResolve();
             })
             .then(() => {
                 expect(onRender).toHaveBeenLastCalledWith({
@@ -275,16 +259,12 @@ describe('withOnyx', () => {
                     },
                 })(ViewWithCollections);
                 render(<TestComponentWithOnyx3 onRender={onRender3} />);
+            })
 
-                return waitForPromisesToResolve();
-            })
-            .then(() => {
-                // When a single item in the collection is updated with mergeCollect()
-                Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
-                    test_1: {ID: 1, newProperty: 'yay'},
-                });
-                return waitForPromisesToResolve();
-            })
+            // When a single item in the collection is updated with mergeCollect()
+            .then(() => Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
+                test_1: {ID: 1, newProperty: 'yay'},
+            }))
             .then(() => {
                 // Then the component subscribed to the modified item should have the new version of the item
                 // and all other components should be unchanged.
@@ -319,16 +299,12 @@ describe('withOnyx', () => {
                     },
                 })(ViewWithCollections);
                 render(<TestComponentWithOnyx onRender={onRender} />);
+            })
 
-                return waitForPromisesToResolve();
-            })
-            .then(() => {
-                // When the `number` property is updated using mergeCollection to be 2
-                Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
-                    test_1: {number: 2},
-                });
-                return waitForPromisesToResolve();
-            })
+            // When the `number` property is updated using mergeCollection to be 2
+            .then(() => Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
+                test_1: {number: 2},
+            }))
             .then(() => {
                 // Then the component subscribed to the modified item should be rendered twice.
                 // The first time it will render with number === 1
@@ -354,22 +330,17 @@ describe('withOnyx', () => {
                     },
                 })(ViewWithCollections);
                 render(<TestComponentWithOnyx onRender={onRender} />);
+            })
 
-                return waitForPromisesToResolve();
-            })
-            .then(() => {
-                // And we set the value to the same value it was before
-                Onyx.merge(ONYX_KEYS.SIMPLE_KEY, 'string');
-                return waitForPromisesToResolve();
-            })
+            // And we set the value to the same value it was before
+            .then(() => Onyx.merge(ONYX_KEYS.SIMPLE_KEY, 'string'))
             .then(() => {
                 // Then the component subscribed to the modified item should only render once
                 expect(onRender).toHaveBeenCalledTimes(1);
                 expect(onRender.mock.calls[0][0].simple).toBe('string');
 
                 // If we change the value to something new
-                Onyx.merge(ONYX_KEYS.SIMPLE_KEY, 'long_string');
-                return waitForPromisesToResolve();
+                return Onyx.merge(ONYX_KEYS.SIMPLE_KEY, 'long_string');
             })
             .then(() => {
                 // Then the component subscribed to the modified item should only render once

--- a/tests/unit/withOnyxTest.js
+++ b/tests/unit/withOnyxTest.js
@@ -23,10 +23,13 @@ Onyx.init({
 beforeEach(() => Onyx.clear());
 
 describe('withOnyx', () => {
-    it('should render with the test data when using withOnyx', () => {
-        let result;
-
-        return Onyx.set(ONYX_KEYS.TEST_KEY, 'test1')
+    it('should render immediately with the test data when using withOnyx', () => {
+        // Note: earlier, after rendering a component we had to do another
+        // waitForPromisesToResolve() to wait for Onyx's next tick updating
+        // the component from {loading: true} to {loading:false, ...data}.
+        // We now changed the architecture, so that when a key can be retrieved
+        // synchronously from cache, we expect the component to be rendered immediately.
+        Onyx.set(ONYX_KEYS.TEST_KEY, 'test1')
             .then(() => {
                 const TestComponentWithOnyx = withOnyx({
                     text: {
@@ -34,10 +37,7 @@ describe('withOnyx', () => {
                     },
                 })(ViewWithText);
 
-                result = render(<TestComponentWithOnyx />);
-                return waitForPromisesToResolve();
-            })
-            .then(() => {
+                const result = render(<TestComponentWithOnyx />);
                 const textComponent = result.getByText('test1');
                 expect(textComponent).not.toBeNull();
             });

--- a/tests/unit/withOnyxTest.js
+++ b/tests/unit/withOnyxTest.js
@@ -1,3 +1,4 @@
+/* eslint-disable rulesdir/onyx-props-must-have-default */
 import React from 'react';
 import {render} from '@testing-library/react-native';
 import Onyx, {withOnyx} from '../../lib';

--- a/tests/unit/withOnyxTest.js
+++ b/tests/unit/withOnyxTest.js
@@ -1,4 +1,3 @@
-/* eslint-disable rulesdir/onyx-props-must-have-default */
 import React from 'react';
 import {render} from '@testing-library/react-native';
 import Onyx, {withOnyx} from '../../lib';

--- a/tests/unit/withOnyxTest.js
+++ b/tests/unit/withOnyxTest.js
@@ -163,11 +163,17 @@ describe('withOnyx', () => {
                 const result = render(<TestComponentWithOnyx collectionID="1" />);
                 rerender = result.rerender;
                 getByTestId = result.getByTestId;
-
+            })
+            .then(() => {
                 expect(getByTestId('text-element').props.children).toEqual('test_1');
-
+            })
+            .then(() => {
                 rerender(<TestComponentWithOnyx collectionID="2" />);
 
+                // Note, when we change the prop, we need to wait for the next tick:
+                return waitForPromisesToResolve();
+            })
+            .then(() => {
                 expect(getByTestId('text-element').props.children).toEqual('test_2');
             });
     });

--- a/tests/unit/withOnyxTest.js
+++ b/tests/unit/withOnyxTest.js
@@ -151,7 +151,6 @@ describe('withOnyx', () => {
     it('should update if a prop dependent key changes', () => {
         let rerender;
         let getByTestId;
-        const onRender = jest.fn();
         const TestComponentWithOnyx = withOnyx({
             text: {
                 key: props => `${ONYX_KEYS.COLLECTION.TEST_KEY}${props.collectionID}`,
@@ -161,18 +160,14 @@ describe('withOnyx', () => {
         Onyx.set(`${ONYX_KEYS.COLLECTION.TEST_KEY}2`, 'test_2');
         return waitForPromisesToResolve()
             .then(() => {
-                const result = render(<TestComponentWithOnyx onRender={onRender} collectionID="1" />);
+                const result = render(<TestComponentWithOnyx collectionID="1" />);
                 rerender = result.rerender;
                 getByTestId = result.getByTestId;
-            })
-            .then(() => {
+
                 expect(getByTestId('text-element').props.children).toEqual('test_1');
-            })
-            .then(() => {
+
                 rerender(<TestComponentWithOnyx collectionID="2" />);
-                return waitForPromisesToResolve(); // TODO: interesting, here we need to await. Why?
-            })
-            .then(() => {
+
                 expect(getByTestId('text-element').props.children).toEqual('test_2');
             });
     });

--- a/tests/unit/withOnyxTest.js
+++ b/tests/unit/withOnyxTest.js
@@ -274,7 +274,7 @@ describe('withOnyx', () => {
                 render(<TestComponentWithOnyx3 onRender={onRender3} />);
             })
 
-            // When a single item in the collection is updated with mergeCollect()
+            // When a single item in the collection is updated with mergeCollection()
             .then(() => Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
                 test_1: {ID: 1, newProperty: 'yay'},
             }))


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

This PR introduces support for `withOnyx` to load data from cache immediately and synchronously. This greatly increases the chance when rending a `withOnyx` wrapped component that it can render right away, instead of being blocked by a loading state at first.

Overview of the changes made: 

- **`tryGetCachedValue`**: New method in `Onyx.js` that is used by `withOnyx` to get values from cache
- **`withOnyx.js`**: In the constructor of the wrapper class try to load all data from cache. Only activate loading state, if not all data was available from cache.
- **`Onyx.js`**: 
  - Cleaned up the code a bit by combining certain statements
  - Added a few more equality checks before calling `setState`

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/react-native-onyx/issues/269

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

The tests have been modified to reflect the changes made. In particular a lot of the `waitForPromiseToResolve` calls were removed. They aren't needed anymore, as a component can render immediately, once we have the data in onyx, as we don't need to wait for the next tick.

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->

/
