### PR TITLE
Fix concurrent writes in the update operation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ dist/
 
 # IDEs
 .idea
+.vscode
 
 # Decrypted private key we do not want to commit
 .github/OSBotify-private-key.asc

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -1392,6 +1392,28 @@ function mergeCollection(collectionKey, collection) {
         });
 }
 
+function innerUpdate(data) {
+    if (data.length === 0) {
+        return Promise.resolve();
+    }
+
+    const {onyxMethod, key, value} = data.shift();
+    switch (onyxMethod) {
+        case METHOD.SET:
+            return set(key, value).then(() => innerUpdate(data));
+        case METHOD.MERGE:
+            return merge(key, value).then(() => innerUpdate(data));
+        case METHOD.MERGE_COLLECTION:
+            return mergeCollection(key, value).then(() => innerUpdate(data));
+        case METHOD.MULTI_SET:
+            return multiSet(value).then(() => innerUpdate(data));
+        case METHOD.CLEAR:
+            return clear().then(() => innerUpdate(data));
+        default:
+            return Promise.resolve();
+    }
+}
+
 /**
  * Insert API responses and lifecycle data into Onyx
  *
@@ -1414,32 +1436,7 @@ function update(data) {
         }
     });
 
-    const promises = [];
-    let clearPromise = Promise.resolve();
-
-    _.each(data, ({onyxMethod, key, value}) => {
-        switch (onyxMethod) {
-            case METHOD.SET:
-                promises.push(() => set(key, value));
-                break;
-            case METHOD.MERGE:
-                promises.push(() => merge(key, value));
-                break;
-            case METHOD.MERGE_COLLECTION:
-                promises.push(() => mergeCollection(key, value));
-                break;
-            case METHOD.MULTI_SET:
-                promises.push(() => multiSet(value));
-                break;
-            case METHOD.CLEAR:
-                clearPromise = clear();
-                break;
-            default:
-                break;
-        }
-    });
-
-    return clearPromise.then(() => Promise.all(_.map(promises, p => p())));
+    return innerUpdate(data);
 }
 
 /**
@@ -1534,6 +1531,7 @@ const Onyx = {
     connect,
     disconnect,
     set,
+    get,
     multiSet,
     merge,
     mergeCollection,

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -1392,6 +1392,12 @@ function mergeCollection(collectionKey, collection) {
         });
 }
 
+/**
+ * Internal recursive function to execute the functions in the correct order
+ *
+ * @param {Array} data An array of objects with shape {onyxMethod: oneOf('set', 'merge', 'mergeCollection', 'multiSet', 'clear'), key: string, value: *}
+ * @returns {Promise<Void>}
+ */
 function innerUpdate(data) {
     if (data.length === 0) {
         return Promise.resolve();
@@ -1430,8 +1436,9 @@ function innerUpdate(data) {
  */
 function update(data) {
     // First, validate the Onyx object is in the format we expect
+    const validMethods = [METHOD.CLEAR, METHOD.SET, METHOD.MERGE, METHOD.MERGE_COLLECTION, METHOD.MULTI_SET];
     _.each(data, ({onyxMethod, key, value}) => {
-        if (!_.contains([METHOD.CLEAR, METHOD.SET, METHOD.MERGE, METHOD.MERGE_COLLECTION, METHOD.MULTI_SET], onyxMethod)) {
+        if (!_.contains(validMethods, onyxMethod)) {
             throw new Error(`Invalid onyxMethod ${onyxMethod} in Onyx update.`);
         }
         if (onyxMethod === METHOD.MULTI_SET) {
@@ -1443,6 +1450,9 @@ function update(data) {
             throw new Error(`Invalid ${typeof key} key provided in Onyx update. Onyx key must be of type string.`);
         }
     });
+
+    // Put clear operation on top
+    data.sort(a => (a.onyxMethod === METHOD.CLEAR ? -1 : 1));
 
     return innerUpdate(data);
 }

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -1539,7 +1539,6 @@ const Onyx = {
     connect,
     disconnect,
     set,
-    get,
     multiSet,
     merge,
     mergeCollection,

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -1398,20 +1398,28 @@ function innerUpdate(data) {
     }
 
     const {onyxMethod, key, value} = data.shift();
+    let promise = Promise.resolve();
     switch (onyxMethod) {
         case METHOD.SET:
-            return set(key, value).then(() => innerUpdate(data));
+            promise = set(key, value);
+            break;
         case METHOD.MERGE:
-            return merge(key, value).then(() => innerUpdate(data));
+            promise = merge(key, value);
+            break;
         case METHOD.MERGE_COLLECTION:
-            return mergeCollection(key, value).then(() => innerUpdate(data));
+            promise = mergeCollection(key, value);
+            break;
         case METHOD.MULTI_SET:
-            return multiSet(value).then(() => innerUpdate(data));
+            promise = multiSet(value);
+            break;
         case METHOD.CLEAR:
-            return clear().then(() => innerUpdate(data));
+            promise = clear();
+            break;
         default:
-            return Promise.resolve();
+            break;
     }
+
+    return promise.then(() => innerUpdate(data));
 }
 
 /**

--- a/tests/unit/onyxTest.js
+++ b/tests/unit/onyxTest.js
@@ -899,9 +899,9 @@ describe('Onyx', () => {
             {onyxMethod: Onyx.METHOD.MERGE_COLLECTION, key: ONYX_KEYS.COLLECTION.TEST_UPDATE, value: {[itemKey]: {a: 'a'}}},
         ])
             .then(() => {
-                expect(collectionCallback).toHaveBeenNthCalledWith(1, {[itemKey]: {a: 'a'}});
-                expect(testCallback).toHaveBeenNthCalledWith(1, 'taco', ONYX_KEYS.TEST_KEY);
-                expect(otherTestCallback).toHaveBeenNthCalledWith(1, 'pizza', ONYX_KEYS.OTHER_TEST);
+                expect(collectionCallback).toHaveBeenNthCalledWith(2, {[itemKey]: {a: 'a'}});
+                expect(testCallback).toHaveBeenNthCalledWith(2, 'taco', ONYX_KEYS.TEST_KEY);
+                expect(otherTestCallback).toHaveBeenNthCalledWith(2, 'pizza', ONYX_KEYS.OTHER_TEST);
                 Onyx.disconnect(connectionIDs);
             });
     });
@@ -958,6 +958,43 @@ describe('Onyx', () => {
                     test2: 'test2',
                     test3: 'test3',
                 });
+            });
+    });
+
+    it('should write data in order', () => {
+        const key = `${ONYX_KEYS.TEST_KEY}123`
+        connectionID = Onyx.connect({
+            key,
+            initWithStoredValues: false,
+            callback: () => null,
+        });
+
+        return waitForPromisesToResolve()
+            .then(() => {
+                // Given the initial Onyx state: {test: true, otherTest: {test1: 'test1'}}
+                Onyx.set(key, true);
+                return waitForPromisesToResolve();
+            })
+            .then(() => Onyx.update([
+                {
+                    onyxMethod: 'set',
+                    key,
+                    value: 'one',
+                },
+                {
+                    onyxMethod: 'merge',
+                    key,
+                    value: 'two',
+                },
+                {
+                    onyxMethod: 'set',
+                    key,
+                    value: 'three',
+                },
+            ]))
+            .then(() => Onyx.get(key))
+            .then((value) => {
+                expect(value).toBe('three');
             });
     });
 });

--- a/tests/unit/onyxTest.js
+++ b/tests/unit/onyxTest.js
@@ -997,4 +997,32 @@ describe('Onyx', () => {
                 expect(value).toBe('three');
             });
     });
+
+    it('should persist data in the correct order', () => {
+        const key = `${ONYX_KEYS.TEST_KEY}123`;
+        const callback = jest.fn();
+        connectionID = Onyx.connect({
+            key,
+            initWithStoredValues: false,
+            callback,
+        });
+
+        return waitForPromisesToResolve()
+            .then(() => Onyx.update([
+                {
+                    onyxMethod: 'set',
+                    key,
+                    value: 'one',
+                },
+                {
+                    onyxMethod: 'clear',
+                },
+
+            ]))
+            .then(() => Storage.getItem(key))
+            .then((value) => {
+                expect(callback).toHaveBeenNthCalledWith(1, 'one', key);
+                expect(value).toBe('one');
+            });
+    });
 });

--- a/tests/unit/onyxTest.js
+++ b/tests/unit/onyxTest.js
@@ -962,7 +962,7 @@ describe('Onyx', () => {
     });
 
     it('should write data in order', () => {
-        const key = `${ONYX_KEYS.TEST_KEY}123`
+        const key = `${ONYX_KEYS.TEST_KEY}123`;
         connectionID = Onyx.connect({
             key,
             initWithStoredValues: false,


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
The update operation was written in such manner that it fired all database operations at once. Some of the operations internally rely on other promises, meaning they will get re-scheduled on another tick. This causes unpredictable behavior as you cannot guarantee the order of the operations. The solution is clear and is the only one, all DB writes must respect the order of the operations.

The incorrect ordering of the operations being committed to the DB causes other random behavior around the app as well. Linked the two issues.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/App/issues/28737
https://github.com/Expensify/App/pull/28584


### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
Added one more test that makes sure the correct data is persisted. It failed with the previous implementation, now it passes.

### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->
