### PR TITLE
Add a noop for setting memory only keys

### DIFF
--- a/lib/storage/providers/IDBKeyVal.js
+++ b/lib/storage/providers/IDBKeyVal.js
@@ -86,6 +86,9 @@ const provider = {
      */
     clear: () => clear(getCustomStore()),
 
+    // This is a noop for now in order to keep clients from crashing see https://github.com/Expensify/Expensify/issues/312438
+    setMemoryOnlyKeys: () => {},
+
     /**
      * Returns all keys available in storage
      * @returns {Promise<String[]>}


### PR DESCRIPTION
### Details
This was removed in https://github.com/Expensify/react-native-onyx/commit/2047f732881866f082f8464567fcfee5aaf72fbb and needs to have a full implementation built and tested

### Related Issues
Fixes https://github.com/Expensify/Expensify/issues/312438

### Automated Tests
None

### Linked PRs
TBD
