### PR TITLE
fix callback key param when not waiting for collection callback

### DIFF
--- a/lib/Onyx.d.ts
+++ b/lib/Onyx.d.ts
@@ -50,7 +50,7 @@ type ConnectOptions<TKey extends OnyxKey> = BaseConnectOptions &
           }
         | {
               key: TKey;
-              callback?: (value: OnyxEntry<KeyValueMapping[TKey]>, key?: TKey) => void;
+              callback?: (value: OnyxEntry<KeyValueMapping[TKey]>, key: TKey) => void;
               waitForCollectionCallback?: false;
           }
     );

--- a/lib/Onyx.d.ts
+++ b/lib/Onyx.d.ts
@@ -45,7 +45,7 @@ type ConnectOptions<TKey extends OnyxKey> = BaseConnectOptions &
     (
         | {
               key: TKey extends CollectionKey ? TKey : never;
-              callback?: (value: OnyxCollection<KeyValueMapping[TKey]>, key?: TKey) => void;
+              callback?: (value: OnyxCollection<KeyValueMapping[TKey]>) => void;
               waitForCollectionCallback: true;
           }
         | {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

When `waitForCollectionCallback` is undefined or false, the callback will always be called with a key.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK: /

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->
