### PR TITLE
Use "set" in IDBKeyVal.mergeItem instead of duplicate merge logic

### DIFF
--- a/lib/storage/providers/IDBKeyVal.js
+++ b/lib/storage/providers/IDBKeyVal.js
@@ -70,7 +70,8 @@ const provider = {
      * @return {Promise<void>}
      */
     mergeItem(key, _changes, modifiedData) {
-        return provider.multiMerge([[key, modifiedData]]);
+        // Since Onyx also merged the existing value with the changes, we can just set the value directly
+        return provider.setItem(key, modifiedData);
     },
 
     /**


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

@marcaaron @tgolen 

### Details
<!-- Explanation of the change or anything fishy that is going on -->

Since in `Onyx.merge` we already read the existing value and merge it with the changes, we don't need to do that in `IDBKeyVal.mergeItem()` anymore. Therefore, we will simply use `IDBKeyVal.setItem()` directly. 

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/react-native-onyx/pull/333#issuecomment-1722726499

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->
