### PR TITLE
Only use cache value when merge is not pending for key

### DIFF
--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -901,7 +901,6 @@ function broadcastUpdate(key, value, hasChanged, method) {
 }
 
 /**
- * @private
  * @param {String} key
  * @returns {Boolean}
  */
@@ -1409,6 +1408,7 @@ const Onyx = {
     METHOD,
     setMemoryOnlyKeys,
     tryGetCachedValue,
+    hasPendingMergeForKey,
 };
 
 /**

--- a/lib/withOnyx.js
+++ b/lib/withOnyx.js
@@ -41,7 +41,18 @@ export default function (mapOnyxToState) {
                     const key = Str.result(mapping.key, props);
                     const value = Onyx.tryGetCachedValue(key, mapping);
 
-                    if (value !== undefined) {
+                    /**
+                     * If we have a pending merge for a key it could mean that data is being set via Onyx.merge() and someone expects a component to have this data immediately.
+                     *
+                     * @example
+                     *
+                     * Onyx.merge('report_123', value);
+                     * Navigation.navigate(route); // Where "route" expects the "value" to be available immediately once rendered.
+                     *
+                     * In reality, Onyx.merge() will only update the subscriber after all merges have been batched and the previous value is retrieved via a get() (returns a promise).
+                     * So, we won't use the cache optimization here as it will lead us to arbitrarily defer various actions in the application code.
+                     */
+                    if (value !== undefined && !Onyx.hasPendingMergeForKey(key)) {
                         // eslint-disable-next-line no-param-reassign
                         resultObj[propertyName] = value;
                     }


### PR DESCRIPTION
### Details

See documentation in code comment for more info and [this Slack thread](https://expensify.slack.com/archives/C035J5C9FAP/p1692145133839509?thread_ts=1691655217.992579&cid=C035J5C9FAP).

### Related Issues

### Automated Tests

We should add these later...

### Linked PRs

https://github.com/Expensify/App/compare/marcaaron-reapply-onyx-upgrade-use-cache-with-fixes?expand=1