### PR TITLE
Batch updates second try

### DIFF
--- a/jestSetup.js
+++ b/jestSetup.js
@@ -9,3 +9,7 @@ jest.mock('react-native-quick-sqlite', () => ({
 }));
 
 jest.useRealTimers();
+
+const unstable_batchedUpdates_jest = require('react-test-renderer').unstable_batchedUpdates;
+require('./lib/batch.native').default = unstable_batchedUpdates_jest;
+

--- a/jestSetup.js
+++ b/jestSetup.js
@@ -2,3 +2,5 @@ jest.mock('./lib/storage');
 jest.mock('./lib/storage/NativeStorage', () => require('./lib/storage/__mocks__'));
 jest.mock('./lib/storage/WebStorage', () => require('./lib/storage/__mocks__'));
 jest.mock('./lib/storage/providers/IDBKeyVal', () => require('./lib/storage/__mocks__'));
+
+jest.useRealTimers();

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -803,10 +803,11 @@ function disconnect(connectionID, keyToRemoveFromEvictionBlocklist) {
     delete callbackToStateMapping[connectionID];
 }
 
-// [key, value, canUpdateSubscriber]
-let pendingUpdates = [];
 let scheduledPromise;
-let pendingCollectionUpdates = [];
+
+// [key, value, canUpdateSubscriber]
+let pendingSubscriberUpdates = [];
+let pendingCollectionSubscriberUpdates = [];
 
 /**
  * We are batching together onyx updates. This helps with use cases where we schedule onyx updates after each other.
@@ -815,7 +816,7 @@ let pendingCollectionUpdates = [];
  * cause react to schedule the updates at once instead of after each other. This is mainly a performance optimization.
  * @returns {Promise}
  */
