### PR TITLE
Add test to make sure providers implement the same methods.

### DIFF
--- a/jestSetup.js
+++ b/jestSetup.js
@@ -2,3 +2,7 @@ jest.mock('./lib/storage');
 jest.mock('./lib/storage/NativeStorage', () => require('./lib/storage/__mocks__'));
 jest.mock('./lib/storage/WebStorage', () => require('./lib/storage/__mocks__'));
 jest.mock('./lib/storage/providers/IDBKeyVal', () => require('./lib/storage/__mocks__'));
+jest.mock('react-native-device-info', () => ({getFreeDiskStorage: () => {}}));
+jest.mock('react-native-quick-sqlite', () => ({
+    open: () => ({execute: () => {}}),
+}));

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -73,6 +73,37 @@ const reduceCollectionWithSelector = (collection, selector, withOnyxInstanceStat
 }, {});
 
 /**
+ * Add any new implemented methods here so that we can guarantee both storage providers will implement the same methods.
+ * Update this function if you add or remove a method.
+ *
+ * @param {object} StorageProvider
+ */
+function validateStorageProvider(StorageProvider) {
+    const storageProviderMethods = [
+        'setItem', 'multiGet', 'multiMerge', 'mergeItem', 'multiSet', 'clear', 'setMemoryOnlyKeys', 'getAllKeys', 'getItem', 'removeItem', 'removeItems', 'getDatabaseSize',
+    ];
+    _.each(storageProviderMethods, (methodName) => {
+        if (_.isFunction(Storage[methodName])) {
+            return;
+        }
+
+        throw new Error(`Storage provider must implement ${methodName}()`);
+    });
+
+    if (_.keys(StorageProvider).length === storageProviderMethods.length) {
+        return;
+    }
+
+    _.each(StorageProvider, (method, key) => {
+        if (_.contains(storageProviderMethods, method)) {
+            return;
+        }
+
+        throw new Error(`New method '${key}()' implemented in Storage provider. Please add it to the validateStorageProvider() function.`);
+    });
+}
+
+/**
  * Get some data from the store
  *
  * @private
@@ -1378,6 +1409,8 @@ function init({
     shouldSyncMultipleInstances = Boolean(global.localStorage),
     debugSetState = false,
 } = {}) {
+    validateStorageProvider(Storage);
+
     if (captureMetrics) {
         // The code here is only bundled and applied when the captureMetrics is set
         // eslint-disable-next-line no-use-before-define

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -73,37 +73,6 @@ const reduceCollectionWithSelector = (collection, selector, withOnyxInstanceStat
 }, {});
 
 /**
- * Add any new implemented methods here so that we can guarantee both storage providers will implement the same methods.
- * Update this function if you add or remove a method.
- *
- * @param {object} StorageProvider
- */
-function validateStorageProvider(StorageProvider) {
-    const storageProviderMethods = [
-        'setItem', 'multiGet', 'multiMerge', 'mergeItem', 'multiSet', 'clear', 'setMemoryOnlyKeys', 'getAllKeys', 'getItem', 'removeItem', 'removeItems', 'getDatabaseSize',
-    ];
-    _.each(storageProviderMethods, (methodName) => {
-        if (_.isFunction(Storage[methodName])) {
-            return;
-        }
-
-        throw new Error(`Storage provider must implement ${methodName}()`);
-    });
-
-    if (_.keys(StorageProvider).length === storageProviderMethods.length) {
-        return;
-    }
-
-    _.each(StorageProvider, (method, key) => {
-        if (_.contains(storageProviderMethods, method)) {
-            return;
-        }
-
-        throw new Error(`New method '${key}()' implemented in Storage provider. Please add it to the validateStorageProvider() function.`);
-    });
-}
-
-/**
  * Get some data from the store
  *
  * @private
@@ -1409,8 +1378,6 @@ function init({
     shouldSyncMultipleInstances = Boolean(global.localStorage),
     debugSetState = false,
 } = {}) {
-    validateStorageProvider(Storage);
-
     if (captureMetrics) {
         // The code here is only bundled and applied when the captureMetrics is set
         // eslint-disable-next-line no-use-before-define

--- a/lib/storage/__mocks__/index.js
+++ b/lib/storage/__mocks__/index.js
@@ -58,6 +58,7 @@ const idbKeyvalMock = {
     getDatabaseSize() {
         return Promise.resolve({bytesRemaining: 0, bytesUsed: 99999});
     },
+    setMemoryOnlyKeys() {},
 };
 
 const idbKeyvalMockSpy = {
@@ -78,6 +79,7 @@ const idbKeyvalMockSpy = {
         storageMapInternal = data;
     }),
     getDatabaseSize: jest.fn(idbKeyvalMock.getDatabaseSize),
+    setMemoryOnlyKeys: jest.fn(idbKeyvalMock.setMemoryOnlyKeys),
 };
 
 export default idbKeyvalMockSpy;

--- a/lib/storage/providers/SQLiteStorage.js
+++ b/lib/storage/providers/SQLiteStorage.js
@@ -160,6 +160,11 @@ const provider = {
                 };
             });
     },
+
+    /**
+     * Noop on native
+     */
+    keepInstancesSync: () => {},
 };
 
 export default provider;

