### PR TITLE
Don't recreate iterator every time

### DIFF
--- a/lib/OnyxCache.js
+++ b/lib/OnyxCache.js
@@ -179,18 +179,16 @@ class OnyxCache {
      * Remove keys that don't fall into the range of recently used keys
      */
     removeLeastRecentlyUsedKeys() {
-        let toRemove = this.recentKeys.size - this.maxRecentKeysSize;
-        if (toRemove <= 0) {
+        let numKeysToRemove = this.recentKeys.size - this.maxRecentKeysSize;
+        if (numKeysToRemove <= 0) {
             return;
         }
         const iterator = this.recentKeys.values();
         const temp = [];
-        while (toRemove > 0) {
+        while (numKeysToRemove > 0) {
             const value = iterator.next().value;
-            if (value !== undefined) {
-                temp.push(value);
-            }
-            toRemove--;
+            temp.push(value);
+            numKeysToRemove--;
         }
 
         for (let i = 0; i < temp.length; ++i) {

--- a/lib/OnyxCache.js
+++ b/lib/OnyxCache.js
@@ -179,12 +179,23 @@ class OnyxCache {
      * Remove keys that don't fall into the range of recently used keys
      */
     removeLeastRecentlyUsedKeys() {
-        while (this.recentKeys.size > this.maxRecentKeysSize) {
-            const iterator = this.recentKeys.values();
+        let toRemove = this.recentKeys.size - this.maxRecentKeysSize;
+        if (toRemove <= 0) {
+            return;
+        }
+        const iterator = this.recentKeys.values();
+        const temp = [];
+        while (toRemove > 0) {
             const value = iterator.next().value;
             if (value !== undefined) {
-                this.drop(value);
+                temp.push(value);
             }
+            toRemove--;
+        }
+
+        for (let i = 0; i < temp.length; ++i) {
+            delete this.storageMap[temp[i]];
+            this.recentKeys.delete(temp[i]);
         }
     }
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

Turned out that during chat switching we have cases when we remove several items at the same time. 
In those cases we don't want to recreate iterator. 

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->
