### PR TITLE
Fix 

### DIFF
--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -235,14 +235,8 @@ function tryGetCachedValue(key, mapping = {}) {
     let val = cache.getValue(key);
 
     if (isCollectionKey(key)) {
-        const allCacheKeys = cache.getAllKeys();
-
-        // It is possible we haven't loaded all keys yet so we do not know if the
-        // collection actually exists.
-        if (allCacheKeys.length === 0) {
-            return;
-        }
-        const matchingKeys = _.filter(allCacheKeys, k => k.startsWith(key));
+        const allKeys = cache.getAllKeys();
+        const matchingKeys = _.filter(allKeys, k => k.startsWith(key));
         const values = _.reduce(matchingKeys, (finalObject, matchedKey) => {
             const cachedValue = cache.getValue(matchedKey);
             if (cachedValue) {
@@ -252,7 +246,9 @@ function tryGetCachedValue(key, mapping = {}) {
             }
             return finalObject;
         }, {});
-
+        if (_.isEmpty(values)) {
+            return;
+        }
         val = values;
     }
 
@@ -830,10 +826,6 @@ function connect(mapping) {
             // since there are none matched. In withOnyx() we wait for all connected keys to return a value before rendering the child
             // component. This null value will be filtered out so that the connected component can utilize defaultProps.
             if (matchingKeys.length === 0) {
-                if (mapping.key && !isCollectionKey(mapping.key)) {
-                    cache.set(mapping.key, null);
-                }
-
                 // Here we cannot use batching because the null value is expected to be set immediately for default props
                 // or they will be undefined.
                 sendDataToConnection(mapping, null, undefined, false);

--- a/lib/withOnyx.js
+++ b/lib/withOnyx.js
@@ -101,20 +101,21 @@ export default function (mapOnyxToState, shouldDelayUpdates = false) {
                 this.checkEvictableKeys();
             }
 
-            componentDidUpdate() {
+            componentDidUpdate(prevProps, prevState) {
                 // When the state is passed to the key functions with Str.result(), omit anything
                 // from state that was not part of the mapped keys.
-                const onyxDataFromState = getOnyxDataFromState(this.state, mapOnyxToState);
+                const previousOnyxDataFromState = getOnyxDataFromState(prevState, mapOnyxToState);
+                const currentOnyxDataFromState = getOnyxDataFromState(this.state, mapOnyxToState);
 
                 // If any of the mappings use data from the props, then when the props change, all the
                 // connections need to be reconnected with the new props
                 _.each(mapOnyxToState, (mapping, propName) => {
-                    const previousKey = mapping.previousKey;
-                    const newKey = Str.result(mapping.key, {...this.props, ...onyxDataFromState});
+                    const previousKey = Str.result(mapping.key, {...prevProps, ...previousOnyxDataFromState});
+                    const newKey = Str.result(mapping.key, {...this.props, ...currentOnyxDataFromState});
                     if (previousKey !== newKey) {
                         Onyx.disconnect(this.activeConnectionIDs[previousKey], previousKey);
                         delete this.activeConnectionIDs[previousKey];
-                        this.connectMappingToOnyx(mapping, propName);
+                        this.connectMappingToOnyx(mapping, propName, newKey);
                     }
                 });
                 this.checkEvictableKeys();
@@ -252,23 +253,13 @@ export default function (mapOnyxToState, shouldDelayUpdates = false) {
              * @param {string|function} mapping.key key to connect to. can be a string or a
              * function that takes this.props as an argument and returns a string
              * @param {string} statePropertyName the name of the state property that Onyx will add the data to
-             * @param {boolean} [mapping.initWithStoredValues] If set to false, then no data will be prefilled into the
-             *  component
+             * @param {string} [key] used to overwrite the mapping.key value which is used when when the props used to construct the key value have changed
              */
-            connectMappingToOnyx(mapping, statePropertyName) {
-                const key = Str.result(mapping.key, {...this.props, ...getOnyxDataFromState(this.state, mapOnyxToState)});
-
-                // Remember the previous key so that if it ever changes, the component will reconnect to Onyx
-                // in componentDidUpdate
-                if (statePropertyName !== 'initialValue' && mapOnyxToState[statePropertyName]) {
-                    // eslint-disable-next-line no-param-reassign
-                    mapOnyxToState[statePropertyName].previousKey = key;
-                }
-
+            connectMappingToOnyx(mapping, statePropertyName, key) {
                 // eslint-disable-next-line rulesdir/prefer-onyx-connect-in-libs
                 this.activeConnectionIDs[key] = Onyx.connect({
                     ...mapping,
-                    key,
+                    key: !_.isUndefined(key) ? key : Str.result(mapping.key, {...this.props, ...getOnyxDataFromState(this.state, mapOnyxToState)}),
                     statePropertyName,
                     withOnyxInstance: this,
                     displayName,

--- a/tests/components/ViewWithCollections.js
+++ b/tests/components/ViewWithCollections.js
@@ -29,10 +29,6 @@ const ViewWithCollections = React.forwardRef((props, ref) => {
 
     props.onRender(props);
 
-    if (_.size(props.collections) === 0) {
-        return <Text>empty</Text>;
-    }
-
     return (
         <View>
             {_.map(props.collections, (collection, i) => (

--- a/tests/components/ViewWithText.js
+++ b/tests/components/ViewWithText.js
@@ -4,13 +4,12 @@ import PropTypes from 'prop-types';
 import {View, Text} from 'react-native';
 
 const propTypes = {
-    text: PropTypes.string,
+    text: PropTypes.string.isRequired,
     onRender: PropTypes.func,
 };
 
 const defaultProps = {
     onRender: () => {},
-    text: null,
 };
 
 function ViewWithText(props) {
@@ -18,7 +17,7 @@ function ViewWithText(props) {
 
     return (
         <View>
-            <Text testID="text-element">{props.text || 'null'}</Text>
+            <Text testID="text-element">{props.text}</Text>
         </View>
     );
 }

--- a/tests/unit/withOnyxTest.js
+++ b/tests/unit/withOnyxTest.js
@@ -6,7 +6,6 @@ import ViewWithText from '../components/ViewWithText';
 import ViewWithCollections from '../components/ViewWithCollections';
 import waitForPromisesToResolve from '../utils/waitForPromisesToResolve';
 import ViewWithObject from '../components/ViewWithObject';
-import StorageMock from '../../lib/storage';
 
 const ONYX_KEYS = {
     TEST_KEY: 'test',
@@ -521,114 +520,6 @@ describe('withOnyxTest', () => {
                 // Component still has not updated
                 expect(onRender).toHaveBeenCalledTimes(4);
                 expect(onRender.mock.calls[3][0].simple).toBe('long_string');
-            });
-    });
-
-    it('should render immediately when a onyx component is mounted a 2nd time', () => {
-        const TestComponentWithOnyx = withOnyx({
-            text: {
-                key: ONYX_KEYS.TEST_KEY,
-            },
-        })(ViewWithText);
-        const onRender = jest.fn();
-        let renderResult;
-
-        // Set the value in storage, but not in cache.
-        return StorageMock.setItem(ONYX_KEYS.TEST_KEY, 'test1')
-            .then(() => {
-                renderResult = render(<TestComponentWithOnyx onRender={onRender} />);
-
-                // The component should not render initially since we have no data in cache.
-                // Use `waitForPromisesToResolve` before making the assertions and make sure
-                // onRender was not called.
-                expect(onRender).not.toHaveBeenCalled();
-                return waitForPromisesToResolve();
-            })
-            .then(waitForPromisesToResolve)
-            .then(() => {
-                let textComponent = renderResult.getByText('test1');
-                expect(textComponent).not.toBeNull();
-                expect(onRender).toHaveBeenCalledTimes(1);
-
-                // Unmount the component and mount it again. It should now render immediately.
-                // Do not use `waitForPromisesToResolve` before making the assertions and make sure
-                // onRender was called.
-                renderResult.unmount();
-                renderResult = render(<TestComponentWithOnyx onRender={onRender} />);
-
-                textComponent = renderResult.getByText('test1');
-                expect(textComponent).not.toBeNull();
-                expect(onRender).toHaveBeenCalledTimes(2);
-            });
-    });
-
-    it('should cache missing keys', () => {
-        const TestComponentWithOnyx = withOnyx({
-            text: {
-                key: ONYX_KEYS.TEST_KEY,
-            },
-        })(ViewWithText);
-        const onRender = jest.fn();
-
-        // Render with a key that doesn't exist in cache or storage.
-        let renderResult = render(<TestComponentWithOnyx onRender={onRender} />);
-
-        // The component should not render initially since we have no data in cache.
-        // Use `waitForPromisesToResolve` before making the assertions and make sure
-        // onRender was not called.
-        expect(onRender).not.toHaveBeenCalled();
-        return waitForPromisesToResolve().then(() => {
-            let textComponent = renderResult.getByText('null');
-            expect(textComponent).not.toBeNull();
-            expect(onRender).toHaveBeenCalledTimes(1);
-
-            // Unmount the component and mount it again. It should now render immediately.
-            // Do not use `waitForPromisesToResolve` before making the assertions and make sure
-            // onRender was called.
-            renderResult.unmount();
-            renderResult = render(<TestComponentWithOnyx onRender={onRender} />);
-            textComponent = renderResult.getByText('null');
-            expect(textComponent).not.toBeNull();
-            expect(onRender).toHaveBeenCalledTimes(2);
-        });
-    });
-
-    it('should cache empty collections', () => {
-        const TestComponentWithOnyx = withOnyx({
-            text: {
-                key: ONYX_KEYS.COLLECTION.TEST_KEY,
-            },
-        })(ViewWithCollections);
-        const onRender = jest.fn();
-        let renderResult;
-
-        // Set a random item in storage since Onyx will only think keys are loaded
-        // in cache if there are at least one key.
-        return StorageMock.setItem(ONYX_KEYS.SIMPLE_KEY, 'simple')
-            .then(() => {
-                // Render with a collection that doesn't exist in cache or storage.
-                renderResult = render(<TestComponentWithOnyx onRender={onRender} />);
-
-                // The component should not render initially since we have no data in cache.
-                // Use `waitForPromisesToResolve` before making the assertions and make sure
-                // onRender was not called.
-                expect(onRender).not.toHaveBeenCalled();
-
-                return waitForPromisesToResolve();
-            })
-            .then(() => {
-                let textComponent = renderResult.getByText('empty');
-                expect(textComponent).not.toBeNull();
-                expect(onRender).toHaveBeenCalledTimes(1);
-
-                // Unmount the component and mount it again. It should now render immediately.
-                // Do not use `waitForPromisesToResolve` before making the assertions and make sure
-                // onRender was called.
-                renderResult.unmount();
-                renderResult = render(<TestComponentWithOnyx onRender={onRender} />);
-                textComponent = renderResult.getByText('empty');
-                expect(textComponent).not.toBeNull();
-                expect(onRender).toHaveBeenCalledTimes(2);
             });
     });
 });


### PR DESCRIPTION
This was reported while testing https://github.com/Expensify/App/pull/29169#issuecomment-1770558360

### Details
1. 

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Manual Tests
<!---
Each set of changes should be tested against the Expensify/App repo on all platforms to verify it does not break our staging App.
--->

### Author Checklist

- [ ] I linked the correct issue in the `### Related Issues` section above
- [ ] I wrote clear testing steps that cover the changes made in this PR
    - [ ] I added steps for local testing in the `Tests` section
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android / native
    - [ ] Android / Chrome
    - [ ] iOS / native
    - [ ] iOS / Safari
    - [ ] MacOS / Chrome / Safari
    - [ ] MacOS / Desktop
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [ ] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [ ] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [ ] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [ ] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [ ] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [ ] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [ ] I verified that if a function's arguments changed that all usages have also been updated correctly
- [ ] If a new component is created I verified that:
    - [ ] A similar component doesn't exist in the codebase
    - [ ] All props are defined accurately and each prop has a `/** comment above it */`
    - [ ] The file is named correctly
    - [ ] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [ ] The only data being stored in the state is data necessary for rendering and nothing else
    - [ ] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [ ] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [ ] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [ ] All JSX used for rendering exists in the render method
    - [ ] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [ ] If any new file was added I verified that:
    - [ ] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [ ] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

</details>
