### PR TITLE
Fix an incorrect method of looking up previous keys

### DIFF
--- a/lib/withOnyx.js
+++ b/lib/withOnyx.js
@@ -101,20 +101,21 @@ export default function (mapOnyxToState, shouldDelayUpdates = false) {
                 this.checkEvictableKeys();
             }
 
-            componentDidUpdate() {
+            componentDidUpdate(prevProps, prevState) {
                 // When the state is passed to the key functions with Str.result(), omit anything
                 // from state that was not part of the mapped keys.
-                const onyxDataFromState = getOnyxDataFromState(this.state, mapOnyxToState);
+                const previousOnyxDataFromState = getOnyxDataFromState(prevState, mapOnyxToState);
+                const currentOnyxDataFromState = getOnyxDataFromState(this.state, mapOnyxToState);
 
                 // If any of the mappings use data from the props, then when the props change, all the
                 // connections need to be reconnected with the new props
                 _.each(mapOnyxToState, (mapping, propName) => {
-                    const previousKey = mapping.previousKey;
-                    const newKey = Str.result(mapping.key, {...this.props, ...onyxDataFromState});
+                    const previousKey = Str.result(mapping.key, {...prevProps, ...previousOnyxDataFromState});
+                    const newKey = Str.result(mapping.key, {...this.props, ...currentOnyxDataFromState});
                     if (previousKey !== newKey) {
                         Onyx.disconnect(this.activeConnectionIDs[previousKey], previousKey);
                         delete this.activeConnectionIDs[previousKey];
-                        this.connectMappingToOnyx(mapping, propName);
+                        this.connectMappingToOnyx(mapping, propName, newKey);
                     }
                 });
                 this.checkEvictableKeys();
@@ -252,23 +253,13 @@ export default function (mapOnyxToState, shouldDelayUpdates = false) {
              * @param {string|function} mapping.key key to connect to. can be a string or a
              * function that takes this.props as an argument and returns a string
              * @param {string} statePropertyName the name of the state property that Onyx will add the data to
-             * @param {boolean} [mapping.initWithStoredValues] If set to false, then no data will be prefilled into the
-             *  component
+             * @param {string} [key] used to overwrite the mapping.key value which is used when when the props used to construct the key value have changed
              */
-            connectMappingToOnyx(mapping, statePropertyName) {
-                const key = Str.result(mapping.key, {...this.props, ...getOnyxDataFromState(this.state, mapOnyxToState)});
-
-                // Remember the previous key so that if it ever changes, the component will reconnect to Onyx
-                // in componentDidUpdate
-                if (statePropertyName !== 'initialValue' && mapOnyxToState[statePropertyName]) {
-                    // eslint-disable-next-line no-param-reassign
-                    mapOnyxToState[statePropertyName].previousKey = key;
-                }
-
+            connectMappingToOnyx(mapping, statePropertyName, key) {
                 // eslint-disable-next-line rulesdir/prefer-onyx-connect-in-libs
                 this.activeConnectionIDs[key] = Onyx.connect({
                     ...mapping,
-                    key,
+                    key: !_.isUndefined(key) ? key : Str.result(mapping.key, {...this.props, ...getOnyxDataFromState(this.state, mapOnyxToState)}),
                     statePropertyName,
                     withOnyxInstance: this,
                     displayName,


### PR DESCRIPTION
This was reported while testing https://github.com/Expensify/App/pull/29169#issuecomment-1770558360

### Details
I was able to reproduce the issue with the infinite loading of avatars. While debugging the problem, I found that it was `ReportScreen.js` which was infinitely re-rendering. This manifested in the infinite loading of avatars. Since `ReportScreen` is at the top of the view hierarchy, I concluded the issue was definitely in `withOnyx()`. 

To debug it further, I began to inspect what happened when `componentDidUpdate` runs, and then checks to see if the key changed (eg. `previousKey !== newKey`). I found that the logic was properly detecting that the key changed, so `withOnyx` correctly tried to reconnect with the new key. When the new connection happened, the logic is supposed to remember what the previous key was (eg. `mapOnyxToState[statePropertyName].previousKey = key;`). This triggers `componentDidUpdate()` again and I found that the `previousKey` was always wrong. It wasn't actually changing, so `withOnyx` went into an infinite loop trying to reconnect to the same keys over and over again.

I fixed it by utilizing `prevProps` and `prevState` arguments from `componentDidUpdate()` to more accurately calculate what the previous and current keys were, rather than relying on a reference to `mapOnyxToState[statePropertyName].previousKey`. This now correctly picked up the change to keys and prevents the infinite connection.

### Related Issues
https://github.com/Expensify/App/pull/29169

### Automated Tests
None

### Manual Tests
This requires a little bit of setup.

#### Setup in NewDot
1. In NewDot (you should be on `main` with version `1.0.100` of Onyx), log in as a user and be sure you have an avatar uploaded
2. Create a workspace and upload an avatar for the workspace
3. Request money from the workspace (+ > request money > manual)
4. After you create the request, you will be on the workspace chat

#### Setup NewDot to run the Onyx fix
1. Go to the `react-native-onyx` directory and run `npm run build && cp -r dist ~/Expensidev/App/node_modules/react-native-onyx` to copy the changes from this PR into NewDot (you may need to adjust the file paths)
2. For NewDot, start the build with `npm run web`
3. Go to the workspace chat that you requested money from
4. Click on the request preview to go to the report details that lists all the requests
5. Now click the link in the chat header to go back to the workspace chat
6. Open the JS console and go to the network tab (be sure to remove all request filters)
7. Verify that you do not see the avatars loading infinitely
8. Navigate back and forth between each of those report views a few times
7. Verify that you do not see the avatars loading infinitely in the network tab

### Author Checklist

- [x] I linked the correct issue in the `### Related Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native cannot test because no access to network console
    - [x] Android / Chrome cannot test because no access to network console
    - [x] iOS / native cannot test because no access to network console
    - [x] iOS / Safari cannot test because no access to network console
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->
![image](https://github.com/Expensify/react-native-onyx/assets/1228807/fafe9b34-324e-4a2b-b65c-fd1b4532a81c)

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->
 cannot test because no access to network console
</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->
 cannot test because no access to network console
</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->
![image](https://github.com/Expensify/react-native-onyx/assets/1228807/fd43e281-9db2-4b0e-9b97-e8ab5245eb1d)

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->
 cannot test because no access to network console
</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->
 cannot test because no access to network console
</details>
