### PR TITLE
[HOLD] Don't include null in collection callbacks

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,4 +15,13 @@ module.exports = {
         },
     },
     ignorePatterns: 'dist',
+    overrides: [
+        {
+            files: ['tests/**/*.{js,jsx,ts,tsx}'],
+            rules: {
+                '@lwc/lwc/no-async-await': 'off',
+                'no-await-in-loop': 'off',
+            },
+        },
+    ],
 };

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -1259,18 +1259,33 @@ function mergeCollection(collectionKey, collection) {
 
     return getAllKeys()
         .then((persistedKeys) => {
-            // Split to keys that exist in storage and keys that don't
-            const [existingKeys, newKeys] = _.chain(collection)
-                .keys()
-                .partition(key => persistedKeys.includes(key))
-                .value();
+            const existingKeysToKeep = [];
+            const keysToRemove = [];
+            const collectionWithoutKeysToRemove = collection;
+            const keyValuePairsForExistingCollection = [];
+            const keyValuePairsForNewCollection = [];
+            _.each(collection, (value, key) => {
+                if (value === null) {
+                    keysToRemove.push(key);
+                    delete collectionWithoutKeysToRemove[key];
+                    return;
+                }
 
-            const existingKeyCollection = _.pick(collection, existingKeys);
-            const newCollection = _.pick(collection, newKeys);
-            const keyValuePairsForExistingCollection = prepareKeyValuePairsForStorage(existingKeyCollection);
-            const keyValuePairsForNewCollection = prepareKeyValuePairsForStorage(newCollection);
+                if (persistedKeys.includes(key)) {
+                    existingKeysToKeep.push(key);
+                    keyValuePairsForExistingCollection.push([key, removeNullObjectValues(value)]);
+                    return;
+                }
+
+                keyValuePairsForNewCollection.push([key, removeNullObjectValues(value)]);
+            });
 
             const promises = [];
+
+            if (keysToRemove.length > 0) {
+                _.each(keysToRemove, (key) => cache.drop(key));
+                promises.push(Storage.removeItems(keysToRemove));
+            }
 
             // New keys will be added via multiSet while existing keys will be updated using multiMerge
             // This is because setting a key that doesn't exist yet with multiMerge will throw errors
@@ -1284,9 +1299,9 @@ function mergeCollection(collectionKey, collection) {
 
             // Prefill cache if necessary by calling get() on any existing keys and then merge original data to cache
             // and update all subscribers
-            Promise.all(_.map(existingKeys, get)).then(() => {
-                cache.merge(collection);
-                keysChanged(collectionKey, collection);
+            Promise.all(_.map(existingKeysToKeep, get)).then(() => {
+                cache.merge(collectionWithoutKeysToRemove);
+                keysChanged(collectionKey, collectionWithoutKeysToRemove);
             });
 
             return Promise.all(promises)

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -636,7 +636,7 @@ function sendDataToConnection(mapping, val, matchedKey) {
         return;
     }
 
-    if (_.isFunction(mapping.callback)) {
+    if (_.isFunction(mapping.callback) && (isCollectionKey(mapping.key) || matchedKey)) {
         mapping.callback(val, matchedKey);
     }
 }
@@ -1021,6 +1021,10 @@ function multiSet(data) {
  * @returns {*}
  */
 function applyMerge(existingValue, changes) {
+    if (_.some(changes, change => _.isNull(change))) {
+        return null;
+    }
+
     const lastChange = _.last(changes);
 
     if (_.isArray(existingValue) || _.isArray(lastChange)) {
@@ -1081,6 +1085,11 @@ function merge(key, changes) {
 
                 // After that we merge the batched changes with the existing value
                 const modifiedData = removeNullObjectValues(applyMerge(existingValue, [batchedChanges]));
+
+                // If the data is null, remove it from cache and store
+                if (_.isNull(modifiedData)) {
+                    return remove(key);
+                }
 
                 // On native platforms we use SQLite which utilises JSON_PATCH to merge changes.
                 // JSON_PATCH generally removes top-level nullish values from the stored object.

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -1021,21 +1021,21 @@ function multiSet(data) {
  * @returns {*}
  */
 function applyMerge(existingValue, changes) {
-    if (_.some(changes, change => _.isNull(change))) {
-        return null;
-    }
-
     const lastChange = _.last(changes);
+    if (_.isNull(lastChange)) {
+        return lastChange;
+    }
 
     if (_.isArray(existingValue) || _.isArray(lastChange)) {
         return lastChange;
     }
 
-    if (_.isObject(existingValue) || _.every(changes, _.isObject)) {
+    const changesToMake = _.filter(changes, change => Boolean(change));
+    if (_.isObject(existingValue) || _.every(changesToMake, _.isObject)) {
         // Object values are merged one after the other
         // lodash adds a small overhead so we don't use it here
         // eslint-disable-next-line prefer-object-spread, rulesdir/prefer-underscore-method
-        return _.reduce(changes, (modifiedData, change) => fastMerge(modifiedData, change),
+        return _.reduce(changesToMake, (modifiedData, change) => fastMerge(modifiedData, change),
             existingValue || {});
     }
 

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -488,7 +488,7 @@ function keysChanged(collectionKey, partialCollection) {
  * @param {*} data
  * @param {Function} [canUpdateSubscriber] only subscribers that pass this truth test will be updated
  */
-function keyChanged(key, data, canUpdateSubscriber) {
+function keyChanged(key, data, canUpdateSubscriber = () => true) {
     // Add or remove this key from the recentlyAccessedKeys lists
     if (!_.isNull(data)) {
         addLastAccessedKey(key);
@@ -502,7 +502,7 @@ function keyChanged(key, data, canUpdateSubscriber) {
     const stateMappingKeys = _.keys(callbackToStateMapping);
     for (let i = 0; i < stateMappingKeys.length; i++) {
         const subscriber = callbackToStateMapping[stateMappingKeys[i]];
-        if (!subscriber || !isKeyMatch(subscriber.key, key) || (_.isFunction(canUpdateSubscriber) && !canUpdateSubscriber(subscriber))) {
+        if (!subscriber || !isKeyMatch(subscriber.key, key) || !canUpdateSubscriber(subscriber)) {
             continue;
         }
 

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -1283,7 +1283,7 @@ function mergeCollection(collectionKey, collection) {
             const promises = [];
 
             if (keysToRemove.length > 0) {
-                _.each(keysToRemove, (key) => cache.drop(key));
+                _.each(keysToRemove, key => cache.drop(key));
                 promises.push(Storage.removeItems(keysToRemove));
             }
 

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -509,7 +509,9 @@ function keyChanged(key, data, canUpdateSubscriber) {
         if (_.isFunction(subscriber.callback)) {
             if (isCollectionKey(subscriber.key) && subscriber.waitForCollectionCallback) {
                 const cachedCollection = getCachedCollection(subscriber.key);
-                cachedCollection[key] = data;
+                if (data !== null) {
+                    cachedCollection[key] = data;
+                }
                 subscriber.callback(cachedCollection);
                 continue;
             }

--- a/tests/unit/onyxTest.js
+++ b/tests/unit/onyxTest.js
@@ -53,6 +53,22 @@ describe('Onyx', () => {
             expect(keys.includes(ONYX_KEYS.OTHER_TEST)).toBe(false);
         }));
 
+    it('should not provide null values to subscriber callback when set is called with null value', () => {
+        const subscriberCallback = jest.fn();
+        Onyx.connect({
+            key: ONYX_KEYS.COLLECTION.TEST_CONNECT_COLLECTION,
+            waitForCollectionCallback: true,
+            callback: subscriberCallback,
+        });
+        const itemID = 'abcd';
+        const testKey = `${ONYX_KEYS.COLLECTION.TEST_CONNECT_COLLECTION}${itemID}`;
+        return Onyx.set(testKey, 42)
+            .then(() => expect(subscriberCallback).toHaveBeenCalledWith({[testKey]: 42}))
+            .then(() => Onyx.set(testKey, null))
+            .then(() => expect(subscriberCallback).toHaveBeenCalledWith({}))
+            .then(() => expect(subscriberCallback).toHaveBeenCalledTimes(2));
+    });
+
     it('should set a simple key', () => {
         let testKeyValue;
 

--- a/tests/unit/onyxTest.js
+++ b/tests/unit/onyxTest.js
@@ -746,14 +746,11 @@ describe('Onyx', () => {
                 return waitForPromisesToResolve();
             })
             .then(() => {
-                // Then we expect the callback to have called twice, once for the initial connect call + once for the collection update
-                expect(mockCallback).toHaveBeenCalledTimes(2);
+                // Then we expect the callback to have been called once for the collection update
+                expect(mockCallback).toHaveBeenCalledTimes(1);
 
-                // AND the value for the first call should be null since the collection was not initialized at that point
-                expect(mockCallback).toHaveBeenNthCalledWith(1, null, undefined);
-
-                // AND the value for the second call should be collectionUpdate since the collection was updated
-                expect(mockCallback).toHaveBeenNthCalledWith(2, collectionUpdate.testPolicy_1, 'testPolicy_1');
+                // The value for the call should be collectionUpdate since the collection was updated
+                expect(mockCallback).toHaveBeenCalledWith(collectionUpdate.testPolicy_1, 'testPolicy_1');
             });
     });
 


### PR DESCRIPTION
### Details
Coming from https://github.com/Expensify/App/issues/25481#issuecomment-1687321203, we are including null in `Onyx.connect` subscriber callbacks if it's a collection key w/ `waitForCollectionCallback: true` 🐛 

This PR adds a test to cover this edge case and then prevents it such that the full collection w/o null is given to the subscriber.

### Related Issues
Fixes https://github.com/Expensify/react-native-onyx/issues/310

### Automated Tests
Added automated test to cover this.

### Linked PRs
Not created yet