--- a/tests/unit/storage/providers/StorageProviderTest.js
+++ b/tests/unit/storage/providers/StorageProviderTest.js
@@ -1,0 +1,21 @@
+/* eslint-disable import/first */
+jest.mock('react-native-quick-sqlite', () => ({
+    open: () => ({execute: () => {}}),
+}));
+jest.mock('react-native-device-info', () => ({getFreeDiskStorage: () => {}}));
+jest.unmock('../../../../lib/storage/NativeStorage');
+jest.unmock('../../../../lib/storage/WebStorage');
+jest.unmock('../../../../lib/storage/providers/IDBKeyVal');
+
+import _ from 'underscore';
+import NativeStorage from '../../../../lib/storage/NativeStorage';
+import WebStorage from '../../../../lib/storage/WebStorage';
+
+it('storage providers have same methods implemented', () => {
+    const nativeMethods = _.keys(NativeStorage);
+    const webMethods = _.keys(WebStorage);
+    expect(nativeMethods.length).toEqual(webMethods.length);
+
+    const unimplementedMethods = _.difference(nativeMethods, webMethods);
+    expect(unimplementedMethods.length).toBe(0);
+});

--- a/tests/unit/storage/providers/StorageProviderTest.js
+++ b/tests/unit/storage/providers/StorageProviderTest.js
@@ -1,8 +1,4 @@
 /* eslint-disable import/first */
-jest.mock('react-native-quick-sqlite', () => ({
-    open: () => ({execute: () => {}}),
-}));
-jest.mock('react-native-device-info', () => ({getFreeDiskStorage: () => {}}));
 jest.unmock('../../../../lib/storage/NativeStorage');
 jest.unmock('../../../../lib/storage/WebStorage');
 jest.unmock('../../../../lib/storage/providers/IDBKeyVal');

--- a/tests/unit/storage/providers/StorageProviderTest.js
+++ b/tests/unit/storage/providers/StorageProviderTest.js
@@ -10,8 +10,6 @@ import WebStorage from '../../../../lib/storage/WebStorage';
 it('storage providers have same methods implemented', () => {
     const nativeMethods = _.keys(NativeStorage);
     const webMethods = _.keys(WebStorage);
-    expect(nativeMethods.length).toEqual(webMethods.length);
-
     const unimplementedMethods = _.difference(nativeMethods, webMethods);
     expect(unimplementedMethods.length).toBe(0);
 });


### PR DESCRIPTION
cc @tgolen 

### Details

Just a quick basic test to help verify if we are adding methods to one provider and not the other in the future.

### Related Issues

https://github.com/Expensify/App/issues/26304

### Automated Tests

Yes.

1. Remove the `setMemoryOnlyKeys()` method from the IDBKeyVal storage provider
2. Run `npm run test storageprovidertest`
3. Verify it fails
4. Add the method back
5. Re-run test
6. Verify it succeeds.

### Linked PRs

No need as this is just adding a test.