### PR TITLE
feat: bump the peer dependency version of react-native-performance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "idb-keyval": "^6.2.1",
         "react": ">=18.1.0",
         "react-native-device-info": "^10.3.0",
-        "react-native-performance": "^4.0.0",
+        "react-native-performance": "^5.1.0",
         "react-native-quick-sqlite": "^8.0.0-beta.2"
       },
       "peerDependenciesMeta": {

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   "peerDependencies": {
     "idb-keyval": "^6.2.1",
     "react": ">=18.1.0",
-    "react-native-performance": "^4.0.0",
+    "react-native-performance": "^5.1.0",
     "react-native-quick-sqlite": "^8.0.0-beta.2",
     "react-native-device-info": "^10.3.0"
   },


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
This PR updates the version of `react-native-performance` peer dependency from `4.0.0` to `5.1.0`.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/App/issues/26987

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
N/A

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->
https://github.com/Expensify/App/pull/27289