### PR TITLE
[TS] Allow deep null values on merge operations

### DIFF
--- a/lib/Onyx.d.ts
+++ b/lib/Onyx.d.ts
@@ -1,7 +1,6 @@
 import {Component} from 'react';
-import {PartialDeep} from 'type-fest';
 import * as Logger from './Logger';
-import {CollectionKey, CollectionKeyBase, DeepRecord, KeyValueMapping, OnyxCollection, OnyxEntry, OnyxKey, NullableProperties} from './types';
+import {CollectionKey, CollectionKeyBase, DeepRecord, KeyValueMapping, NullishDeep, OnyxCollection, OnyxEntry, OnyxKey} from './types';
 
 /**
  * Represents a mapping object where each `OnyxKey` maps to either a value of its corresponding type in `KeyValueMapping` or `null`.
@@ -79,14 +78,14 @@ type OnyxUpdate =
               | {
                     onyxMethod: typeof METHOD.MERGE;
                     key: TKey;
-                    value: PartialDeep<KeyValueMapping[TKey]>;
+                    value: NullishDeep<KeyValueMapping[TKey]>;
                 };
       }[OnyxKey]
     | {
           [TKey in CollectionKeyBase]: {
               onyxMethod: typeof METHOD.MERGE_COLLECTION;
               key: TKey;
-              value: Record<`${TKey}${string}`, PartialDeep<KeyValueMapping[TKey]>>;
+              value: Record<`${TKey}${string}`, NullishDeep<KeyValueMapping[TKey]>>;
           };
       }[CollectionKeyBase];
 
@@ -202,7 +201,7 @@ declare function multiSet(data: Partial<NullableKeyValueMapping>): Promise<void>
  * @param key ONYXKEYS key
  * @param value Object or Array value to merge
  */
-declare function merge<TKey extends OnyxKey>(key: TKey, value: NullableProperties<PartialDeep<KeyValueMapping[TKey]>>): Promise<void>;
+declare function merge<TKey extends OnyxKey>(key: TKey, value: NullishDeep<KeyValueMapping[TKey]>): Promise<void>;
 
 /**
  * Clear out all the data in the store
@@ -246,7 +245,7 @@ declare function clear(keysToPreserve?: OnyxKey[]): Promise<void>;
  */
 declare function mergeCollection<TKey extends CollectionKeyBase, TMap>(
     collectionKey: TKey,
-    collection: Collection<TKey, TMap, PartialDeep<KeyValueMapping[TKey]>>,
+    collection: Collection<TKey, TMap, NullishDeep<KeyValueMapping[TKey]>>,
 ): Promise<void>;
 
 /**

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -1,10 +1,13 @@
 import {Merge} from 'type-fest';
+import {BuiltIns} from 'type-fest/source/internal';
 
 /**
  * Represents a deeply nested record. It maps keys to values,
  * and those values can either be of type `TValue` or further nested `DeepRecord` instances.
  */
-type DeepRecord<TKey extends string | number | symbol, TValue> = {[key: string]: TValue | DeepRecord<TKey, TValue>};
+type DeepRecord<TKey extends string | number | symbol, TValue> = {
+    [key: string]: TValue | DeepRecord<TKey, TValue>;
+};
 
 /**
  * Represents type options to configure all Onyx methods.
@@ -180,14 +183,42 @@ type OnyxEntry<TOnyxValue> = TOnyxValue | null;
  */
 type OnyxCollection<TOnyxValue> = OnyxEntry<Record<string, TOnyxValue | null>>;
 
+type NonTransformableTypes =
+    | BuiltIns
+    | ((...args: any[]) => unknown)
+    | Map<unknown, unknown>
+    | Set<unknown>
+    | ReadonlyMap<unknown, unknown>
+    | ReadonlySet<unknown>
+    | unknown[]
+    | readonly unknown[];
+
 /**
- * The `NullableProperties<T>` sets the values of all properties in `T` to be nullable (i.e., `| null`).
- * It doesn't recurse into nested property values, this means it applies the nullability only to the top-level properties.
+ * Create a type from another type with all keys and nested keys set to optional or null.
  *
- * @template T The type of the properties to convert to nullable properties.
+ * @example
+ * const settings: Settings = {
+ *	 textEditor: {
+ *	 	fontSize: 14;
+ *	 	fontColor: '#000000';
+ *	 	fontWeight: 400;
+ *	 }
+ *	 autosave: true;
+ * };
+ *
+ * const applySavedSettings = (savedSettings: NullishDeep<Settings>) => {
+ * 	 return {...settings, ...savedSettings};
+ * }
+ *
+ * settings = applySavedSettings({textEditor: {fontWeight: 500, fontColor: null}});
  */
-type NullableProperties<T> = {
-    [P in keyof T]: T[P] | null;
+type NullishDeep<T> = T extends NonTransformableTypes ? T : T extends object ? NullishObjectDeep<T> : unknown;
+
+/**
+Same as `NullishDeep`, but accepts only `object`s as inputs. Internal helper for `NullishDeep`.
+*/
+type NullishObjectDeep<ObjectType extends object> = {
+    [KeyType in keyof ObjectType]?: NullishDeep<ObjectType[KeyType]> | null;
 };
 
 export {
@@ -201,5 +232,5 @@ export {
     OnyxEntry,
     OnyxKey,
     Selector,
-    NullableProperties,
+    NullishDeep,
 };


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details

This PR fix the typings related to `merge` operations to allow setting `null` to deep properties inside the object. Currently this is blocking several TS PRs. They were fixed on [this PR](https://github.com/Expensify/react-native-onyx/pull/353) but it [got reverted](https://github.com/Expensify/react-native-onyx/pull/378), so I created a separate one.

cc @blazejkustra 

### Related Issues

### Automated Tests

### Linked PRs

- https://github.com/Expensify/App/pull/28316
- https://github.com/Expensify/App/pull/27652
- https://github.com/Expensify/App/pull/28269
- https://github.com/Expensify/App/issues/24884
- https://github.com/Expensify/App/issues/24918
- https://github.com/Expensify/App/pull/28031