### PR TITLE
Fix getAllKeys when keys are removed from cache

### DIFF
--- a/lib/OnyxCache.js
+++ b/lib/OnyxCache.js
@@ -183,7 +183,8 @@ class OnyxCache {
             const iterator = this.recentKeys.values();
             const value = iterator.next().value;
             if (value !== undefined) {
-                this.drop(value);
+                delete this.storageMap[value];
+                this.recentKeys.delete(value);
             }
         }
     }

--- a/tests/unit/onyxCacheTest.js
+++ b/tests/unit/onyxCacheTest.js
@@ -647,6 +647,9 @@ describe('Onyx', () => {
                     expect(cache.hasCacheForKey('key2')).toBe(true);
                     expect(cache.hasCacheForKey('key3')).toBe(true);
                     expect(cache.hasCacheForKey('key4')).toBe(true);
+
+                    // getAllKeys should still return all keys since they exist in storage.
+                    expect(cache.getAllKeys().length).toEqual(9);
                 });
         });
     });


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details

When testing an account with a very large amount of chats we hit an issue where onyx will return undefined for an item that actually exists in storage. This is because that item was evicted from Onyx cache.

When items are evicted from cache we should not delete the key in `storageKeys` since this is used to determine if the item exists in storage.

Onyx uses that value to get all keys as soon as it has some items (https://github.com/Expensify/react-native-onyx/blob/main/lib/Onyx.js#L115). This means `getAllKeys` from cache needs to return all keys in Storage, not keys currently cached.

### Related Issues
N/A

### Automated Tests

Updated a test to add a check for getAllKeys after keys are evicted from cache.

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->
