### PR TITLE
Revert "Use collection key value map instead of recomputing everytime"

### DIFF
--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -27,8 +27,8 @@ let lastConnectionID = 0;
 // Holds a mapping of all the react components that want their state subscribed to a store key
 const callbackToStateMapping = {};
 
-// Keeps a copy of the values of the onyx collection keys as a map for faster lookups
-let onyxCollectionKeyMap = {};
+// Stores all of the keys that Onyx can use. Must be defined in init().
+let onyxKeys = {};
 
 // Holds a list of keys that have been directly subscribed to or recently modified from least to most recent
 let recentlyAccessedKeys = [];
@@ -141,7 +141,7 @@ function getAllKeys() {
  * @returns {Boolean}
  */
 function isCollectionKey(key) {
-    return onyxCollectionKeyMap.has(key);
+    return _.contains(_.values(onyxKeys.COLLECTION), key);
 }
 
 /**
@@ -1392,13 +1392,8 @@ function init({
         cache.setRecentKeysLimit(maxCachedKeysCount);
     }
 
-    // We need the value of the collection keys later for checking if a
-    // key is a collection. We store it in a map for faster lookup.
-    const collectionValues = _.values(keys.COLLECTION);
-    onyxCollectionKeyMap = _.reduce(collectionValues, (acc, val) => {
-        acc.set(val, true);
-        return acc;
-    }, new Map());
+    // Let Onyx know about all of our keys
+    onyxKeys = keys;
 
     // Set our default key states to use when initializing and clearing Onyx data
     defaultKeyStates = initialKeyStates;


### PR DESCRIPTION
Reverts Expensify/react-native-onyx#316

This is causing the Jest tests to fail in App: https://github.com/Expensify/App/actions/runs/6027173662/job/16353221477