### PR TITLE
Use collection key value map instead of recomputing everytime

### DIFF
--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -27,8 +27,8 @@ let lastConnectionID = 0;
 // Holds a mapping of all the react components that want their state subscribed to a store key
 const callbackToStateMapping = {};
 
-// Stores all of the keys that Onyx can use. Must be defined in init().
-let onyxKeys = {};
+// Keeps a copy of the values of the onyx collection keys as a a map for faster lookups
+let onyxCollectionKeyMap = {};
 
 // Holds a list of keys that have been directly subscribed to or recently modified from least to most recent
 let recentlyAccessedKeys = [];
@@ -141,7 +141,7 @@ function getAllKeys() {
  * @returns {Boolean}
  */
 function isCollectionKey(key) {
-    return _.contains(_.values(onyxKeys.COLLECTION), key);
+    return onyxCollectionKeyMap.has(key);
 }
 
 /**
@@ -1392,8 +1392,13 @@ function init({
         cache.setRecentKeysLimit(maxCachedKeysCount);
     }
 
-    // Let Onyx know about all of our keys
-    onyxKeys = keys;
+    // We need the value of the collection keys later for checking if a
+    // key is a collection. We store it in a map for faster lookup.
+    const collectionValues = _.values(keys.COLLECTION);
+    onyxCollectionKeyMap = _.reduce(collectionValues, (acc, val) => {
+        acc.set(val, true);
+        return acc;
+    }, new Map());
 
     // Set our default key states to use when initializing and clearing Onyx data
     defaultKeyStates = initialKeyStates;

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -27,7 +27,7 @@ let lastConnectionID = 0;
 // Holds a mapping of all the react components that want their state subscribed to a store key
 const callbackToStateMapping = {};
 
-// Keeps a copy of the values of the onyx collection keys as a a map for faster lookups
+// Keeps a copy of the values of the onyx collection keys as a map for faster lookups
 let onyxCollectionKeyMap = {};
 
 // Holds a list of keys that have been directly subscribed to or recently modified from least to most recent


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

During a performance audit of a large account we noticed, that the `isKeyMatch` time was taking a lot of time. After further investigation we found that this code is problematic:

https://github.com/Expensify/react-native-onyx/blob/680e3cb10dcfeba9cf40f7f32fd0aa1bdd8b01e0/lib/Onyx.js#L143-L145

We recompute an array again and again and then use includes on an array to check for a match. Do this thousand of times and it becomes slow. Optimising this code reduced the startup time by ~600ms (on a powerful emulator, effects might be stronger on physical device)

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK: https://expensify.slack.com/archives/C035J5C9FAP/p1692808883217069

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->
