### PR TITLE
Propagate merge events across tabs

### DIFF
--- a/lib/storage/WebStorage.js
+++ b/lib/storage/WebStorage.js
@@ -40,6 +40,9 @@ const webStorage = {
         this.removeItems = keys => Storage.removeItems(keys)
             .then(() => raiseStorageSyncManyKeysEvent(keys));
 
+        this.mergeItem = (key, batchedChanges, modifiedData) => Storage.mergeItem(key, batchedChanges, modifiedData)
+            .then(() => raiseStorageSyncEvent(key));
+
         // If we just call Storage.clear other tabs will have no idea which keys were available previously
         // so that they can call keysChanged for them. That's why we iterate over every key and raise a storage sync
         // event for each one


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

There is currently [a bug](https://github.com/Expensify/App/issues/26190) with data propagation across tabs. After some debugging I found out that `merge` events are not propagated across tabs. This fixes the issue, but not sure if it is the correct solution, since it will propagate all merge events across tabs, which might increase the loads on the pages. A review is required.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/App/issues/26190

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->
