### PR TITLE
Allow null properties for Onyx.merge

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,9 @@
+module.exports = {
+    tabWidth: 4,
+    singleQuote: true,
+    trailingComma: "all",
+    bracketSpacing: false,
+    arrowParens: "always",
+    printWidth: 160,
+    singleAttributePerLine: true,
+};

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,9 +1,0 @@
-module.exports = {
-    tabWidth: 4,
-    singleQuote: true,
-    trailingComma: "all",
-    bracketSpacing: false,
-    arrowParens: "always",
-    printWidth: 160,
-    singleAttributePerLine: true,
-};

--- a/lib/Onyx.d.ts
+++ b/lib/Onyx.d.ts
@@ -1,15 +1,7 @@
 import {Component} from 'react';
 import {PartialDeep} from 'type-fest';
 import * as Logger from './Logger';
-import {
-    CollectionKey,
-    CollectionKeyBase,
-    DeepRecord,
-    KeyValueMapping,
-    OnyxCollection,
-    OnyxEntry,
-    OnyxKey,
-} from './types';
+import {CollectionKey, CollectionKeyBase, DeepRecord, KeyValueMapping, OnyxCollection, OnyxEntry, OnyxKey, Nullable} from './types';
 
 /**
  * Represents a mapping object where each `OnyxKey` maps to either a value of its corresponding type in `KeyValueMapping` or `null`.
@@ -210,7 +202,7 @@ declare function multiSet(data: Partial<NullableKeyValueMapping>): Promise<void>
  * @param key ONYXKEYS key
  * @param value Object or Array value to merge
  */
-declare function merge<TKey extends OnyxKey>(key: TKey, value: PartialDeep<KeyValueMapping[TKey]>): Promise<void>;
+declare function merge<TKey extends OnyxKey>(key: TKey, value: Nullable<PartialDeep<KeyValueMapping[TKey]>>): Promise<void>;
 
 /**
  * Clear out all the data in the store

--- a/lib/Onyx.d.ts
+++ b/lib/Onyx.d.ts
@@ -1,7 +1,7 @@
 import {Component} from 'react';
 import {PartialDeep} from 'type-fest';
 import * as Logger from './Logger';
-import {CollectionKey, CollectionKeyBase, DeepRecord, KeyValueMapping, OnyxCollection, OnyxEntry, OnyxKey, Nullable} from './types';
+import {CollectionKey, CollectionKeyBase, DeepRecord, KeyValueMapping, OnyxCollection, OnyxEntry, OnyxKey, NullableProperties} from './types';
 
 /**
  * Represents a mapping object where each `OnyxKey` maps to either a value of its corresponding type in `KeyValueMapping` or `null`.
@@ -202,7 +202,7 @@ declare function multiSet(data: Partial<NullableKeyValueMapping>): Promise<void>
  * @param key ONYXKEYS key
  * @param value Object or Array value to merge
  */
-declare function merge<TKey extends OnyxKey>(key: TKey, value: Nullable<PartialDeep<KeyValueMapping[TKey]>>): Promise<void>;
+declare function merge<TKey extends OnyxKey>(key: TKey, value: NullableProperties<PartialDeep<KeyValueMapping[TKey]>>): Promise<void>;
 
 /**
  * Clear out all the data in the store

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -190,4 +190,16 @@ type NullableProperties<T> = {
     [P in keyof T]: T[P] | null;
 };
 
-export {CollectionKey, CollectionKeyBase, CustomTypeOptions, DeepRecord, Key, KeyValueMapping, OnyxCollection, OnyxEntry, OnyxKey, Selector, NullableProperties as Nullable};
+export {
+    CollectionKey,
+    CollectionKeyBase,
+    CustomTypeOptions,
+    DeepRecord,
+    Key,
+    KeyValueMapping,
+    OnyxCollection,
+    OnyxEntry,
+    OnyxKey,
+    Selector,
+    NullableProperties,
+};

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -1,4 +1,4 @@
-import {IsEqual, Merge} from 'type-fest';
+import {Merge} from 'type-fest';
 
 /**
  * Represents a deeply nested record. It maps keys to values,
@@ -106,9 +106,7 @@ type OnyxKey = Key | CollectionKey;
  * The mapping is derived from the `values` property of the `TypeOptions` type.
  */
 type KeyValueMapping = {
-    [TKey in keyof TypeOptions['values'] as TKey extends CollectionKeyBase
-        ? `${TKey}${string}`
-        : TKey]: TypeOptions['values'][TKey];
+    [TKey in keyof TypeOptions['values'] as TKey extends CollectionKeyBase ? `${TKey}${string}` : TKey]: TypeOptions['values'][TKey];
 };
 
 /**
@@ -182,15 +180,14 @@ type OnyxEntry<TOnyxValue> = TOnyxValue | null;
  */
 type OnyxCollection<TOnyxValue> = OnyxEntry<Record<string, TOnyxValue | null>>;
 
-export {
-    CollectionKey,
-    CollectionKeyBase,
-    CustomTypeOptions,
-    DeepRecord,
-    Key,
-    KeyValueMapping,
-    OnyxCollection,
-    OnyxEntry,
-    OnyxKey,
-    Selector,
+/**
+ * The `NullableProperties<T>` sets the values of all properties in `T` to be nullable (i.e., `| null`).
+ * It doesn't recurse into nested property values, this means it applies the nullability only to the top-level properties.
+ *
+ * @template T The type of the properties to convert to nullable properties.
+ */
+type NullableProperties<T> = {
+    [P in keyof T]: T[P] | null;
 };
+
+export {CollectionKey, CollectionKeyBase, CustomTypeOptions, DeepRecord, Key, KeyValueMapping, OnyxCollection, OnyxEntry, OnyxKey, Selector, NullableProperties as Nullable};


### PR DESCRIPTION
### Details

While migrating https://github.com/Expensify/App/pull/27355, I noticed that it's not possible to pass `null` to clear a value with `Onyx.merge()` in Typescript. This PR aims to fix that. 

Side note: I opened a discussion on [slack](https://expensify.slack.com/archives/C01GTK53T8Q/p1694688747559989) to show some inconsistency when using `null` in `Onyx.merge`.