### PR TITLE
Fix race condition when tempState is deleted before loading flag is set to false

### DIFF
--- a/lib/withOnyx.js
+++ b/lib/withOnyx.js
@@ -146,7 +146,11 @@ export default function (mapOnyxToState, shouldDelayUpdates = false) {
                 const prevValue = this.state[statePropertyName];
 
                 // If the component is not loading (read "mounting"), then we can just update the state
-                if (!this.state.loading) {
+                // There is a small race condition here. On line 172 the setState is used with a callback
+                // and setState is an async operation anyways but we already delete tempState on line 170
+                // Therefore there is a small window of time where it is possible that loading is false but tempState is undefined
+                // therefore line 163 will fail when trying to set the property
+                if (!this.state.loading || !this.tempState) {
                     // Performance optimization, do not trigger update with same values
                     if (prevValue === val || utils.areObjectsEmpty(prevValue, val)) {
                         return;

--- a/lib/withOnyx.js
+++ b/lib/withOnyx.js
@@ -146,10 +146,12 @@ export default function (mapOnyxToState, shouldDelayUpdates = false) {
                 const prevValue = this.state[statePropertyName];
 
                 // If the component is not loading (read "mounting"), then we can just update the state
-                // There is a small race condition here. On line 172 the setState is used with a callback
-                // and setState is an async operation anyways but we already delete tempState on line 170
-                // Therefore there is a small window of time where it is possible that loading is false but tempState is undefined
-                // therefore line 163 will fail when trying to set the property
+                // There is a small race condition.
+                // When calling setWithOnyxState we delete the tempState object that is used to hold temporary state updates while the HOC is gathering data.
+                // However the loading flag is only set on the setState callback down below. setState however is an async operation that is also batched,
+                // therefore there is a small window of time where the loading flag is not false but the tempState is already gone
+                // (while the update is queued and waiting to be applied).
+                // This simply bypasses the loading check if the tempState is gone and the update can be safely queued with a normal setStateProxy.
                 if (!this.state.loading || !this.tempState) {
                     // Performance optimization, do not trigger update with same values
                     if (prevValue === val || utils.areObjectsEmpty(prevValue, val)) {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
There is a small race condition. When calling setWithOnyxState we delete the `tempState` object that is used to hold temporary state updates while the HOC is gathering data. However the loading flag is only set on the `setState` callback down below. setState however is an async operation that is also batched, therefore there is a small window of time where the loading flag is not false but the tempState is already gone (while the update is queued and waiting to be applied). This simply bypasses the loading check if the tempState is gone and the update can be safely queued with a normal `setStateProxy`.


### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK https://github.com/Expensify/App/issues/28419

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->
