### PR TITLE
Make remove key O(log N) instead of O(N^2)

### DIFF
--- a/lib/OnyxCache.js
+++ b/lib/OnyxCache.js
@@ -181,9 +181,9 @@ class OnyxCache {
     removeLeastRecentlyUsedKeys() {
         while (this.recentKeys.size > this.maxRecentKeysSize) {
             const iterator = this.recentKeys.values();
-            const value = iterator.next().value
+            const value = iterator.next().value;
             if (value !== undefined) {
-                this.drop(value)
+                this.drop(value);
             }
         }
     }

--- a/lib/OnyxCache.js
+++ b/lib/OnyxCache.js
@@ -179,16 +179,13 @@ class OnyxCache {
      * Remove keys that don't fall into the range of recently used keys
      */
     removeLeastRecentlyUsedKeys() {
-        if (this.recentKeys.size <= this.maxRecentKeysSize) {
-            return;
+        while (this.recentKeys.size > this.maxRecentKeysSize) {
+            const iterator = this.recentKeys.values();
+            const value = iterator.next().value
+            if (value !== undefined) {
+                this.drop(value)
+            }
         }
-
-        // Get the last N keys by doing a negative slice
-        const recentlyAccessed = [...this.recentKeys].slice(-this.maxRecentKeysSize);
-        const storageKeys = _.keys(this.storageMap);
-        const keysToRemove = _.difference(storageKeys, recentlyAccessed);
-
-        _.each(keysToRemove, this.drop);
     }
 
     /**


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

I profiled app start with account provided by @danieldoglas. Turned out that remove key from cache takes O(n^2) where n is number of keys we have in cache which is set to 10k. The reason for that is that `_.difference(storageKeys, recentlyAccessed);` is quadratic. It calls filter method and pass there lambda that calls contains. 
https://github.com/jashkenas/underscore/blob/d12221366eacbb63e37cff328bed475f34ebe083/modules/difference.js#L8
<img width="601" alt="Screenshot 2023-09-22 at 10 55 53" src="https://github.com/Expensify/react-native-onyx/assets/12784455/79ce8461-68d0-423a-89f0-c95f5dc7503d">


Instead we now make use of BTS structure which set is and nice property that we can access first element in O(log n) time. 
<img width="358" alt="Screenshot 2023-09-22 at 10 58 27" src="https://github.com/Expensify/react-native-onyx/assets/12784455/80d8df6a-0883-45ce-ac09-96613ede700c">
Before ^
<img width="329" alt="Screenshot 2023-09-22 at 10 58 49" src="https://github.com/Expensify/react-native-onyx/assets/12784455/448a80f9-8715-4b5c-8147-adde8f8163c0">
After ^
### Details


<!-- Explanation of the change or anything fishy that is going on -->

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->
