### PR TITLE
Export ConnectOptions type from package

### DIFF
--- a/lib/Onyx.d.ts
+++ b/lib/Onyx.d.ts
@@ -2,13 +2,12 @@ import {Component} from 'react';
 import {PartialDeep} from 'type-fest';
 import * as Logger from './Logger';
 import {
-    CollectionKey,
     CollectionKeyBase,
     DeepRecord,
     KeyValueMapping,
-    OnyxCollection,
     OnyxEntry,
     OnyxKey,
+    ConnectOptions
 } from './types';
 
 /**
@@ -19,41 +18,6 @@ import {
 type NullableKeyValueMapping = {
     [TKey in OnyxKey]: OnyxEntry<KeyValueMapping[TKey]>;
 };
-
-/**
- * Represents the base options used in `Onyx.connect()` method.
- */
-type BaseConnectOptions = {
-    statePropertyName?: string;
-    withOnyxInstance?: Component;
-    initWithStoredValues?: boolean;
-};
-
-/**
- * Represents the options used in `Onyx.connect()` method.
- * The type is built from `BaseConnectOptions` and extended to handle key/callback related options.
- * It includes two different forms, depending on whether we are waiting for a collection callback or not.
- *
- * If `waitForCollectionCallback` is `true`, it expects `key` to be a Onyx collection key and `callback` will be triggered with the whole collection
- * and will pass `value` as an `OnyxCollection`.
- *
- *
- * If `waitForCollectionCallback` is `false` or not specified, the `key` can be any Onyx key and `callback` will be triggered with updates of each collection item
- * and will pass `value` as an `OnyxEntry`.
- */
-type ConnectOptions<TKey extends OnyxKey> = BaseConnectOptions &
-    (
-        | {
-              key: TKey extends CollectionKey ? TKey : never;
-              callback?: (value: OnyxCollection<KeyValueMapping[TKey]>) => void;
-              waitForCollectionCallback: true;
-          }
-        | {
-              key: TKey;
-              callback?: (value: OnyxEntry<KeyValueMapping[TKey]>, key: TKey) => void;
-              waitForCollectionCallback?: false;
-          }
-    );
 
 /**
  * Represents a mapping between Onyx collection keys and their respective values.

--- a/lib/Onyx.d.ts
+++ b/lib/Onyx.d.ts
@@ -2,12 +2,13 @@ import {Component} from 'react';
 import {PartialDeep} from 'type-fest';
 import * as Logger from './Logger';
 import {
+    CollectionKey,
     CollectionKeyBase,
     DeepRecord,
     KeyValueMapping,
+    OnyxCollection,
     OnyxEntry,
     OnyxKey,
-    ConnectOptions
 } from './types';
 
 /**
@@ -18,6 +19,41 @@ import {
 type NullableKeyValueMapping = {
     [TKey in OnyxKey]: OnyxEntry<KeyValueMapping[TKey]>;
 };
+
+/**
+ * Represents the base options used in `Onyx.connect()` method.
+ */
+type BaseConnectOptions = {
+    statePropertyName?: string;
+    withOnyxInstance?: Component;
+    initWithStoredValues?: boolean;
+};
+
+/**
+ * Represents the options used in `Onyx.connect()` method.
+ * The type is built from `BaseConnectOptions` and extended to handle key/callback related options.
+ * It includes two different forms, depending on whether we are waiting for a collection callback or not.
+ *
+ * If `waitForCollectionCallback` is `true`, it expects `key` to be a Onyx collection key and `callback` will be triggered with the whole collection
+ * and will pass `value` as an `OnyxCollection`.
+ *
+ *
+ * If `waitForCollectionCallback` is `false` or not specified, the `key` can be any Onyx key and `callback` will be triggered with updates of each collection item
+ * and will pass `value` as an `OnyxEntry`.
+ */
+type ConnectOptions<TKey extends OnyxKey> = BaseConnectOptions &
+    (
+        | {
+              key: TKey extends CollectionKey ? TKey : never;
+              callback?: (value: OnyxCollection<KeyValueMapping[TKey]>) => void;
+              waitForCollectionCallback: true;
+          }
+        | {
+              key: TKey;
+              callback?: (value: OnyxEntry<KeyValueMapping[TKey]>, key: TKey) => void;
+              waitForCollectionCallback?: false;
+          }
+    );
 
 /**
  * Represents a mapping between Onyx collection keys and their respective values.
@@ -287,4 +323,4 @@ declare const Onyx: {
 };
 
 export default Onyx;
-export {OnyxUpdate};
+export {OnyxUpdate, ConnectOptions};

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,6 +1,6 @@
 import Onyx, {OnyxUpdate} from './Onyx';
-import {CustomTypeOptions, OnyxCollection, OnyxEntry} from './types';
+import {CustomTypeOptions, OnyxCollection, OnyxEntry, ConnectOptions} from './types';
 import withOnyx from './withOnyx';
 
 export default Onyx;
-export {CustomTypeOptions, OnyxCollection, OnyxEntry, OnyxUpdate, withOnyx};
+export {CustomTypeOptions, OnyxCollection, OnyxEntry, OnyxUpdate, withOnyx, ConnectOptions};

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,6 +1,6 @@
 import Onyx, {OnyxUpdate} from './Onyx';
-import {CustomTypeOptions, OnyxCollection, OnyxEntry, ConnectOptions} from './types';
+import {CustomTypeOptions, OnyxCollection, OnyxEntry} from './types';
 import withOnyx from './withOnyx';
 
 export default Onyx;
-export {CustomTypeOptions, OnyxCollection, OnyxEntry, OnyxUpdate, withOnyx, ConnectOptions};
+export {CustomTypeOptions, OnyxCollection, OnyxEntry, OnyxUpdate, withOnyx};

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,6 +1,6 @@
-import Onyx, {OnyxUpdate} from './Onyx';
+import Onyx, {OnyxUpdate, ConnectOptions} from './Onyx';
 import {CustomTypeOptions, OnyxCollection, OnyxEntry} from './types';
 import withOnyx from './withOnyx';
 
 export default Onyx;
-export {CustomTypeOptions, OnyxCollection, OnyxEntry, OnyxUpdate, withOnyx};
+export {CustomTypeOptions, OnyxCollection, OnyxEntry, OnyxUpdate, withOnyx, ConnectOptions};

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -1,5 +1,4 @@
 import {IsEqual, Merge} from 'type-fest';
-import {Component} from 'react'
 
 /**
  * Represents a deeply nested record. It maps keys to values,
@@ -183,41 +182,6 @@ type OnyxEntry<TOnyxValue> = TOnyxValue | null;
  */
 type OnyxCollection<TOnyxValue> = OnyxEntry<Record<string, TOnyxValue | null>>;
 
