### PR TITLE
Fix cache for missing keys and empty collections

### DIFF
--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -235,14 +235,14 @@ function tryGetCachedValue(key, mapping = {}) {
     let val = cache.getValue(key);
 
     if (isCollectionKey(key)) {
-        const allKeys = cache.getAllKeys();
+        const allCacheKeys = cache.getAllKeys();
 
         // It is possible we haven't loaded all keys yet so we do not know if the
         // collection actually exists.
-        if (allKeys.length === 0) {
+        if (allCacheKeys.length === 0) {
             return;
         }
-        const matchingKeys = _.filter(allKeys, k => k.startsWith(key));
+        const matchingKeys = _.filter(allCacheKeys, k => k.startsWith(key));
         const values = _.reduce(matchingKeys, (finalObject, matchedKey) => {
             const cachedValue = cache.getValue(matchedKey);
             if (cachedValue) {

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -236,6 +236,12 @@ function tryGetCachedValue(key, mapping = {}) {
 
     if (isCollectionKey(key)) {
         const allKeys = cache.getAllKeys();
+
+        // It is possible we haven't loaded all keys yet so we do not know if the
+        // collection actually exists.
+        if (allKeys.length === 0) {
+            return;
+        }
         const matchingKeys = _.filter(allKeys, k => k.startsWith(key));
         const values = _.reduce(matchingKeys, (finalObject, matchedKey) => {
             const cachedValue = cache.getValue(matchedKey);
@@ -246,9 +252,7 @@ function tryGetCachedValue(key, mapping = {}) {
             }
             return finalObject;
         }, {});
-        if (_.isEmpty(values)) {
-            return;
-        }
+
         val = values;
     }
 
@@ -826,6 +830,10 @@ function connect(mapping) {
             // since there are none matched. In withOnyx() we wait for all connected keys to return a value before rendering the child
             // component. This null value will be filtered out so that the connected component can utilize defaultProps.
             if (matchingKeys.length === 0) {
+                if (mapping.key && !isCollectionKey(mapping.key)) {
+                    cache.set(mapping.key, null);
+                }
+
                 // Here we cannot use batching because the null value is expected to be set immediately for default props
                 // or they will be undefined.
                 sendDataToConnection(mapping, null, undefined, false);

--- a/tests/components/ViewWithCollections.js
+++ b/tests/components/ViewWithCollections.js
@@ -29,6 +29,10 @@ const ViewWithCollections = React.forwardRef((props, ref) => {
 
     props.onRender(props);
 
+    if (_.size(props.collections) === 0) {
+        return <Text>empty</Text>;
+    }
+
     return (
         <View>
             {_.map(props.collections, (collection, i) => (

--- a/tests/components/ViewWithText.js
+++ b/tests/components/ViewWithText.js
@@ -4,12 +4,13 @@ import PropTypes from 'prop-types';
 import {View, Text} from 'react-native';
 
 const propTypes = {
-    text: PropTypes.string.isRequired,
+    text: PropTypes.string,
     onRender: PropTypes.func,
 };
 
 const defaultProps = {
     onRender: () => {},
+    text: null,
 };
 
 function ViewWithText(props) {
@@ -17,7 +18,7 @@ function ViewWithText(props) {
 
     return (
         <View>
-            <Text testID="text-element">{props.text}</Text>
+            <Text testID="text-element">{props.text || 'null'}</Text>
         </View>
     );
 }

--- a/tests/unit/withOnyxTest.js
+++ b/tests/unit/withOnyxTest.js
@@ -6,6 +6,7 @@ import ViewWithText from '../components/ViewWithText';
 import ViewWithCollections from '../components/ViewWithCollections';
 import waitForPromisesToResolve from '../utils/waitForPromisesToResolve';
 import ViewWithObject from '../components/ViewWithObject';
+import StorageMock from '../../lib/storage';
 
 const ONYX_KEYS = {
     TEST_KEY: 'test',
@@ -520,6 +521,100 @@ describe('withOnyxTest', () => {
                 // Component still has not updated
                 expect(onRender).toHaveBeenCalledTimes(4);
                 expect(onRender.mock.calls[3][0].simple).toBe('long_string');
+            });
+    });
+
+    it('should render immediately when a onyx component is mounted a 2nd time', () => {
+        const TestComponentWithOnyx = withOnyx({
+            text: {
+                key: ONYX_KEYS.TEST_KEY,
+            },
+        })(ViewWithText);
+        const onRender = jest.fn();
+        let renderResult;
+
+        // Set the value in storage, but not in cache.
+        return StorageMock.setItem(ONYX_KEYS.TEST_KEY, 'test1')
+            .then(() => {
+                renderResult = render(<TestComponentWithOnyx onRender={onRender} />);
+
+                // The component should not render initially since we have no data in cache.
+                expect(onRender).not.toHaveBeenCalled();
+                return waitForPromisesToResolve();
+            })
+            .then(waitForPromisesToResolve)
+            .then(() => {
+                let textComponent = renderResult.getByText('test1');
+                expect(textComponent).not.toBeNull();
+                expect(onRender).toHaveBeenCalledTimes(1);
+
+                // Unmount the component and mount it again. It should now render immediately.
+                renderResult.unmount();
+                renderResult = render(<TestComponentWithOnyx onRender={onRender} />);
+
+                textComponent = renderResult.getByText('test1');
+                expect(textComponent).not.toBeNull();
+                expect(onRender).toHaveBeenCalledTimes(2);
+            });
+    });
+
+    it('should cache missing keys', () => {
+        const TestComponentWithOnyx = withOnyx({
+            text: {
+                key: ONYX_KEYS.TEST_KEY,
+            },
+        })(ViewWithText);
+        const onRender = jest.fn();
+
+        // Render with a key that doesn't exist in cache or storage.
+        let renderResult = render(<TestComponentWithOnyx onRender={onRender} />);
+
+        // The component should not render initially since we have no data in cache.
+        expect(onRender).not.toHaveBeenCalled();
+        return waitForPromisesToResolve().then(() => {
+            let textComponent = renderResult.getByText('null');
+            expect(textComponent).not.toBeNull();
+            expect(onRender).toHaveBeenCalledTimes(1);
+
+            // Unmount the component and mount it again. It should now render immediately.
+            renderResult.unmount();
+            renderResult = render(<TestComponentWithOnyx onRender={onRender} />);
+            textComponent = renderResult.getByText('null');
+            expect(textComponent).not.toBeNull();
+            expect(onRender).toHaveBeenCalledTimes(2);
+        });
+    });
+
+    it('should cache empty collections', () => {
+        const TestComponentWithOnyx = withOnyx({
+            text: {
+                key: ONYX_KEYS.COLLECTION.TEST_KEY,
+            },
+        })(ViewWithCollections);
+        const onRender = jest.fn();
+        let renderResult;
+
+        return StorageMock.setItem(ONYX_KEYS.SIMPLE_KEY, 'simple')
+            .then(() => {
+                // Render with a collection that doesn't exist in cache or storage.
+                renderResult = render(<TestComponentWithOnyx onRender={onRender} />);
+
+                // The component should not render initially since we have no data in cache.
+                expect(onRender).not.toHaveBeenCalled();
+
+                return waitForPromisesToResolve();
+            })
+            .then(() => {
+                let textComponent = renderResult.getByText('empty');
+                expect(textComponent).not.toBeNull();
+                expect(onRender).toHaveBeenCalledTimes(1);
+
+                // Unmount the component and mount it again. It should now render immediately.
+                renderResult.unmount();
+                renderResult = render(<TestComponentWithOnyx onRender={onRender} />);
+                textComponent = renderResult.getByText('empty');
+                expect(textComponent).not.toBeNull();
+                expect(onRender).toHaveBeenCalledTimes(2);
             });
     });
 });

--- a/tests/unit/withOnyxTest.js
+++ b/tests/unit/withOnyxTest.js
@@ -539,6 +539,8 @@ describe('withOnyxTest', () => {
                 renderResult = render(<TestComponentWithOnyx onRender={onRender} />);
 
                 // The component should not render initially since we have no data in cache.
+                // Use `waitForPromisesToResolve` before making the assertions and make sure
+                // onRender was not called.
                 expect(onRender).not.toHaveBeenCalled();
                 return waitForPromisesToResolve();
             })
@@ -549,6 +551,8 @@ describe('withOnyxTest', () => {
                 expect(onRender).toHaveBeenCalledTimes(1);
 
                 // Unmount the component and mount it again. It should now render immediately.
+                // Do not use `waitForPromisesToResolve` before making the assertions and make sure
+                // onRender was called.
                 renderResult.unmount();
                 renderResult = render(<TestComponentWithOnyx onRender={onRender} />);
 
@@ -570,6 +574,8 @@ describe('withOnyxTest', () => {
         let renderResult = render(<TestComponentWithOnyx onRender={onRender} />);
 
         // The component should not render initially since we have no data in cache.
+        // Use `waitForPromisesToResolve` before making the assertions and make sure
+        // onRender was not called.
         expect(onRender).not.toHaveBeenCalled();
         return waitForPromisesToResolve().then(() => {
             let textComponent = renderResult.getByText('null');
@@ -577,6 +583,8 @@ describe('withOnyxTest', () => {
             expect(onRender).toHaveBeenCalledTimes(1);
 
             // Unmount the component and mount it again. It should now render immediately.
+            // Do not use `waitForPromisesToResolve` before making the assertions and make sure
+            // onRender was called.
             renderResult.unmount();
             renderResult = render(<TestComponentWithOnyx onRender={onRender} />);
             textComponent = renderResult.getByText('null');
@@ -594,12 +602,16 @@ describe('withOnyxTest', () => {
         const onRender = jest.fn();
         let renderResult;
 
+        // Set a random item in storage since Onyx will only think keys are loaded
+        // in cache if there are at least one key.
         return StorageMock.setItem(ONYX_KEYS.SIMPLE_KEY, 'simple')
             .then(() => {
                 // Render with a collection that doesn't exist in cache or storage.
                 renderResult = render(<TestComponentWithOnyx onRender={onRender} />);
 
                 // The component should not render initially since we have no data in cache.
+                // Use `waitForPromisesToResolve` before making the assertions and make sure
+                // onRender was not called.
                 expect(onRender).not.toHaveBeenCalled();
 
                 return waitForPromisesToResolve();
@@ -610,6 +622,8 @@ describe('withOnyxTest', () => {
                 expect(onRender).toHaveBeenCalledTimes(1);
 
                 // Unmount the component and mount it again. It should now render immediately.
+                // Do not use `waitForPromisesToResolve` before making the assertions and make sure
+                // onRender was called.
                 renderResult.unmount();
                 renderResult = render(<TestComponentWithOnyx onRender={onRender} />);
                 textComponent = renderResult.getByText('empty');


### PR DESCRIPTION
### Details

I found 2 cases where onyx component do not properly cache their data and cause it to be fetched from storage every time it mounts, even if it mounted before.

The first case is when the key does not exist in storage. In that case we never end up calling the `get` function and just send null to the connection. This means that we never cache that this key doesn't exist. To fix that we can manually set null in the cache for this code path.

The 2nd case is when we have an empty collection. Currently `tryGetCachedValue` always returns `undefined` when the collection is empty, but we always have all keys available so it is safe to just return an empty collection in that case. The only case where we don't have all keys is if we never called `getAllKeys` before and in that case `cache.getAllKeys` will be empty, so that is the only case where we need to return `undefined`.

### Related Issues
N/A

Slack: https://expensify.slack.com/archives/C05LX9D6E07/p1696601323002289

### Automated Tests

This adds 3 tests to validate caching behavior of `withOnyx`. The first one validates a simple case of mounting and unmounting a component. The first time it mounts it should load data from storage and the 2nd time it should be able to synchronously render. This test already passes before these changes.

The 2nd and 3rd test validate behaviors fixed in the PR, missing keys and empty collections. It makes sure that they are also properly cached on remount.

### Manual Tests

I tested in expensify app by scrolling to the bottom of the chats list to make sure all data has been loaded in cache, then start profiling with react devtools and scroll back to the top of the list.

Before:

You can see a large number of small renders

<img width="508" alt="image" src="https://github.com/Expensify/react-native-onyx/assets/2677334/ee689c25-c380-4129-b386-ff143e667339">

They are caused by `loading` prop change, which should not happen since we already loaded that data.

<img width="313" alt="image" src="https://github.com/Expensify/react-native-onyx/assets/2677334/59f36a8d-d2f3-4d4b-9301-4633d5051459">

After:

Only a few bigger renders, seems like there is still an extra render for each chat cell because of a change to the personalDetails prop, we could investigate in a follow up.

<img width="472" alt="image" src="https://github.com/Expensify/react-native-onyx/assets/2677334/9641d124-bb55-4f56-b5f3-2c0fabbdbd1e">


Also manually tested the main app screens to make sure it doesn't cause any issues.

### Author Checklist

- [x] I linked the correct issue in the `### Related Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>

<img width="427" alt="image" src="https://github.com/Expensify/react-native-onyx/assets/2677334/c9839618-2a45-4a32-b37f-81be71ccab21">

</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

</details>