-function scheduleOnyxFlushIfNeeded() {
+function scheduleSubscriberUpdatesFlushIfNeeded() {
     if (scheduledPromise) {
         return scheduledPromise;
     }
@@ -823,10 +824,10 @@ function scheduleOnyxFlushIfNeeded() {
     scheduledPromise = new Promise((resolve) => {
         setTimeout(() => {
             scheduledPromise = null;
-            const updatesCopy = pendingUpdates;
-            pendingUpdates = [];
-            const updatesCollectionCopy = pendingCollectionUpdates;
-            pendingCollectionUpdates = [];
+            const updatesCopy = pendingSubscriberUpdates;
+            pendingSubscriberUpdates = [];
+            const updatesCollectionCopy = pendingCollectionSubscriberUpdates;
+            pendingCollectionSubscriberUpdates = [];
             unstable_batchedUpdates(() => {
                 for (let i = 0; i < updatesCopy.length; ++i) {
                     keyChanged(updatesCopy[i][0], updatesCopy[i][1], updatesCopy[i][2]);
@@ -845,16 +846,16 @@ function scheduleOnyxFlushIfNeeded() {
  * Schedules an update that will be appended to the macro task queue (so it doesn't update the subscribers immediately).
  *
  * @example
- * scheduleNotifySubscribers(key, value, subscriber => subscriber.initWithStoredValues === false)
+ * scheduleSubscriberUpdate(key, value, subscriber => subscriber.initWithStoredValues === false)
  *
  * @param {String} key
  * @param {*} value
  * @param {Function} [canUpdateSubscriber] only subscribers that pass this truth test will be updated
  * @returns {Promise}
  */
-function scheduleNotifySubscribers(key, value, canUpdateSubscriber) {
-    pendingUpdates.push([key, value, canUpdateSubscriber]);
-    return scheduleOnyxFlushIfNeeded();
+function scheduleSubscriberUpdate(key, value, canUpdateSubscriber) {
+    pendingSubscriberUpdates.push([key, value, canUpdateSubscriber]);
+    return scheduleSubscriberUpdatesFlushIfNeeded();
 }
 
 /**
@@ -867,8 +868,8 @@ function scheduleNotifySubscribers(key, value, canUpdateSubscriber) {
  * @returns {Promise}
  */
 function scheduleNotifyCollectionSubscribers(key, value) {
-    pendingCollectionUpdates.push([key, value]);
-    return scheduleOnyxFlushIfNeeded();
+    pendingCollectionSubscriberUpdates.push([key, value]);
+    return scheduleSubscriberUpdatesFlushIfNeeded();
 }
 
 /**
@@ -880,7 +881,7 @@ function scheduleNotifyCollectionSubscribers(key, value) {
  */
 function remove(key) {
     cache.drop(key);
-    scheduleNotifySubscribers(key, null);
+    scheduleSubscriberUpdate(key, null);
     return Storage.removeItem(key);
 }
 
@@ -955,7 +956,7 @@ function broadcastUpdate(key, value, hasChanged, method) {
         cache.addToAccessedKeys(key);
     }
 
-    return scheduleNotifySubscribers(key, value, subscriber => hasChanged || subscriber.initWithStoredValues === false);
+    return scheduleSubscriberUpdate(key, value, subscriber => hasChanged || subscriber.initWithStoredValues === false);
 }
 
 /**
@@ -1044,7 +1045,7 @@ function multiSet(data) {
     const updatePromises = _.map(data, (val, key) => {
         // Update cache and optimistically inform subscribers on the next tick
         cache.set(key, val);
-        return scheduleNotifySubscribers(key, val);
+        return scheduleSubscriberUpdate(key, val);
     });
 
     return Storage.multiSet(keyValuePairs)
@@ -1238,7 +1239,7 @@ function clear(keysToPreserve = []) {
 
             // Notify the subscribers for each key/value group so they can receive the new values
             _.each(keyValuesToResetIndividually, (value, key) => {
-                updatePromises.push(scheduleNotifySubscribers(key, value));
+                updatePromises.push(scheduleSubscriberUpdate(key, value));
             });
             _.each(keyValuesToResetAsCollection, (value, key) => {
                 updatePromises.push(scheduleNotifyCollectionSubscribers(key, value));

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -21,6 +21,7 @@ const METHOD = {
 
 // Key/value store of Onyx key and arrays of values to merge
 const mergeQueue = {};
+const mergeQueuePromise = {};
 
 // Keeps track of the last connectionID that was used so we can keep incrementing it
 let lastConnectionID = 0;
@@ -804,7 +805,7 @@ function disconnect(connectionID, keyToRemoveFromEvictionBlocklist) {
 
 // [key, value, canUpdateSubscriber]
 let pendingUpdates = [];
-let scheduled = false;
+let scheduledPromise;
 let pendingCollectionUpdates = [];
 
 /**
@@ -812,29 +813,32 @@ let pendingCollectionUpdates = [];
  * This happens for example in the Onyx.update function, where we process API responses that might contain a lot of
  * update operations. Instead of calling the subscribers for each update operation, we batch them together which will
  * cause react to schedule the updates at once instead of after each other. This is mainly a performance optimization.
- * @returns {void}
+ * @returns {Promise}
  */
 function scheduleOnyxFlushIfNeeded() {
-    if (scheduled) {
-        return;
+    if (scheduledPromise) {
+        return scheduledPromise;
     }
 
-    scheduled = true;
-    setTimeout(() => {
-        scheduled = false;
-        const updatesCopy = pendingUpdates;
-        pendingUpdates = [];
-        const updatesCollectionCopy = pendingCollectionUpdates;
-        pendingCollectionUpdates = [];
-        unstable_batchedUpdates(() => {
-            for (let i = 0; i < updatesCopy.length; ++i) {
-                keyChanged(updatesCopy[i][0], updatesCopy[i][1], updatesCopy[i][2]);
-            }
-            for (let i = 0; i < updatesCollectionCopy.length; ++i) {
-                keysChanged(updatesCollectionCopy[i][0], updatesCollectionCopy[i][1]);
-            }
-        });
-    }, 0);
+    scheduledPromise = new Promise((resolve) => {
+        setTimeout(() => {
+            scheduledPromise = null;
+            const updatesCopy = pendingUpdates;
+            pendingUpdates = [];
+            const updatesCollectionCopy = pendingCollectionUpdates;
+            pendingCollectionUpdates = [];
+            unstable_batchedUpdates(() => {
+                for (let i = 0; i < updatesCopy.length; ++i) {
+                    keyChanged(updatesCopy[i][0], updatesCopy[i][1], updatesCopy[i][2]);
+                }
+                for (let i = 0; i < updatesCollectionCopy.length; ++i) {
+                    keysChanged(updatesCollectionCopy[i][0], updatesCollectionCopy[i][1]);
+                }
+            });
+            resolve();
+        }, 0);
+    });
+    return scheduledPromise;
 }
 
 /**
@@ -846,10 +850,11 @@ function scheduleOnyxFlushIfNeeded() {
  * @param {String} key
  * @param {*} value
  * @param {Function} [canUpdateSubscriber] only subscribers that pass this truth test will be updated
+ * @returns {Promise}
  */
 function scheduleNotifySubscribers(key, value, canUpdateSubscriber) {
     pendingUpdates.push([key, value, canUpdateSubscriber]);
-    scheduleOnyxFlushIfNeeded();
+    return scheduleOnyxFlushIfNeeded();
 }
 
 /**
@@ -859,10 +864,11 @@ function scheduleNotifySubscribers(key, value, canUpdateSubscriber) {
  *
  * @param {String} key
  * @param {*} value
+ * @returns {Promise}
  */
 function scheduleNotifyCollectionSubscribers(key, value) {
     pendingCollectionUpdates.push([key, value]);
-    scheduleOnyxFlushIfNeeded();
+    return scheduleOnyxFlushIfNeeded();
 }
 
 /**
@@ -935,6 +941,7 @@ function evictStorageAndRetry(error, onyxMethod, ...args) {
  * @param {*} value
  * @param {Boolean} hasChanged
  * @param {String} method
+ * @returns {Promise}
  */
 function broadcastUpdate(key, value, hasChanged, method) {
     // Logging properties only since values could be sensitive things we don't want to log
@@ -948,7 +955,7 @@ function broadcastUpdate(key, value, hasChanged, method) {
         cache.addToAccessedKeys(key);
     }
 
-    scheduleNotifySubscribers(key, value, subscriber => hasChanged || subscriber.initWithStoredValues === false);
+    return scheduleNotifySubscribers(key, value, subscriber => hasChanged || subscriber.initWithStoredValues === false);
 }
 
 /**
@@ -999,15 +1006,16 @@ function set(key, value) {
     const hasChanged = cache.hasValueChanged(key, valueWithNullRemoved);
 
     // This approach prioritizes fast UI changes without waiting for data to be stored in device storage.
-    broadcastUpdate(key, valueWithNullRemoved, hasChanged, 'set');
+    const updatePromise = broadcastUpdate(key, valueWithNullRemoved, hasChanged, 'set');
 
     // If the value has not changed, calling Storage.setItem() would be redundant and a waste of performance, so return early instead.
     if (!hasChanged) {
-        return Promise.resolve();
+        return updatePromise;
     }
 
     return Storage.setItem(key, valueWithNullRemoved)
-        .catch(error => evictStorageAndRetry(error, set, key, valueWithNullRemoved));
+        .catch(error => evictStorageAndRetry(error, set, key, valueWithNullRemoved))
+        .then(() => updatePromise);
 }
 
 /**
@@ -1033,14 +1041,15 @@ function prepareKeyValuePairsForStorage(data) {
 function multiSet(data) {
     const keyValuePairs = prepareKeyValuePairsForStorage(data);
 
-    _.each(data, (val, key) => {
+    const updatePromises = _.map(data, (val, key) => {
         // Update cache and optimistically inform subscribers on the next tick
         cache.set(key, val);
-        scheduleNotifySubscribers(key, val);
+        return scheduleNotifySubscribers(key, val);
     });
 
     return Storage.multiSet(keyValuePairs)
-        .catch(error => evictStorageAndRetry(error, multiSet, data));
+        .catch(error => evictStorageAndRetry(error, multiSet, data))
+        .then(() => Promise.all(updatePromises));
 }
 
 /**
@@ -1096,19 +1105,19 @@ function merge(key, changes) {
     // Using the initial value from storage in subsequent merge attempts will lead to an incorrect final merged value.
     if (mergeQueue[key]) {
         mergeQueue[key].push(changes);
-        return Promise.resolve();
+        return mergeQueuePromise[key];
     }
     mergeQueue[key] = [changes];
 
-    return get(key)
+    mergeQueuePromise[key] = get(key)
         .then((existingValue) => {
             try {
                 // We first only merge the changes, so we can provide these to the native implementation (SQLite uses only delta changes in "JSON_PATCH" to merge)
                 let batchedChanges = applyMerge(undefined, mergeQueue[key]);
 
-                // Clean up the write queue so we
-                // don't apply these changes again
+                // Clean up the write queue, so we don't apply these changes again
                 delete mergeQueue[key];
+                delete mergeQueuePromise[key];
 
                 // After that we merge the batched changes with the existing value
                 const modifiedData = removeNullObjectValues(applyMerge(existingValue, [batchedChanges]));
@@ -1124,20 +1133,22 @@ function merge(key, changes) {
                 const hasChanged = cache.hasValueChanged(key, modifiedData);
 
                 // This approach prioritizes fast UI changes without waiting for data to be stored in device storage.
-                broadcastUpdate(key, modifiedData, hasChanged, 'merge');
+                const updatePromise = broadcastUpdate(key, modifiedData, hasChanged, 'merge');
 
                 // If the value has not changed, calling Storage.setItem() would be redundant and a waste of performance, so return early instead.
                 if (!hasChanged) {
-                    return Promise.resolve();
+                    return updatePromise;
                 }
 
-                return Storage.mergeItem(key, batchedChanges, modifiedData);
+                return Storage.mergeItem(key, batchedChanges, modifiedData)
+                    .then(() => updatePromise);
             } catch (error) {
                 Logger.logAlert(`An error occurred while applying merge for key: ${key}, Error: ${error}`);
+                return Promise.resolve();
             }
-
-            return Promise.resolve();
         });
+
+    return mergeQueuePromise[key];
 }
 
 /**
@@ -1223,19 +1234,21 @@ function clear(keysToPreserve = []) {
                 keysToBeClearedFromStorage.push(key);
             });
 
+            const updatePromises = [];
+
             // Notify the subscribers for each key/value group so they can receive the new values
             _.each(keyValuesToResetIndividually, (value, key) => {
-                scheduleNotifySubscribers(key, value);
+                updatePromises.push(scheduleNotifySubscribers(key, value));
             });
             _.each(keyValuesToResetAsCollection, (value, key) => {
-                scheduleNotifyCollectionSubscribers(key, value);
+                updatePromises.push(scheduleNotifyCollectionSubscribers(key, value));
             });
 
             const defaultKeyValuePairs = _.pairs(_.omit(defaultKeyStates, keysToPreserve));
 
             // Remove only the items that we want cleared from storage, and reset others to default
             _.each(keysToBeClearedFromStorage, key => cache.drop(key));
-            return Storage.removeItems(keysToBeClearedFromStorage).then(() => Storage.multiSet(defaultKeyValuePairs));
+            return Storage.removeItems(keysToBeClearedFromStorage).then(() => Storage.multiSet(defaultKeyValuePairs)).then(() => Promise.all(updatePromises));
         });
 }
 
@@ -1306,13 +1319,14 @@ function mergeCollection(collectionKey, collection) {
 
             // Prefill cache if necessary by calling get() on any existing keys and then merge original data to cache
             // and update all subscribers
-            Promise.all(_.map(existingKeys, get)).then(() => {
+            const promiseUpdate = Promise.all(_.map(existingKeys, get)).then(() => {
                 cache.merge(collection);
-                scheduleNotifyCollectionSubscribers(collectionKey, collection);
+                return scheduleNotifyCollectionSubscribers(collectionKey, collection);
             });
 
             return Promise.all(promises)
-                .catch(error => evictStorageAndRetry(error, mergeCollection, collection));
+                .catch(error => evictStorageAndRetry(error, mergeCollection, collection))
+                .then(() => promiseUpdate);
         });
 }
 

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -8,6 +8,7 @@ import createDeferredTask from './createDeferredTask';
 import fastMerge from './fastMerge';
 import * as PerformanceUtils from './metrics/PerformanceUtils';
 import Storage from './storage';
+import unstable_batchedUpdates from './batch';
 
 // Method constants
 const METHOD = {
@@ -801,6 +802,31 @@ function disconnect(connectionID, keyToRemoveFromEvictionBlocklist) {
     delete callbackToStateMapping[connectionID];
 }
 
+var pendingCollectionUpdates = [];
+var pendingUpdates = [];
+var scheduled = false;
+
+function scheduleOnyxFlushIfNeeded() {
+  if (!scheduled) {
+    scheduled = true;
+    setTimeout(function () {
+      scheduled = false;
+      var updatesCopy = pendingUpdates;
+      pendingUpdates = [];
+      var updatesCollectionCopy = pendingCollectionUpdates;
+      pendingCollectionUpdates = [];
+      (0, _batch.default)(function flushUpdatesOnyx() {
+        for (var i = 0; i < updatesCopy.length; ++i) {
+          keyChanged(updatesCopy[i][0], updatesCopy[i][1]);
+        }
+        for (var i = 0; i < updatesCollectionCopy.length; ++i) {
+          keysChanged(updatesCollectionCopy[i][0], updatesCollectionCopy[i][1]);
+        }
+      });
+    }, 0);
+  }
+}
+
 /**
  * This method mostly exists for historical reasons as this library was initially designed without a memory cache and one was added later.
  * For this reason, Onyx works more similar to what you might expect from a native AsyncStorage with reads, writes, etc all becoming
@@ -816,7 +842,8 @@ function disconnect(connectionID, keyToRemoveFromEvictionBlocklist) {
  */
 // eslint-disable-next-line rulesdir/no-negated-variables
 function notifySubscribersOnNextTick(key, value, canUpdateSubscriber) {
-    Promise.resolve().then(() => keyChanged(key, value, canUpdateSubscriber));
+    pendingUpdates.push([key, value]);
+    scheduleOnyxFlushIfNeeded();
 }
 
 /**
@@ -829,7 +856,8 @@ function notifySubscribersOnNextTick(key, value, canUpdateSubscriber) {
  */
 // eslint-disable-next-line rulesdir/no-negated-variables
 function notifyCollectionSubscribersOnNextTick(key, value) {
-    Promise.resolve().then(() => keysChanged(key, value));
+    pendingCollectionUpdates.push([key, value]);
+    scheduleOnyxFlushIfNeeded();
 }
 
 /**
@@ -1275,7 +1303,7 @@ function mergeCollection(collectionKey, collection) {
             // and update all subscribers
             Promise.all(_.map(existingKeys, get)).then(() => {
                 cache.merge(collection);
-                keysChanged(collectionKey, collection);
+                notifyCollectionSubscribersOnNextTick(collectionKey, collection)
             });
 
             return Promise.all(promises)

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -824,7 +824,7 @@ function scheduleSubscriberUpdatesFlushIfNeeded() {
     }
 
     scheduledPromise = new Promise((resolve) => {
-        /* We use (setTimout, 0) here which should be called once native module calles are flushed (usually at the end of the frame)
+        /* We use (setTimeout, 0) here which should be called once native module calls are flushed (usually at the end of the frame)
          * We may investigate if (setTimout, 1) (which in React Native is equal to requestAnimationFrame) works even better
          * then the batch will be flushed on next frame.
          */

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -825,7 +825,7 @@ function scheduleSubscriberUpdatesFlushIfNeeded() {
 
     scheduledPromise = new Promise((resolve) => {
         /* We use (setTimeout, 0) here which should be called once native module calls are flushed (usually at the end of the frame)
-         * We may investigate if (setTimout, 1) (which in React Native is equal to requestAnimationFrame) works even better
+         * We may investigate if (setTimeout, 1) (which in React Native is equal to requestAnimationFrame) works even better
          * then the batch will be flushed on next frame.
          */
         setTimeout(() => {

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -802,9 +802,10 @@ function disconnect(connectionID, keyToRemoveFromEvictionBlocklist) {
     delete callbackToStateMapping[connectionID];
 }
 
-let pendingCollectionUpdates = [];
+// [key, value, canUpdateSubscriber]
 let pendingUpdates = [];
 let scheduled = false;
+let pendingCollectionUpdates = [];
 
 function scheduleOnyxFlushIfNeeded() {
     if (scheduled) {
@@ -820,7 +821,7 @@ function scheduleOnyxFlushIfNeeded() {
         pendingCollectionUpdates = [];
         unstable_batchedUpdates(() => {
             for (let i = 0; i < updatesCopy.length; ++i) {
-                keyChanged(updatesCopy[i][0], updatesCopy[i][1]);
+                keyChanged(updatesCopy[i][0], updatesCopy[i][1], updatesCopy[i][2]);
             }
             for (let i = 0; i < updatesCollectionCopy.length; ++i) {
                 keysChanged(updatesCollectionCopy[i][0], updatesCollectionCopy[i][1]);
@@ -844,7 +845,7 @@ function scheduleOnyxFlushIfNeeded() {
  */
 // eslint-disable-next-line rulesdir/no-negated-variables
 function notifySubscribersOnNextTick(key, value, canUpdateSubscriber) {
-    pendingUpdates.push([key, value]);
+    pendingUpdates.push([key, value, canUpdateSubscriber]);
     scheduleOnyxFlushIfNeeded();
 }
 

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -807,6 +807,8 @@ let scheduledPromise;
 
 // [key, value, canUpdateSubscriber]
 let pendingSubscriberUpdates = [];
+
+// [key, value]
 let pendingCollectionSubscriberUpdates = [];
 
 /**

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -807,6 +807,13 @@ let pendingUpdates = [];
 let scheduled = false;
 let pendingCollectionUpdates = [];
 
+/**
+ * We are batching together onyx updates. This helps with use cases where we schedule onyx updates after each other.
+ * This happens for example in the Onyx.update function, where we process API responses that might contain a lot of
+ * update operations. Instead of calling the subscribers for each update operation, we batch them together which will
+ * cause react to schedule the updates at once instead of after each other. This is mainly a performance optimization.
+ * @returns {void}
+ */
 function scheduleOnyxFlushIfNeeded() {
     if (scheduled) {
         return;
@@ -831,20 +838,16 @@ function scheduleOnyxFlushIfNeeded() {
 }
 
 /**
- * This method mostly exists for historical reasons as this library was initially designed without a memory cache and one was added later.
- * For this reason, Onyx works more similar to what you might expect from a native AsyncStorage with reads, writes, etc all becoming
- * available async. Since we have code in our main applications that might expect things to work this way it's not safe to change this
- * behavior just yet.
+ * Schedules an update that will be appended to the macro task queue (so it doesn't update the subscribers immediately).
  *
  * @example
- * notifySubscribersOnNextTick(key, value, subscriber => subscriber.initWithStoredValues === false)
+ * scheduleNotifySubscribers(key, value, subscriber => subscriber.initWithStoredValues === false)
  *
  * @param {String} key
  * @param {*} value
  * @param {Function} [canUpdateSubscriber] only subscribers that pass this truth test will be updated
  */
-// eslint-disable-next-line rulesdir/no-negated-variables
-function notifySubscribersOnNextTick(key, value, canUpdateSubscriber) {
+function scheduleNotifySubscribers(key, value, canUpdateSubscriber) {
     pendingUpdates.push([key, value, canUpdateSubscriber]);
     scheduleOnyxFlushIfNeeded();
 }
@@ -857,8 +860,7 @@ function notifySubscribersOnNextTick(key, value, canUpdateSubscriber) {
  * @param {String} key
  * @param {*} value
  */
-// eslint-disable-next-line rulesdir/no-negated-variables
-function notifyCollectionSubscribersOnNextTick(key, value) {
+function scheduleNotifyCollectionSubscribers(key, value) {
     pendingCollectionUpdates.push([key, value]);
     scheduleOnyxFlushIfNeeded();
 }
@@ -872,7 +874,7 @@ function notifyCollectionSubscribersOnNextTick(key, value) {
  */
 function remove(key) {
     cache.drop(key);
-    notifySubscribersOnNextTick(key, null);
+    scheduleNotifySubscribers(key, null);
     return Storage.removeItem(key);
 }
 
@@ -946,7 +948,7 @@ function broadcastUpdate(key, value, hasChanged, method) {
         cache.addToAccessedKeys(key);
     }
 
-    notifySubscribersOnNextTick(key, value, subscriber => hasChanged || subscriber.initWithStoredValues === false);
+    scheduleNotifySubscribers(key, value, subscriber => hasChanged || subscriber.initWithStoredValues === false);
 }
 
 /**
@@ -1034,7 +1036,7 @@ function multiSet(data) {
     _.each(data, (val, key) => {
         // Update cache and optimistically inform subscribers on the next tick
         cache.set(key, val);
-        notifySubscribersOnNextTick(key, val);
+        scheduleNotifySubscribers(key, val);
     });
 
     return Storage.multiSet(keyValuePairs)
@@ -1223,10 +1225,10 @@ function clear(keysToPreserve = []) {
 
             // Notify the subscribers for each key/value group so they can receive the new values
             _.each(keyValuesToResetIndividually, (value, key) => {
-                notifySubscribersOnNextTick(key, value);
+                scheduleNotifySubscribers(key, value);
             });
             _.each(keyValuesToResetAsCollection, (value, key) => {
-                notifyCollectionSubscribersOnNextTick(key, value);
+                scheduleNotifyCollectionSubscribers(key, value);
             });
 
             const defaultKeyValuePairs = _.pairs(_.omit(defaultKeyStates, keysToPreserve));
@@ -1306,7 +1308,7 @@ function mergeCollection(collectionKey, collection) {
             // and update all subscribers
             Promise.all(_.map(existingKeys, get)).then(() => {
                 cache.merge(collection);
-                notifyCollectionSubscribersOnNextTick(collectionKey, collection);
+                scheduleNotifyCollectionSubscribers(collectionKey, collection);
             });
 
             return Promise.all(promises)

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -822,6 +822,10 @@ function scheduleSubscriberUpdatesFlushIfNeeded() {
     }
 
     scheduledPromise = new Promise((resolve) => {
+        /* We use (setTimout, 0) here which should be called once native module calles are flushed (usually at the end of the frame)
+         * We may investigate if (setTimout, 1) (which in React Native is equal to requestAnimationFrame) works even better
+         * then the batch will be flushed on next frame.
+         */
         setTimeout(() => {
             scheduledPromise = null;
             const updatesCopy = pendingSubscriberUpdates;

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -822,13 +822,8 @@ function disconnect(connectionID, keyToRemoveFromEvictionBlocklist) {
     delete callbackToStateMapping[connectionID];
 }
 
-let scheduledPromise;
-
-// [key, value, canUpdateSubscriber, notifyRegularSubscribers, notifyWithOnyxSubscribers]
-let pendingSubscriberUpdates = [];
-
-// [key, value, notifyRegularSubscribers, notifyWithOnyxSubscribers]
-let pendingCollectionSubscriberUpdates = [];
+let batchUpdatesPromise = null;
+let batchUpdatesQueue = [];
 
 /**
  * We are batching together onyx updates. This helps with use cases where we schedule onyx updates after each other.
@@ -837,34 +832,35 @@ let pendingCollectionSubscriberUpdates = [];
  * cause react to schedule the updates at once instead of after each other. This is mainly a performance optimization.
  * @returns {Promise}
  */
-function scheduleSubscriberUpdatesFlushIfNeeded() {
-    if (scheduledPromise) {
-        return scheduledPromise;
+function maybeFlushBatchUpdates() {
+    if (batchUpdatesPromise) {
+        return batchUpdatesPromise;
     }
 
-    scheduledPromise = new Promise((resolve) => {
+    batchUpdatesPromise = new Promise((resolve) => {
         /* We use (setTimeout, 0) here which should be called once native module calls are flushed (usually at the end of the frame)
          * We may investigate if (setTimeout, 1) (which in React Native is equal to requestAnimationFrame) works even better
          * then the batch will be flushed on next frame.
          */
         setTimeout(() => {
-            scheduledPromise = null;
-            const updatesCopy = pendingSubscriberUpdates;
-            pendingSubscriberUpdates = [];
-            const updatesCollectionCopy = pendingCollectionSubscriberUpdates;
-            pendingCollectionSubscriberUpdates = [];
+            const updatesCopy = batchUpdatesQueue;
+            batchUpdatesQueue = [];
+            batchUpdatesPromise = null;
             unstable_batchedUpdates(() => {
-                for (let i = 0; i < updatesCopy.length; ++i) {
-                    keyChanged(updatesCopy[i][0], updatesCopy[i][1], updatesCopy[i][2], updatesCopy[i][3], updatesCopy[i][4]);
-                }
-                for (let i = 0; i < updatesCollectionCopy.length; ++i) {
-                    keysChanged(updatesCollectionCopy[i][0], updatesCollectionCopy[i][1], updatesCollectionCopy[i][2], updatesCollectionCopy[i][3]);
-                }
+                updatesCopy.forEach((applyUpdates) => {
+                    applyUpdates();
+                });
             });
+
             resolve();
         }, 0);
     });
-    return scheduledPromise;
+    return batchUpdatesPromise;
+}
+
+function batchUpdates(updates) {
+    batchUpdatesQueue.push(updates);
+    return maybeFlushBatchUpdates();
 }
 
 /**
@@ -880,8 +876,8 @@ function scheduleSubscriberUpdatesFlushIfNeeded() {
  */
 function scheduleSubscriberUpdate(key, value, canUpdateSubscriber) {
     const promise = Promise.resolve().then(() => keyChanged(key, value, canUpdateSubscriber, true, false));
-    pendingSubscriberUpdates.push([key, value, canUpdateSubscriber, false, true]);
-    return Promise.all([scheduleSubscriberUpdatesFlushIfNeeded(), promise]);
+    batchUpdates(() => keyChanged(key, value, canUpdateSubscriber, false, true));
+    return Promise.all([maybeFlushBatchUpdates(), promise]);
 }
 
 /**
@@ -895,8 +891,8 @@ function scheduleSubscriberUpdate(key, value, canUpdateSubscriber) {
  */
 function scheduleNotifyCollectionSubscribers(key, value) {
     const promise = Promise.resolve().then(() => keysChanged(key, value, true, false));
-    pendingCollectionSubscriberUpdates.push([key, value, false, true]);
-    return Promise.all([scheduleSubscriberUpdatesFlushIfNeeded(), promise]);
+    batchUpdates(() => keysChanged(key, value, false, true));
+    return Promise.all([maybeFlushBatchUpdates(), promise]);
 }
 
 /**

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -802,29 +802,31 @@ function disconnect(connectionID, keyToRemoveFromEvictionBlocklist) {
     delete callbackToStateMapping[connectionID];
 }
 
-var pendingCollectionUpdates = [];
-var pendingUpdates = [];
-var scheduled = false;
+let pendingCollectionUpdates = [];
+let pendingUpdates = [];
+let scheduled = false;
 
 function scheduleOnyxFlushIfNeeded() {
-  if (!scheduled) {
+    if (scheduled) {
+        return;
+    }
+
     scheduled = true;
-    setTimeout(function () {
-      scheduled = false;
-      var updatesCopy = pendingUpdates;
-      pendingUpdates = [];
-      var updatesCollectionCopy = pendingCollectionUpdates;
-      pendingCollectionUpdates = [];
-      (0, _batch.default)(function flushUpdatesOnyx() {
-        for (var i = 0; i < updatesCopy.length; ++i) {
-          keyChanged(updatesCopy[i][0], updatesCopy[i][1]);
-        }
-        for (var i = 0; i < updatesCollectionCopy.length; ++i) {
-          keysChanged(updatesCollectionCopy[i][0], updatesCollectionCopy[i][1]);
-        }
-      });
+    setTimeout(() => {
+        scheduled = false;
+        const updatesCopy = pendingUpdates;
+        pendingUpdates = [];
+        const updatesCollectionCopy = pendingCollectionUpdates;
+        pendingCollectionUpdates = [];
+        unstable_batchedUpdates(() => {
+            for (let i = 0; i < updatesCopy.length; ++i) {
+                keyChanged(updatesCopy[i][0], updatesCopy[i][1]);
+            }
+            for (let i = 0; i < updatesCollectionCopy.length; ++i) {
+                keysChanged(updatesCollectionCopy[i][0], updatesCollectionCopy[i][1]);
+            }
+        });
     }, 0);
-  }
 }
 
 /**
@@ -1303,7 +1305,7 @@ function mergeCollection(collectionKey, collection) {
             // and update all subscribers
             Promise.all(_.map(existingKeys, get)).then(() => {
                 cache.merge(collection);
-                notifyCollectionSubscribersOnNextTick(collectionKey, collection)
+                notifyCollectionSubscribersOnNextTick(collectionKey, collection);
             });
 
             return Promise.all(promises)

--- a/lib/batch.js
+++ b/lib/batch.js
@@ -1,0 +1,2 @@
+import {unstable_batchedUpdates} from 'react-dom';
+export default unstable_batchedUpdates;

--- a/lib/batch.js
+++ b/lib/batch.js
@@ -1,2 +1,3 @@
 import {unstable_batchedUpdates} from 'react-dom';
+
 export default unstable_batchedUpdates;

--- a/lib/batch.native.js
+++ b/lib/batch.native.js
@@ -1,0 +1,3 @@
+import {unstable_batchedUpdates} from 'react-native';
+
+export default unstable_batchedUpdates;

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "metro-react-native-babel-preset": "^0.72.3",
         "prop-types": "^15.7.2",
         "react": "18.2.0",
+        "react-dom": "^18.1.0",
         "react-native": "0.71.2",
         "react-native-device-info": "^10.3.0",
         "react-native-performance": "^2.0.0",
@@ -52,6 +53,7 @@
       "peerDependencies": {
         "idb-keyval": "^6.2.1",
         "react": ">=18.1.0",
+        "react-dom": ">=18.1.0",
         "react-native-device-info": "^10.3.0",
         "react-native-performance": "^4.0.0",
         "react-native-quick-sqlite": "^8.0.0-beta.2"
@@ -13360,6 +13362,19 @@
       "dependencies": {
         "shell-quote": "^1.6.1",
         "ws": "^7"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.1.0.tgz",
+      "integrity": "sha512-fU1Txz7Budmvamp7bshe4Zi32d0ll7ect+ccxNu9FlObT605GOEB8BfO4tmRJ39R5Zj831VCpvQ05QPBW5yb+w==",
+      "dev": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.22.0"
+      },
+      "peerDependencies": {
+        "react": "^18.1.0"
       }
     },
     "node_modules/react-is": {
@@ -27464,6 +27479,16 @@
       "requires": {
         "shell-quote": "^1.6.1",
         "ws": "^7"
+      }
+    },
+    "react-dom": {
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.1.0.tgz",
+      "integrity": "sha512-fU1Txz7Budmvamp7bshe4Zi32d0ll7ect+ccxNu9FlObT605GOEB8BfO4tmRJ39R5Zj831VCpvQ05QPBW5yb+w==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.22.0"
       }
     },
     "react-is": {

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "metro-react-native-babel-preset": "^0.72.3",
     "prop-types": "^15.7.2",
     "react": "18.2.0",
+    "react-dom": "^18.1.0",
     "react-native": "0.71.2",
     "react-native-device-info": "^10.3.0",
     "react-native-performance": "^2.0.0",
@@ -79,9 +80,10 @@
   "peerDependencies": {
     "idb-keyval": "^6.2.1",
     "react": ">=18.1.0",
+    "react-dom": ">=18.1.0",
+    "react-native-device-info": "^10.3.0",
     "react-native-performance": "^4.0.0",
-    "react-native-quick-sqlite": "^8.0.0-beta.2",
-    "react-native-device-info": "^10.3.0"
+    "react-native-quick-sqlite": "^8.0.0-beta.2"
   },
   "peerDependenciesMeta": {
     "idb-keyval": {

--- a/tests/components/ViewWithObject.js
+++ b/tests/components/ViewWithObject.js
@@ -1,8 +1,19 @@
 import React from 'react';
 // eslint-disable-next-line no-restricted-imports
 import {Text, View} from 'react-native';
+import PropTypes from 'prop-types';
 
-function ViewWithObject(props) {
+const propTypes = {
+    onRender: PropTypes.func,
+};
+
+const defaultProps = {
+    onRender: () => {},
+};
+
+function ViewWithObject({onRender, ...props}) {
+    onRender();
+
     return (
         <View>
             <Text testID="text-element">{JSON.stringify(props)}</Text>
@@ -10,4 +21,6 @@ function ViewWithObject(props) {
     );
 }
 
+ViewWithObject.propTypes = propTypes;
+ViewWithObject.defaultProps = defaultProps;
 export default ViewWithObject;

--- a/tests/unit/metricsTest.js
+++ b/tests/unit/metricsTest.js
@@ -1,7 +1,6 @@
 import _ from 'underscore';
 import waitForPromisesToResolve from '../utils/waitForPromisesToResolve';
 
-jest.useRealTimers();
 describe('decorateWithMetrics', () => {
     let decorateWithMetrics; let getMetrics; let resetMetrics;
 

--- a/tests/unit/metricsTest.js
+++ b/tests/unit/metricsTest.js
@@ -1,6 +1,7 @@
 import _ from 'underscore';
 import waitForPromisesToResolve from '../utils/waitForPromisesToResolve';
 
+jest.useRealTimers();
 describe('decorateWithMetrics', () => {
     let decorateWithMetrics; let getMetrics; let resetMetrics;
 
@@ -50,14 +51,15 @@ describe('decorateWithMetrics', () => {
         mockFunc = decorateWithMetrics(mockFunc);
         mockFunc();
 
-        waitForPromisesToResolve()
+        return waitForPromisesToResolve()
             .then(() => {
                 // Then the alias should be inferred from the function name
                 const stats = getMetrics();
-                expect(stats).toHaveLength(1);
-                expect(stats).toEqual([
+                const result = stats.summaries.mockFunc;
+                expect(result).not.toBeUndefined();
+                expect(result).toEqual(
                     expect.objectContaining({methodName: 'mockFunc'}),
-                ]);
+                );
             });
     });
 

--- a/tests/unit/onyxCacheTest.js
+++ b/tests/unit/onyxCacheTest.js
@@ -7,6 +7,7 @@ import waitForPromisesToResolve from '../utils/waitForPromisesToResolve';
 import ViewWithText from '../components/ViewWithText';
 import ViewWithCollections from '../components/ViewWithCollections';
 
+jest.useRealTimers();
 describe('Onyx', () => {
     describe('Cache Service', () => {
         /** @type OnyxCache */
@@ -617,8 +618,6 @@ describe('Onyx', () => {
             StorageMock.getItem.mockResolvedValue('"mockValue"');
             const range = _.range(1, 10);
             StorageMock.getAllKeys.mockResolvedValue(_.map(range, n => `key${n}`));
-
-            jest.useFakeTimers();
 
             // Given Onyx with LRU size of 3
             return initOnyx({maxCachedKeysCount: 3})

--- a/tests/unit/onyxCacheTest.js
+++ b/tests/unit/onyxCacheTest.js
@@ -7,7 +7,6 @@ import waitForPromisesToResolve from '../utils/waitForPromisesToResolve';
 import ViewWithText from '../components/ViewWithText';
 import ViewWithCollections from '../components/ViewWithCollections';
 
-jest.useRealTimers();
 describe('Onyx', () => {
     describe('Cache Service', () => {
         /** @type OnyxCache */

--- a/tests/unit/onyxTest.js
+++ b/tests/unit/onyxTest.js
@@ -21,6 +21,7 @@ Onyx.init({
     },
 });
 
+jest.useRealTimers();
 describe('Onyx', () => {
     let connectionID;
 
@@ -66,6 +67,7 @@ describe('Onyx', () => {
 
         // Set a simple key
         return Onyx.set(ONYX_KEYS.TEST_KEY, 'test')
+            .then(waitForPromisesToResolve)
             .then(() => {
                 expect(testKeyValue).toBe('test');
             });
@@ -83,10 +85,12 @@ describe('Onyx', () => {
         });
 
         return Onyx.set(ONYX_KEYS.TEST_KEY, {test1: 'test1'})
+            .then(waitForPromisesToResolve)
             .then(() => {
                 expect(testKeyValue).toEqual({test1: 'test1'});
                 return Onyx.merge(ONYX_KEYS.TEST_KEY, {test2: 'test2'});
             })
+            .then(waitForPromisesToResolve)
             .then(() => {
                 expect(testKeyValue).toEqual({test1: 'test1', test2: 'test2'});
             });
@@ -112,6 +116,7 @@ describe('Onyx', () => {
 
         return waitForPromisesToResolve()
             .then(() => Onyx.set(ONYX_KEYS.TEST_KEY, 'test'))
+            .then(waitForPromisesToResolve)
             .then(() => {
                 expect(testKeyValue).toBe('test');
                 return Onyx.clear().then(waitForPromisesToResolve);
@@ -138,6 +143,7 @@ describe('Onyx', () => {
         });
 
         return Onyx.set(ONYX_KEYS.TEST_KEY, 'test')
+            .then(waitForPromisesToResolve)
             .then(() => {
                 expect(testKeyValue).toBe('test');
                 Onyx.disconnect(connectionID);
@@ -160,6 +166,7 @@ describe('Onyx', () => {
         });
 
         return Onyx.set(ONYX_KEYS.TEST_KEY, ['test1'])
+            .then(waitForPromisesToResolve)
             .then(() => {
                 expect(testKeyValue).toStrictEqual(['test1']);
                 return Onyx.merge(ONYX_KEYS.TEST_KEY, ['test2', 'test3', 'test4']);
@@ -266,6 +273,8 @@ describe('Onyx', () => {
                 value: 'three',
             },
         })
+
+            // .then(waitForPromisesToResolve)
             .then(() => (
 
                 // 2 key values to update and 2 new keys to add.
@@ -289,6 +298,7 @@ describe('Onyx', () => {
                     },
                 })
             ))
+            .then(waitForPromisesToResolve)
             .then(() => {
                 // 3 items on the first mergeCollection + 4 items the next mergeCollection
                 expect(mockCallback).toHaveBeenCalledTimes(7);
@@ -347,6 +357,7 @@ describe('Onyx', () => {
                     value: 'two',
                 },
             }))
+            .then(waitForPromisesToResolve)
             .then(() => {
                 expect(valuesReceived).toEqual({
                     test_1: {
@@ -394,7 +405,7 @@ describe('Onyx', () => {
                 expect(otherTestKeyValue).toEqual({test1: 'test1'});
 
                 // When we pass a data object to Onyx.update
-                Onyx.update([
+                return Onyx.update([
                     {
                         onyxMethod: 'set',
                         key: ONYX_KEYS.TEST_KEY,
@@ -406,8 +417,8 @@ describe('Onyx', () => {
                         value: {test2: 'test2'},
                     },
                 ]);
-                return waitForPromisesToResolve();
             })
+            .then(waitForPromisesToResolve)
             .then(() => {
                 // Then the final Onyx state should be {test: 'one', otherTest: {test1: 'test1', test2: 'test2'}}
                 expect(testKeyValue).toBe('one');
@@ -442,7 +453,7 @@ describe('Onyx', () => {
                 expect(mockCallback).toHaveBeenNthCalledWith(2, {existingData: 'test'}, 'test_2');
 
                 // When we pass a mergeCollection data object to Onyx.update
-                Onyx.update([
+                return Onyx.update([
                     {
                         onyxMethod: 'mergecollection',
                         key: ONYX_KEYS.COLLECTION.TEST_KEY,
@@ -462,8 +473,8 @@ describe('Onyx', () => {
                         },
                     },
                 ]);
-                return waitForPromisesToResolve();
             })
+            .then(waitForPromisesToResolve)
             .then(() => {
                 /* Then the final Onyx state should be:
                     {
@@ -548,6 +559,7 @@ describe('Onyx', () => {
                     },
                 },
             ]))
+            .then(waitForPromisesToResolve)
             .then(() => {
                 expect(valuesReceived).toEqual({
                     test_1: {
@@ -639,6 +651,7 @@ describe('Onyx', () => {
 
             // When mergeCollection is called with an updated collection
             .then(() => Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_POLICY, collectionUpdate))
+            .then(waitForPromisesToResolve)
             .then(() => {
                 // Then we expect the callback to have called twice, once for the initial connect call + once for the collection update
                 expect(mockCallback).toHaveBeenCalledTimes(2);
@@ -666,10 +679,8 @@ describe('Onyx', () => {
         return waitForPromisesToResolve()
 
             // When mergeCollection is called with an updated collection
-            .then(() => {
-                Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_POLICY, collectionUpdate);
-                return waitForPromisesToResolve();
-            })
+            .then(() => Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_POLICY, collectionUpdate))
+            .then(waitForPromisesToResolve)
             .then(() => {
                 // Then we expect the callback to have called twice, once for the initial connect call + once for the collection update
                 expect(mockCallback).toHaveBeenCalledTimes(2);
@@ -698,6 +709,7 @@ describe('Onyx', () => {
 
             // When mergeCollection is called with an updated collection
             .then(() => Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_POLICY}${1}`, collectionUpdate.testPolicy_1))
+            .then(waitForPromisesToResolve)
             .then(() => {
                 // Then we expect the callback to have called twice, once for the initial connect call + once for the collection update
                 expect(mockCallback).toHaveBeenCalledTimes(2);
@@ -733,6 +745,7 @@ describe('Onyx', () => {
 
             // When merge is called with an updated collection
             .then(() => Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_POLICY}${1}`, collectionUpdate.testPolicy_1))
+            .then(waitForPromisesToResolve)
             .then(() => {
                 // Then we expect the callback to have called twice, once for the initial connect call + once for the collection update
                 expect(mockCallback).toHaveBeenCalledTimes(2);
@@ -773,6 +786,7 @@ describe('Onyx', () => {
 
             // When merge is called with an updated collection
             .then(() => Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_POLICY}${1}`, collectionUpdate.testPolicy_1))
+            .then(waitForPromisesToResolve)
             .then(() => {
                 // Then we expect the callback to have called once. 0 times the initial connect call + 1 time for the merge()
                 expect(mockCallback).toHaveBeenCalledTimes(1);
@@ -812,6 +826,7 @@ describe('Onyx', () => {
             {onyxMethod: Onyx.METHOD.MERGE, key: ONYX_KEYS.OTHER_TEST, value: 'pizza'},
             {onyxMethod: Onyx.METHOD.MERGE_COLLECTION, key: ONYX_KEYS.COLLECTION.TEST_UPDATE, value: {[itemKey]: {a: 'a'}}},
         ])
+            .then(waitForPromisesToResolve)
             .then(() => {
                 expect(collectionCallback).toHaveBeenNthCalledWith(1, {[itemKey]: {a: 'a'}});
                 expect(testCallback).toHaveBeenNthCalledWith(1, 'taco', ONYX_KEYS.TEST_KEY);

--- a/tests/unit/onyxTest.js
+++ b/tests/unit/onyxTest.js
@@ -21,7 +21,6 @@ Onyx.init({
     },
 });
 
-jest.useRealTimers();
 describe('Onyx', () => {
     let connectionID;
 

--- a/tests/unit/onyxTest.js
+++ b/tests/unit/onyxTest.js
@@ -67,7 +67,6 @@ describe('Onyx', () => {
 
         // Set a simple key
         return Onyx.set(ONYX_KEYS.TEST_KEY, 'test')
-            .then(waitForPromisesToResolve)
             .then(() => {
                 expect(testKeyValue).toBe('test');
             });
@@ -85,12 +84,10 @@ describe('Onyx', () => {
         });
 
         return Onyx.set(ONYX_KEYS.TEST_KEY, {test1: 'test1'})
-            .then(waitForPromisesToResolve)
             .then(() => {
                 expect(testKeyValue).toEqual({test1: 'test1'});
                 return Onyx.merge(ONYX_KEYS.TEST_KEY, {test2: 'test2'});
             })
-            .then(waitForPromisesToResolve)
             .then(() => {
                 expect(testKeyValue).toEqual({test1: 'test1', test2: 'test2'});
             });
@@ -116,7 +113,6 @@ describe('Onyx', () => {
 
         return waitForPromisesToResolve()
             .then(() => Onyx.set(ONYX_KEYS.TEST_KEY, 'test'))
-            .then(waitForPromisesToResolve)
             .then(() => {
                 expect(testKeyValue).toBe('test');
                 return Onyx.clear().then(waitForPromisesToResolve);
@@ -143,7 +139,6 @@ describe('Onyx', () => {
         });
 
         return Onyx.set(ONYX_KEYS.TEST_KEY, 'test')
-            .then(waitForPromisesToResolve)
             .then(() => {
                 expect(testKeyValue).toBe('test');
                 Onyx.disconnect(connectionID);
@@ -166,7 +161,6 @@ describe('Onyx', () => {
         });
 
         return Onyx.set(ONYX_KEYS.TEST_KEY, ['test1'])
-            .then(waitForPromisesToResolve)
             .then(() => {
                 expect(testKeyValue).toStrictEqual(['test1']);
                 return Onyx.merge(ONYX_KEYS.TEST_KEY, ['test2', 'test3', 'test4']);
@@ -188,11 +182,9 @@ describe('Onyx', () => {
         });
 
         Onyx.merge(ONYX_KEYS.TEST_KEY, {test1: 'test1'});
-        Onyx.merge(ONYX_KEYS.TEST_KEY, {test2: 'test2'});
-        return waitForPromisesToResolve()
-            .then(() => {
-                expect(testKeyValue).toStrictEqual({test1: 'test1', test2: 'test2'});
-            });
+        return Onyx.merge(ONYX_KEYS.TEST_KEY, {test2: 'test2'}).then(() => {
+            expect(testKeyValue).toStrictEqual({test1: 'test1', test2: 'test2'});
+        });
     });
 
     it('should merge 2 arrays when it has no initial stored value for test key', () => {
@@ -206,11 +198,9 @@ describe('Onyx', () => {
         });
 
         Onyx.merge(ONYX_KEYS.TEST_KEY, ['test1']);
-        Onyx.merge(ONYX_KEYS.TEST_KEY, ['test2']);
-        return waitForPromisesToResolve()
-            .then(() => {
-                expect(testKeyValue).toEqual(['test2']);
-            });
+        return Onyx.merge(ONYX_KEYS.TEST_KEY, ['test2']).then(() => {
+            expect(testKeyValue).toEqual(['test2']);
+        });
     });
 
     it('should overwrite an array key nested inside an object', () => {
@@ -224,11 +214,9 @@ describe('Onyx', () => {
         });
 
         Onyx.merge(ONYX_KEYS.TEST_KEY, {something: [1, 2, 3]});
-        Onyx.merge(ONYX_KEYS.TEST_KEY, {something: [4]});
-        return waitForPromisesToResolve()
-            .then(() => {
-                expect(testKeyValue).toEqual({something: [4]});
-            });
+        return Onyx.merge(ONYX_KEYS.TEST_KEY, {something: [4]}).then(() => {
+            expect(testKeyValue).toEqual({something: [4]});
+        });
     });
 
     it('should overwrite an array key nested inside an object when using merge on a collection', () => {
@@ -242,8 +230,7 @@ describe('Onyx', () => {
         });
 
         Onyx.merge(ONYX_KEYS.COLLECTION.TEST_KEY, {test_1: {something: [1, 2, 3]}});
-        Onyx.merge(ONYX_KEYS.COLLECTION.TEST_KEY, {test_1: {something: [4]}});
-        return waitForPromisesToResolve()
+        return Onyx.merge(ONYX_KEYS.COLLECTION.TEST_KEY, {test_1: {something: [4]}})
             .then(() => {
                 expect(testKeyValue).toEqual({test_1: {something: [4]}});
             });
@@ -273,8 +260,6 @@ describe('Onyx', () => {
                 value: 'three',
             },
         })
-
-            // .then(waitForPromisesToResolve)
             .then(() => (
 
                 // 2 key values to update and 2 new keys to add.
@@ -298,7 +283,6 @@ describe('Onyx', () => {
                     },
                 })
             ))
-            .then(waitForPromisesToResolve)
             .then(() => {
                 // 3 items on the first mergeCollection + 4 items the next mergeCollection
                 expect(mockCallback).toHaveBeenCalledTimes(7);
@@ -357,7 +341,6 @@ describe('Onyx', () => {
                     value: 'two',
                 },
             }))
-            .then(waitForPromisesToResolve)
             .then(() => {
                 expect(valuesReceived).toEqual({
                     test_1: {
@@ -418,7 +401,6 @@ describe('Onyx', () => {
                     },
                 ]);
             })
-            .then(waitForPromisesToResolve)
             .then(() => {
                 // Then the final Onyx state should be {test: 'one', otherTest: {test1: 'test1', test2: 'test2'}}
                 expect(testKeyValue).toBe('one');
@@ -474,7 +456,6 @@ describe('Onyx', () => {
                     },
                 ]);
             })
-            .then(waitForPromisesToResolve)
             .then(() => {
                 /* Then the final Onyx state should be:
                     {
@@ -559,7 +540,6 @@ describe('Onyx', () => {
                     },
                 },
             ]))
-            .then(waitForPromisesToResolve)
             .then(() => {
                 expect(valuesReceived).toEqual({
                     test_1: {
@@ -616,8 +596,7 @@ describe('Onyx', () => {
             },
         };
 
-        Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_CONNECT_COLLECTION, initialCollectionData);
-        return waitForPromisesToResolve()
+        return Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_CONNECT_COLLECTION, initialCollectionData)
             .then(() => {
                 // When we connect to that collection with waitForCollectionCallback = true
                 connectionID = Onyx.connect({
@@ -651,7 +630,6 @@ describe('Onyx', () => {
 
             // When mergeCollection is called with an updated collection
             .then(() => Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_POLICY, collectionUpdate))
-            .then(waitForPromisesToResolve)
             .then(() => {
                 // Then we expect the callback to have called twice, once for the initial connect call + once for the collection update
                 expect(mockCallback).toHaveBeenCalledTimes(2);
@@ -671,7 +649,7 @@ describe('Onyx', () => {
             testPolicy_2: {ID: 123, value: 'two'},
         };
 
-        // Given an Onyx.connect call with waitForCollectionCallback=true
+        // Given an Onyx.connect call with waitForCollectionCallback=false
         connectionID = Onyx.connect({
             key: `${ONYX_KEYS.COLLECTION.TEST_POLICY}${1}`,
             callback: mockCallback,
@@ -680,7 +658,6 @@ describe('Onyx', () => {
 
             // When mergeCollection is called with an updated collection
             .then(() => Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_POLICY, collectionUpdate))
-            .then(waitForPromisesToResolve)
             .then(() => {
                 // Then we expect the callback to have called twice, once for the initial connect call + once for the collection update
                 expect(mockCallback).toHaveBeenCalledTimes(2);
@@ -709,7 +686,6 @@ describe('Onyx', () => {
 
             // When mergeCollection is called with an updated collection
             .then(() => Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_POLICY}${1}`, collectionUpdate.testPolicy_1))
-            .then(waitForPromisesToResolve)
             .then(() => {
                 // Then we expect the callback to have called twice, once for the initial connect call + once for the collection update
                 expect(mockCallback).toHaveBeenCalledTimes(2);
@@ -745,7 +721,6 @@ describe('Onyx', () => {
 
             // When merge is called with an updated collection
             .then(() => Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_POLICY}${1}`, collectionUpdate.testPolicy_1))
-            .then(waitForPromisesToResolve)
             .then(() => {
                 // Then we expect the callback to have called twice, once for the initial connect call + once for the collection update
                 expect(mockCallback).toHaveBeenCalledTimes(2);
@@ -786,7 +761,6 @@ describe('Onyx', () => {
 
             // When merge is called with an updated collection
             .then(() => Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_POLICY}${1}`, collectionUpdate.testPolicy_1))
-            .then(waitForPromisesToResolve)
             .then(() => {
                 // Then we expect the callback to have called once. 0 times the initial connect call + 1 time for the merge()
                 expect(mockCallback).toHaveBeenCalledTimes(1);
@@ -826,11 +800,12 @@ describe('Onyx', () => {
             {onyxMethod: Onyx.METHOD.MERGE, key: ONYX_KEYS.OTHER_TEST, value: 'pizza'},
             {onyxMethod: Onyx.METHOD.MERGE_COLLECTION, key: ONYX_KEYS.COLLECTION.TEST_UPDATE, value: {[itemKey]: {a: 'a'}}},
         ])
-            .then(waitForPromisesToResolve)
             .then(() => {
-                expect(collectionCallback).toHaveBeenNthCalledWith(1, {[itemKey]: {a: 'a'}});
-                expect(testCallback).toHaveBeenNthCalledWith(1, 'taco', ONYX_KEYS.TEST_KEY);
-                expect(otherTestCallback).toHaveBeenNthCalledWith(1, 'pizza', ONYX_KEYS.OTHER_TEST);
+                // We are connecting before we update (set) the onyx data, hence the callback will be
+                // invoked with the data on the second call:
+                expect(collectionCallback).toHaveBeenNthCalledWith(2, {[itemKey]: {a: 'a'}});
+                expect(testCallback).toHaveBeenNthCalledWith(2, 'taco', ONYX_KEYS.TEST_KEY);
+                expect(otherTestCallback).toHaveBeenNthCalledWith(2, 'pizza', ONYX_KEYS.OTHER_TEST);
                 Onyx.disconnect(connectionIDs);
             });
     });

--- a/tests/unit/withOnyxTest.js
+++ b/tests/unit/withOnyxTest.js
@@ -101,6 +101,8 @@ describe('withOnyxTest', () => {
                 return Onyx.merge(ONYX_KEYS.SIMPLE_KEY_2, 'string2');
             })
             .then(() => {
+                // We expect it to be 2 as we first is initial render and second are 3 Onyx merges batched together.
+                // As you see onyx merges on the top of the function doesn't account they are done earlier
                 expect(onRender).toHaveBeenCalledTimes(2);
             });
     }));

--- a/tests/unit/withOnyxTest.js
+++ b/tests/unit/withOnyxTest.js
@@ -32,7 +32,7 @@ describe('withOnyx', () => {
         // the component from {loading: true} to {loading:false, ...data}.
         // We now changed the architecture, so that when a key can be retrieved
         // synchronously from cache, we expect the component to be rendered immediately.
-        Onyx.set(ONYX_KEYS.TEST_KEY, 'test1')
+        return Onyx.set(ONYX_KEYS.TEST_KEY, 'test1')
             .then(() => {
                 const TestComponentWithOnyx = withOnyx({
                     text: {

--- a/tests/unit/withOnyxTest.js
+++ b/tests/unit/withOnyxTest.js
@@ -77,11 +77,9 @@ describe('withOnyx', () => {
             });
     });
 
-    it('should batch correctly together little khachapuris', async () => {
-        await Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {[`${ONYX_KEYS.COLLECTION.TEST_KEY}1`]: {ID: 999}});
-        await Onyx.merge(ONYX_KEYS.SIMPLE_KEY, 'prev_string');
-        await Onyx.merge(ONYX_KEYS.SIMPLE_KEY_2, 'prev_string2');
-
+    it('should batch correctly together little khachapuris', () => Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
+        [`${ONYX_KEYS.COLLECTION.TEST_KEY}1`]: {ID: 999},
+    }).then(() => Onyx.merge(ONYX_KEYS.SIMPLE_KEY, 'prev_string')).then(() => Onyx.merge(ONYX_KEYS.SIMPLE_KEY_2, 'prev_string2')).then(() => {
         const TestComponentWithOnyx = withOnyx({
             testKey: {
                 key: `${ONYX_KEYS.COLLECTION.TEST_KEY}1`,
@@ -105,7 +103,7 @@ describe('withOnyx', () => {
             .then(() => {
                 expect(onRender).toHaveBeenCalledTimes(2);
             });
-    });
+    }));
 
     it('should update withOnyx subscriber just once when mergeCollection is used', () => {
         const TestComponentWithOnyx = withOnyx({

--- a/tests/unit/withOnyxTest.js
+++ b/tests/unit/withOnyxTest.js
@@ -73,7 +73,7 @@ describe('withOnyxTest', () => {
                 return Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_KEY}3`, {ID: 345});
             })
             .then(() => {
-                expect(onRender).toHaveBeenCalledTimes(4);
+                expect(onRender).toHaveBeenCalledTimes(2);
             });
     });
 

--- a/tests/unit/withOnyxTest.js
+++ b/tests/unit/withOnyxTest.js
@@ -145,14 +145,12 @@ describe('withOnyx', () => {
         const onRender = jest.fn();
         render(<TestComponentWithOnyx onRender={onRender} />);
         return waitForPromisesToResolve()
-            .then(() => {
-                Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {test_4: {ID: 456}, test_5: {ID: 567}});
-                return Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
-                    test_4: {Name: 'Test4'},
-                    test_5: {Name: 'Test5'},
-                    test_6: {ID: 678, Name: 'Test6'},
-                });
-            })
+            .then(() => Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {test_4: {ID: 456}, test_5: {ID: 567}}))
+            .then(() => Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
+                test_4: {Name: 'Test4'},
+                test_5: {Name: 'Test5'},
+                test_6: {ID: 678, Name: 'Test6'},
+            }))
             .then(() => {
                 expect(onRender).toHaveBeenCalledTimes(3);
                 expect(onRender).toHaveBeenLastCalledWith({

--- a/tests/unit/withOnyxTest.js
+++ b/tests/unit/withOnyxTest.js
@@ -25,7 +25,7 @@ Onyx.init({
 
 beforeEach(() => Onyx.clear());
 
-describe('withOnyx', () => {
+describe('withOnyxTest', () => {
     it('should render immediately with the test data when using withOnyx', () => {
         const onRender = jest.fn();
 

--- a/tests/unit/withOnyxTest.js
+++ b/tests/unit/withOnyxTest.js
@@ -73,6 +73,7 @@ describe('withOnyxTest', () => {
                 return Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_KEY}3`, {ID: 345});
             })
             .then(() => {
+                // We expect 2 due to batching
                 expect(onRender).toHaveBeenCalledTimes(2);
             });
     });

--- a/tests/unit/withOnyxTest.js
+++ b/tests/unit/withOnyxTest.js
@@ -44,7 +44,6 @@ describe('withOnyx', () => {
                 const textComponent = result.getByText('test1');
                 expect(textComponent).not.toBeNull();
 
-                jest.runAllTimers();
                 return waitForPromisesToResolve();
             })
             .then(() => {

--- a/tests/utils/waitForPromisesToResolve.js
+++ b/tests/utils/waitForPromisesToResolve.js
@@ -1,1 +1,1 @@
-export default () => new Promise(setImmediate);
+export default () => new Promise(resolve => setTimeout(resolve, 0));


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->
### The Problem this pull-request solves
One of the main problems with react-native-onyx is that it renders every component in a separate micro-task. Because right now we don't use concurrent rendering every setState not within the same event listener will cause a separate render. Every react render has certain overhead so if it's possible to render 2 state changes together we will only pay for the overhead once. Additionally we introduce additional overhead in render side-effects. For instance in SidebarLinks component we compute which report should be visible. That method is heavy and we run it almost on every render. If we batch 2 setStates together that would save us one such computation. This pull-requests batches all setStates caused by onyx changes that occurs within the same microtask cycle. That saves a ton of time. 

#### Examples of the problem
1) Imagine there are 10 components that are listening to a current report changes. Currently all those components will be notified separately 
2) Imagine we have one component that listens to 4 different onyx props that are changed one by one (SidebarLinks is such component) right now we will render is as many times as we have changes. With this pr we will merge it only once per micotask cycle what will avoid a lot of recomputation

> Note that is change won't be needed anymore once we use concurrent rendering. 

### Details
We use  `unstable_batchedUpdates` method from react (That is currently used in even listeners so it's pretty safe). 
This method triggers single react render for all the setState changes passed to it. 

#### How it works 
![Screenshot 2023-08-28 at 14 46 16](https://github.com/Expensify/react-native-onyx/assets/12784455/7871fa2c-21e7-4d4a-9d92-631d0b98df7c)
For every notifySubscribers or collection subscribers we don't queue the update on micro task queue instead we add that change to pending changes list that is flushed at the end of the current micro task cycle. We do it by setting macro task which is `setTimeout(() => {}, 0)`.
### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->
