### PR TITLE
Fix: NewDot console error when changing language

### DIFF
--- a/lib/withOnyx.js
+++ b/lib/withOnyx.js
@@ -213,7 +213,8 @@ export default function (mapOnyxToState) {
         withOnyx.propTypes = {
             forwardedRef: PropTypes.oneOfType([
                 PropTypes.func,
-                PropTypes.shape({current: PropTypes.instanceOf(React.Component)}),
+                // eslint-disable-next-line react/forbid-prop-types
+                PropTypes.shape({current: PropTypes.any}),
             ]),
         };
         withOnyx.defaultProps = {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

ND DEV: Console Error after changing language. This PR changes the proper prop type for `forwardedRef` in `withOnyx`.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

NA

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Login with any account
2. Open Settings >> Preferences >> Language
3. Change the language
4. Verify that no errors appear in the JS console

- [x] Verify that no errors appear in the JS console

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->
