### PR TITLE
Batch initial hydration

### DIFF
--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -679,10 +679,10 @@ function keyChanged(key, data, canUpdateSubscriber, notifyRegularSubscibers = tr
  * @param {Function} [mapping.callback]
  * @param {String} [mapping.selector]
  * @param {*|null} val
- * @param {String} matchedKey
- * @param {Boolean} batched
+ * @param {String|undefined} matchedKey
+ * @param {Boolean} isBatched
  */
-function sendDataToConnection(mapping, val, matchedKey, batched) {
+function sendDataToConnection(mapping, val, matchedKey, isBatched) {
     // If the mapping no longer exists then we should not send any data.
     // This means our subscriber disconnected or withOnyx wrapped component unmounted.
     if (!callbackToStateMapping[mapping.connectionID]) {
@@ -703,7 +703,7 @@ function sendDataToConnection(mapping, val, matchedKey, batched) {
         }
 
         PerformanceUtils.logSetStateCall(mapping, null, newData, 'sendDataToConnection');
-        if (batched) {
+        if (isBatched) {
             batchUpdates(() => {
                 mapping.withOnyxInstance.setWithOnyxState(mapping.statePropertyName, newData);
             });
@@ -814,7 +814,8 @@ function connect(mapping) {
             // since there are none matched. In withOnyx() we wait for all connected keys to return a value before rendering the child
             // component. This null value will be filtered out so that the connected component can utilize defaultProps.
             if (matchingKeys.length === 0) {
-                // Here we cannot use batching because the null value is expected to be set immediately so that default props work.
+                // Here we cannot use batching because the null value is expected to be set immediately for default props
+                // or they will be undefined.
                 sendDataToConnection(mapping, null, undefined, false);
                 return;
             }

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -49,6 +49,47 @@ let defaultKeyStates = {};
 // Connections can be made before `Onyx.init`. They would wait for this task before resolving
 const deferredInitTask = createDeferredTask();
 
+let batchUpdatesPromise = null;
+let batchUpdatesQueue = [];
+
+/**
+ * We are batching together onyx updates. This helps with use cases where we schedule onyx updates after each other.
+ * This happens for example in the Onyx.update function, where we process API responses that might contain a lot of
+ * update operations. Instead of calling the subscribers for each update operation, we batch them together which will
+ * cause react to schedule the updates at once instead of after each other. This is mainly a performance optimization.
+ * @returns {Promise}
+ */
+function maybeFlushBatchUpdates() {
+    if (batchUpdatesPromise) {
+        return batchUpdatesPromise;
+    }
+
+    batchUpdatesPromise = new Promise((resolve) => {
+        /* We use (setTimeout, 0) here which should be called once native module calls are flushed (usually at the end of the frame)
+         * We may investigate if (setTimeout, 1) (which in React Native is equal to requestAnimationFrame) works even better
+         * then the batch will be flushed on next frame.
+         */
+        setTimeout(() => {
+            const updatesCopy = batchUpdatesQueue;
+            batchUpdatesQueue = [];
+            batchUpdatesPromise = null;
+            unstable_batchedUpdates(() => {
+                updatesCopy.forEach((applyUpdates) => {
+                    applyUpdates();
+                });
+            });
+
+            resolve();
+        }, 0);
+    });
+    return batchUpdatesPromise;
+}
+
+function batchUpdates(updates) {
+    batchUpdatesQueue.push(updates);
+    return maybeFlushBatchUpdates();
+}
+
 /**
  * Uses a selector function to return a simplified version of sourceData
  * @param {Mixed} sourceData
@@ -639,8 +680,9 @@ function keyChanged(key, data, canUpdateSubscriber, notifyRegularSubscibers = tr
  * @param {String} [mapping.selector]
  * @param {*|null} val
  * @param {String} matchedKey
+ * @param {Boolean} batched
  */
-function sendDataToConnection(mapping, val, matchedKey) {
+function sendDataToConnection(mapping, val, matchedKey, batched) {
     // If the mapping no longer exists then we should not send any data.
     // This means our subscriber disconnected or withOnyx wrapped component unmounted.
     if (!callbackToStateMapping[mapping.connectionID]) {
@@ -661,7 +703,13 @@ function sendDataToConnection(mapping, val, matchedKey) {
         }
 
         PerformanceUtils.logSetStateCall(mapping, null, newData, 'sendDataToConnection');
-        mapping.withOnyxInstance.setWithOnyxState(mapping.statePropertyName, newData);
+        if (batched) {
+            batchUpdates(() => {
+                mapping.withOnyxInstance.setWithOnyxState(mapping.statePropertyName, newData);
+            });
+        } else {
+            mapping.withOnyxInstance.setWithOnyxState(mapping.statePropertyName, newData);
+        }
         return;
     }
 
@@ -711,7 +759,7 @@ function getCollectionDataAndSendAsObject(matchingKeys, mapping) {
             finalObject[matchingKeys[i]] = value;
             return finalObject;
         }, {}))
-        .then(val => sendDataToConnection(mapping, val));
+        .then(val => sendDataToConnection(mapping, val, undefined, true));
 }
 
 /**
@@ -766,7 +814,7 @@ function connect(mapping) {
             // since there are none matched. In withOnyx() we wait for all connected keys to return a value before rendering the child
             // component. This null value will be filtered out so that the connected component can utilize defaultProps.
             if (matchingKeys.length === 0) {
-                sendDataToConnection(mapping, null);
+                sendDataToConnection(mapping, null, undefined, false);
                 return;
             }
 
@@ -782,13 +830,13 @@ function connect(mapping) {
 
                     // We did not opt into using waitForCollectionCallback mode so the callback is called for every matching key.
                     for (let i = 0; i < matchingKeys.length; i++) {
-                        get(matchingKeys[i]).then(val => sendDataToConnection(mapping, val, matchingKeys[i]));
+                        get(matchingKeys[i]).then(val => sendDataToConnection(mapping, val, matchingKeys[i], true));
                     }
                     return;
                 }
 
                 // If we are not subscribed to a collection key then there's only a single key to send an update for.
-                get(mapping.key).then(val => sendDataToConnection(mapping, val, mapping.key));
+                get(mapping.key).then(val => sendDataToConnection(mapping, val, mapping.key, true));
                 return;
             }
 
@@ -801,7 +849,7 @@ function connect(mapping) {
                 }
 
                 // If the subscriber is not using a collection key then we just send a single value back to the subscriber
-                get(mapping.key).then(val => sendDataToConnection(mapping, val, mapping.key));
+                get(mapping.key).then(val => sendDataToConnection(mapping, val, mapping.key, true));
                 return;
             }
 
@@ -833,47 +881,6 @@ function disconnect(connectionID, keyToRemoveFromEvictionBlocklist) {
     }
 
     delete callbackToStateMapping[connectionID];
-}
-
-let batchUpdatesPromise = null;
-let batchUpdatesQueue = [];
-
-/**
- * We are batching together onyx updates. This helps with use cases where we schedule onyx updates after each other.
- * This happens for example in the Onyx.update function, where we process API responses that might contain a lot of
- * update operations. Instead of calling the subscribers for each update operation, we batch them together which will
- * cause react to schedule the updates at once instead of after each other. This is mainly a performance optimization.
- * @returns {Promise}
- */
-function maybeFlushBatchUpdates() {
-    if (batchUpdatesPromise) {
-        return batchUpdatesPromise;
-    }
-
-    batchUpdatesPromise = new Promise((resolve) => {
-        /* We use (setTimeout, 0) here which should be called once native module calls are flushed (usually at the end of the frame)
-         * We may investigate if (setTimeout, 1) (which in React Native is equal to requestAnimationFrame) works even better
-         * then the batch will be flushed on next frame.
-         */
-        setTimeout(() => {
-            const updatesCopy = batchUpdatesQueue;
-            batchUpdatesQueue = [];
-            batchUpdatesPromise = null;
-            unstable_batchedUpdates(() => {
-                updatesCopy.forEach((applyUpdates) => {
-                    applyUpdates();
-                });
-            });
-
-            resolve();
-        }, 0);
-    });
-    return batchUpdatesPromise;
-}
-
-function batchUpdates(updates) {
-    batchUpdatesQueue.push(updates);
-    return maybeFlushBatchUpdates();
 }
 
 /**

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -814,6 +814,7 @@ function connect(mapping) {
             // since there are none matched. In withOnyx() we wait for all connected keys to return a value before rendering the child
             // component. This null value will be filtered out so that the connected component can utilize defaultProps.
             if (matchingKeys.length === 0) {
+                // Here we cannot use batching because the null value is expected to be set immediately so that default props work.
                 sendDataToConnection(mapping, null, undefined, false);
                 return;
             }

--- a/tests/unit/withOnyxTest.js
+++ b/tests/unit/withOnyxTest.js
@@ -215,8 +215,9 @@ describe('withOnyxTest', () => {
             .then(() => {
                 rerender(<TestComponentWithOnyx collectionID="2" />);
 
-                // Note, when we change the prop, we need to wait for the next tick:
-                return waitForPromisesToResolve();
+                // Note, when we change the prop, we need to wait for one tick for the
+                // component to update and one tick for batching.
+                return waitForPromisesToResolve().then(waitForPromisesToResolve);
             })
             .then(() => {
                 expect(getByTestId('text-element').props.children).toEqual('test_2');

--- a/tests/unit/withOnyxTest.js
+++ b/tests/unit/withOnyxTest.js
@@ -265,6 +265,7 @@ describe('withOnyxTest', () => {
                 )(ViewWithCollections);
                 render(<TestComponentWithOnyx markReadyForHydration={markReadyForHydration} onRender={onRender} />);
             })
+            .then(waitForPromisesToResolve)
             .then(() => {
                 expect(onRender).toHaveBeenLastCalledWith({
                     collections: {}, markReadyForHydration, onRender, testObject: {id: 1}, testThing: 'Test',


### PR DESCRIPTION
### Details

Batch the initial hydration with the same mechanism introduced in https://github.com/Expensify/react-native-onyx/pull/315. This is useful to make rendering of all connected components happen in the same batch. In this cases this reduces renders when opening a new chat in Expensify from ~100 to ~30.

### Related Issues

N/A

### Automated Tests

This doesn't really add new functionality, I just made sure the existing still pass.

### Linked PRs
N/A
