### PR TITLE
Fix: Remove nullish values on set and on merge when no value is in storage

### DIFF
--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -910,6 +910,21 @@ function hasPendingMergeForKey(key) {
 }
 
 /**
+ * For objects, the key for null values needs to be removed from the object to ensure the value will get removed from storage completely.
+ * On native, SQLite will remove top-level keys that are null. To be consistent, we remove them on web too.
+ * @private
+ * @param {*} value
+ * @returns {*}
+ */
+function cleanObject(value) {
+    if (!_.isArray(value) && _.isObject(value)) {
+        return _.omit(value, objectValue => _.isNull(objectValue));
+    }
+
+    return value;
+}
+
+/**
  * Write a value to our store with the given key
  *
  * @param {String} key ONYXKEY to set
@@ -918,7 +933,9 @@ function hasPendingMergeForKey(key) {
  * @returns {Promise}
  */
 function set(key, value) {
-    if (_.isNull(value)) {
+    let valueCopy = value;
+
+    if (_.isNull(valueCopy)) {
         return remove(key);
     }
 
@@ -926,18 +943,20 @@ function set(key, value) {
         Logger.logAlert(`Onyx.set() called after Onyx.merge() for key: ${key}. It is recommended to use set() or merge() not both.`);
     }
 
-    const hasChanged = cache.hasValueChanged(key, value);
+    valueCopy = cleanObject(valueCopy);
+
+    const hasChanged = cache.hasValueChanged(key, valueCopy);
 
     // This approach prioritizes fast UI changes without waiting for data to be stored in device storage.
-    broadcastUpdate(key, value, hasChanged, 'set');
+    broadcastUpdate(key, valueCopy, hasChanged, 'set');
 
     // If the value has not changed, calling Storage.setItem() would be redundant and a waste of performance, so return early instead.
     if (!hasChanged) {
         return Promise.resolve();
     }
 
-    return Storage.setItem(key, value)
-        .catch(error => evictStorageAndRetry(error, set, key, value));
+    return Storage.setItem(key, valueCopy)
+        .catch(error => evictStorageAndRetry(error, set, key, valueCopy));
 }
 
 /**
@@ -1034,7 +1053,7 @@ function merge(key, changes) {
         .then((existingValue) => {
             try {
                 // We first only merge the changes, so we can provide these to the native implementation (SQLite uses only delta changes in "JSON_PATCH" to merge)
-                const batchedChanges = applyMerge(undefined, mergeQueue[key]);
+                let batchedChanges = applyMerge(undefined, mergeQueue[key]);
 
                 // Clean up the write queue so we
                 // don't apply these changes again
@@ -1043,10 +1062,12 @@ function merge(key, changes) {
                 // After that we merge the batched changes with the existing value
                 let modifiedData = applyMerge(existingValue, [batchedChanges]);
 
-                // For objects, the key for null values needs to be removed from the object to ensure the value will get removed from storage completely.
-                // On native, SQLite will remove top-level keys that are null. To be consistent, we remove them on web too.
-                if (!_.isArray(modifiedData) && _.isObject(modifiedData)) {
-                    modifiedData = _.omit(modifiedData, value => _.isNull(value));
+                modifiedData = cleanObject(modifiedData);
+
+                // On the first write SQLite doesn't use JSON_PATCH, which means, nullish values won't be omitted.
+                // Therefore we remove null values from the `batchedChanges` which are sent to the native implementation, if no existing value is present.
+                if (!existingValue) {
+                    batchedChanges = cleanObject(batchedChanges);
                 }
 
                 const hasChanged = cache.hasValueChanged(key, modifiedData);
@@ -1376,7 +1397,6 @@ const Onyx = {
     multiSet,
     merge,
     mergeCollection,
-    hasPendingMergeForKey,
     update,
     clear,
     getAllKeys,

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -910,18 +910,21 @@ function hasPendingMergeForKey(key) {
 }
 
 /**
- * For objects, the key for null values needs to be removed from the object to ensure the value will get removed from storage completely.
- * On native, SQLite will remove top-level keys that are null. To be consistent, we remove them on web too.
+ * We generally want to remove top-level nullish values from objects written to disk and cache, because it decreases the amount of data stored in memory and on disk.
+ * On native, when merging an existing value with new changes, SQLite will use  JSON_PATCH, which removes top-level nullish values.
+ * To be consistent with the behaviour for merge, we'll also want to remove nullish values for "set" operations.
+ * On web, IndexedDB will keep the top-level keys along with a null value and this uses up storage and memory.
+ * This method will ensure that keys for null values are removed before an object is written to disk and cache so that all platforms are storing the data in the same efficient way.
  * @private
  * @param {*} value
  * @returns {*}
  */
-function cleanObject(value) {
-    if (!_.isArray(value) && _.isObject(value)) {
-        return _.omit(value, objectValue => _.isNull(objectValue));
+function removeNullObjectValues(value) {
+    if (_.isArray(value) || !_.isObject(value)) {
+        return value;
     }
 
-    return value;
+    return _.omit(value, objectValue => _.isNull(objectValue));
 }
 
 /**
@@ -933,9 +936,7 @@ function cleanObject(value) {
  * @returns {Promise}
  */
 function set(key, value) {
-    let valueCopy = value;
-
-    if (_.isNull(valueCopy)) {
+    if (_.isNull(value)) {
         return remove(key);
     }
 
@@ -943,20 +944,20 @@ function set(key, value) {
         Logger.logAlert(`Onyx.set() called after Onyx.merge() for key: ${key}. It is recommended to use set() or merge() not both.`);
     }
 
-    valueCopy = cleanObject(valueCopy);
+    const valueWithNullRemoved = removeNullObjectValues(value);
 
-    const hasChanged = cache.hasValueChanged(key, valueCopy);
+    const hasChanged = cache.hasValueChanged(key, valueWithNullRemoved);
 
     // This approach prioritizes fast UI changes without waiting for data to be stored in device storage.
-    broadcastUpdate(key, valueCopy, hasChanged, 'set');
+    broadcastUpdate(key, valueWithNullRemoved, hasChanged, 'set');
 
     // If the value has not changed, calling Storage.setItem() would be redundant and a waste of performance, so return early instead.
     if (!hasChanged) {
         return Promise.resolve();
     }
 
-    return Storage.setItem(key, valueCopy)
-        .catch(error => evictStorageAndRetry(error, set, key, valueCopy));
+    return Storage.setItem(key, valueWithNullRemoved)
+        .catch(error => evictStorageAndRetry(error, set, key, valueWithNullRemoved));
 }
 
 /**
@@ -1060,14 +1061,14 @@ function merge(key, changes) {
                 delete mergeQueue[key];
 
                 // After that we merge the batched changes with the existing value
-                let modifiedData = applyMerge(existingValue, [batchedChanges]);
+                const modifiedData = removeNullObjectValues(applyMerge(existingValue, [batchedChanges]));
 
-                modifiedData = cleanObject(modifiedData);
-
-                // On the first write SQLite doesn't use JSON_PATCH, which means, nullish values won't be omitted.
-                // Therefore we remove null values from the `batchedChanges` which are sent to the native implementation, if no existing value is present.
+                // On native platforms we use SQLite which utilises JSON_PATCH to merge changes.
+                // JSON_PATCH generally removes top-level nullish values from the stored object.
+                // When there is no existing value though, SQLite will just insert the changes as a new value and thus the top-level nullish values won't be removed.
+                // Therefore we need to remove nullish values from the `batchedChanges` which are sent to the SQLite, if no existing value is present.
                 if (!existingValue) {
-                    batchedChanges = cleanObject(batchedChanges);
+                    batchedChanges = removeNullObjectValues(batchedChanges);
                 }
 
                 const hasChanged = cache.hasValueChanged(key, modifiedData);


### PR DESCRIPTION
@tgolen @marcaaron @hannojg 

In the native implementation with SQLite, the first call to `merge` on a key where no value is in storage will act like a regular `set` since the values are inserted into storage directly.

This is due to this SQLite operation in `SQLiteStorage.mergeItem`:

```sqlite
INSERT INTO keyvaluepairs (record_key, valueJSON)
VALUES (:key, JSON(:value))
ON CONFLICT DO UPDATE
SET valueJSON = JSON_PATCH(valueJSON, JSON(:value));
```

 In order for this to be consistent with how later `merge` with `JSON_PATCH` are working, we need to remove nullish values from the `batchedChanged` in the first merge operation.

Additionally, we'll want to remove nullish values on `set` as well, so that the values in cache and storage are always identical.

<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->
