### PR TITLE
Batch initial hydration.

### DIFF
--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -651,7 +651,10 @@ function sendDataToConnection(mapping, val, matchedKey) {
         }
 
         PerformanceUtils.logSetStateCall(mapping, null, newData, 'sendDataToConnection');
-        mapping.withOnyxInstance.setWithOnyxState(mapping.statePropertyName, newData);
+        batchUpdates(() => {
+            mapping.withOnyxInstance.setWithOnyxState(mapping.statePropertyName, newData);
+        })
+        
         return;
     }
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

We recently opened a pull-request with feature that is batching all setStates called on withOnyx components. 
All but the ones caused by connecting withOnyx to date for the first time. 
It may seem to be not a big deal as we probably don't have much withOnyx components on a single screen. 
Unfortunately, that's not true. All Chat items on the ReportScreen are wrapped in withOnyx. `reactions` and `IOUreport` props are almost never in the cache what basically means we have to delay rendering of an item until we get those from our DB. That means that all messages are rendered in a separate renders :0 

We already handled the case with adding initial value [pr](https://github.com/Expensify/react-native-onyx/pull/329) but I'm sure similar problems occurs in other parts of the app.
This pull-requests adds logic that will batch such setStates automatically. 

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->
