### PR TITLE
Use fast path when we ask for just one key in Connect()

### DIFF
--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -755,8 +755,12 @@ function connect(mapping) {
     deferredInitTask.promise
         .then(() => addKeyToRecentlyAccessedIfNeeded(mapping))
         .then(() => {
-            if (typeof mapping?.key === 'string' && !(mapping?.key.endsWith('_')) && cache.storageKeys.has(mapping?.key)) {
-                return [mapping.key]
+            if (Boolean(mapping.key)
+                && typeof mapping.key === 'string'
+                && !(mapping.key.endsWith('_'))
+                && cache.storageKeys.has(mapping.key)
+            ) {
+                return [mapping.key];
             }
             return getAllKeys();
         })

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -755,6 +755,9 @@ function connect(mapping) {
     deferredInitTask.promise
         .then(() => addKeyToRecentlyAccessedIfNeeded(mapping))
         .then(() => {
+            // Performance improvement
+            // If the mapping is connected to an onyx key that is not a collection
+            // we can skip the call to getAllKeys() and return an array with a single item
             if (Boolean(mapping.key)
                 && typeof mapping.key === 'string'
                 && !(mapping.key.endsWith('_'))

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -754,7 +754,12 @@ function connect(mapping) {
     // Commit connection only after init passes
     deferredInitTask.promise
         .then(() => addKeyToRecentlyAccessedIfNeeded(mapping))
-        .then(getAllKeys)
+        .then(() => {
+            if (typeof mapping?.key === 'string' && !(mapping?.key.endsWith('_')) && cache.storageKeys.has(mapping?.key)) {
+                return [mapping.key]
+            }
+            return getAllKeys();
+        })
         .then((keys) => {
             // We search all the keys in storage to see if any are a "match" for the subscriber we are connecting so that we
             // can send data back to the subscriber. Note that multiple keys can match as a subscriber could either be


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->
We found out that getAllKeys can be extremely slow as it's used very frequently and it just copies keys from cache to just created array. Because on heavy account number of keys can easily reach 50k that takes quite some time. 
In most of the cases we only ask for one keys so to speed it up we just check if it's in the set of keys if it is then we return array with just this item. 
### Details
<!-- Explanation of the change or anything fishy that is going on -->


### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->
