### PR TITLE
Fix idb keyval provider usage in electron environment

### DIFF
--- a/lib/storage/providers/IDBKeyVal.js
+++ b/lib/storage/providers/IDBKeyVal.js
@@ -13,7 +13,15 @@ import {
 import _ from 'underscore';
 import fastMerge from '../../fastMerge';
 
-const customStore = createStore('OnyxDB', 'keyvaluepairs');
+// We don't want to initialize the store while the JS bundle loads as idb-keyval will try to use global.indexedDB
+// which might not be available in certain environments that load the bundle (e.g. electron main process).
+let customStoreInstance;
+const getCustomStore = () => {
+    if (!customStoreInstance) {
+        customStoreInstance = createStore('OnyxDB', 'keyvaluepairs');
+    }
+    return customStoreInstance;
+};
 
 const provider = {
     /**
@@ -22,7 +30,7 @@ const provider = {
      * @param {*} value
      * @return {Promise<void>}
      */
-    setItem: (key, value) => set(key, value, customStore),
+    setItem: (key, value) => set(key, value, getCustomStore()),
 
     /**
      * Get multiple key-value pairs for the give array of keys in a batch.
@@ -30,7 +38,7 @@ const provider = {
      * @param {String[]} keysParam
      * @return {Promise<Array<[key, value]>>}
      */
-    multiGet: keysParam => getMany(keysParam, customStore)
+    multiGet: keysParam => getMany(keysParam, getCustomStore())
         .then(values => _.map(values, (value, index) => [keysParam[index], value])),
 
     /**
@@ -38,7 +46,7 @@ const provider = {
      * @param {Array<[key, value]>} pairs
      * @return {Promise<void>}
      */
-    multiMerge: pairs => customStore('readwrite', (store) => {
+    multiMerge: pairs => getCustomStore()('readwrite', (store) => {
         // Note: we are using the manual store transaction here, to fit the read and update
         // of the items in one transaction to achieve best performance.
 
@@ -70,33 +78,33 @@ const provider = {
      * @param {Array<[key, value]>} pairs
      * @return {Promise<void>}
      */
-    multiSet: pairs => setMany(pairs, customStore),
+    multiSet: pairs => setMany(pairs, getCustomStore()),
 
     /**
      * Clear everything from storage and also stops the SyncQueue from adding anything more to storage
      * @returns {Promise<void>}
      */
-    clear: () => clear(customStore),
+    clear: () => clear(getCustomStore()),
 
     /**
      * Returns all keys available in storage
      * @returns {Promise<String[]>}
      */
-    getAllKeys: () => keys(customStore),
+    getAllKeys: () => keys(getCustomStore()),
 
     /**
      * Get the value of a given key or return `null` if it's not available in storage
      * @param {String} key
      * @return {Promise<*>}
      */
-    getItem: key => get(key, customStore),
+    getItem: key => get(key, getCustomStore()),
 
     /**
      * Remove given key and it's value from storage
      * @param {String} key
      * @returns {Promise<void>}
      */
-    removeItem: key => del(key, customStore),
+    removeItem: key => del(key, getCustomStore()),
 
     /**
      * Remove given keys and their values from storage
@@ -104,7 +112,7 @@ const provider = {
      * @param {Array} keysParam
      * @returns {Promise}
      */
-    removeItems: keysParam => delMany(keysParam, customStore),
+    removeItems: keysParam => delMany(keysParam, getCustomStore()),
 };
 
 export default provider;


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

Follow up on as there is a crash in the expensify desktop app:

- #293 

Don't initialise the store at bundle load time, but at runtime. At load time in electron we are on the main thread, which doesn't has access to the browser environment.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
Related to https://github.com/Expensify/react-native-onyx/issues/281

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->
