### PR TITLE
fix: cannot find module remotedev in production environment

### DIFF
--- a/lib/DevTools.js
+++ b/lib/DevTools.js
@@ -1,5 +1,11 @@
-import {connectViaExtension} from 'remotedev';
 import _ from 'underscore';
+
+const {connectViaExtension} = process.env.NODE_ENV === 'production' ? require('remotedev') : {
+    connectViaExtension: () => ({
+        init: () => {},
+        send: () => {},
+    }),
+};
 
 class DevTools {
     /**
@@ -42,7 +48,7 @@ class DevTools {
      */
     clearState(keysToBeRemoved = []) {
         const pairs = _.map(keysToBeRemoved, key => [key, undefined]);
-        this.registerAction('CLEAR', undefined, _.object((pairs)));
+        this.registerAction('CLEAR', undefined, _.object(pairs));
     }
 }
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
When building react native onyx for `production`,  `node` will throw an error saying that it cannot find `remotedev` module. This is due to the fact that `remotedev` is a `devDependency` which is not included in `production` bundle. To solve this, `remotedev` needs to be dynamically imported.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/App/pull/27130#issuecomment-1713473969

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->