-/**
- * Represents the base options used in `Onyx.connect()` method.
- */
-type BaseConnectOptions = {
-    statePropertyName?: string;
-    withOnyxInstance?: Component;
-    initWithStoredValues?: boolean;
-};
-
-/**
- * Represents the options used in `Onyx.connect()` method.
- * The type is built from `BaseConnectOptions` and extended to handle key/callback related options.
- * It includes two different forms, depending on whether we are waiting for a collection callback or not.
- *
- * If `waitForCollectionCallback` is `true`, it expects `key` to be a Onyx collection key and `callback` will be triggered with the whole collection
- * and will pass `value` as an `OnyxCollection`.
- *
- *
- * If `waitForCollectionCallback` is `false` or not specified, the `key` can be any Onyx key and `callback` will be triggered with updates of each collection item
- * and will pass `value` as an `OnyxEntry`.
- */
-type ConnectOptions<TKey extends OnyxKey> = BaseConnectOptions &
-    (
-        | {
-              key: TKey extends CollectionKey ? TKey : never;
-              callback?: (value: OnyxCollection<KeyValueMapping[TKey]>) => void;
-              waitForCollectionCallback: true;
-          }
-        | {
-              key: TKey;
-              callback?: (value: OnyxEntry<KeyValueMapping[TKey]>, key: TKey) => void;
-              waitForCollectionCallback?: false;
-          }
-    );
-
 export {
     CollectionKey,
     CollectionKeyBase,
@@ -229,6 +193,4 @@ export {
     OnyxEntry,
     OnyxKey,
     Selector,
-    BaseConnectOptions,
-    ConnectOptions
 };

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -1,4 +1,5 @@
 import {IsEqual, Merge} from 'type-fest';
+import {Component} from 'react'
 
 /**
  * Represents a deeply nested record. It maps keys to values,
@@ -182,6 +183,41 @@ type OnyxEntry<TOnyxValue> = TOnyxValue | null;
  */
 type OnyxCollection<TOnyxValue> = OnyxEntry<Record<string, TOnyxValue | null>>;
 
+/**
+ * Represents the base options used in `Onyx.connect()` method.
+ */
+type BaseConnectOptions = {
+    statePropertyName?: string;
+    withOnyxInstance?: Component;
+    initWithStoredValues?: boolean;
+};
+
+/**
+ * Represents the options used in `Onyx.connect()` method.
+ * The type is built from `BaseConnectOptions` and extended to handle key/callback related options.
+ * It includes two different forms, depending on whether we are waiting for a collection callback or not.
+ *
+ * If `waitForCollectionCallback` is `true`, it expects `key` to be a Onyx collection key and `callback` will be triggered with the whole collection
+ * and will pass `value` as an `OnyxCollection`.
+ *
+ *
+ * If `waitForCollectionCallback` is `false` or not specified, the `key` can be any Onyx key and `callback` will be triggered with updates of each collection item
+ * and will pass `value` as an `OnyxEntry`.
+ */
+type ConnectOptions<TKey extends OnyxKey> = BaseConnectOptions &
+    (
+        | {
+              key: TKey extends CollectionKey ? TKey : never;
+              callback?: (value: OnyxCollection<KeyValueMapping[TKey]>) => void;
+              waitForCollectionCallback: true;
+          }
+        | {
+              key: TKey;
+              callback?: (value: OnyxEntry<KeyValueMapping[TKey]>, key: TKey) => void;
+              waitForCollectionCallback?: false;
+          }
+    );
+
 export {
     CollectionKey,
     CollectionKeyBase,
@@ -193,4 +229,6 @@ export {
     OnyxEntry,
     OnyxKey,
     Selector,
+    BaseConnectOptions,
+    ConnectOptions
 };


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

Export `ConnectOptions` type from the library. It turned out during ongoing Expensify TypeScript migration that this type needs to be exported from the library.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->

[#24783](https://github.com/Expensify/App/issues/24783)

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->
