### PR TITLE
Fix IDBKeyVal get returning undefined instead of null

### DIFF
--- a/lib/storage/providers/IDBKeyVal.js
+++ b/lib/storage/providers/IDBKeyVal.js
@@ -104,7 +104,7 @@ const provider = {
      */
     getItem: key => get(key, getCustomStore())
 
-        // idb-keyval returns undefined for missing items, but this needs to return null.
+        // idb-keyval returns undefined for missing items, but this needs to return null so that idb-keyval does the same thing as SQLiteStorage.
         .then(val => (val === undefined ? null : val)),
 
     /**

--- a/lib/storage/providers/IDBKeyVal.js
+++ b/lib/storage/providers/IDBKeyVal.js
@@ -102,7 +102,9 @@ const provider = {
      * @param {String} key
      * @return {Promise<*>}
      */
-    getItem: key => get(key, getCustomStore()).then(val => (val != null ? val : null)),
+    getItem: key => get(key, getCustomStore())
+        // idb-keyval returns undefined for missing items, but this needs to return null.
+        .then(val => (val === undefined ? null : val)),
 
     /**
      * Remove given key and it's value from storage

--- a/lib/storage/providers/IDBKeyVal.js
+++ b/lib/storage/providers/IDBKeyVal.js
@@ -103,6 +103,7 @@ const provider = {
      * @return {Promise<*>}
      */
     getItem: key => get(key, getCustomStore())
+
         // idb-keyval returns undefined for missing items, but this needs to return null.
         .then(val => (val === undefined ? null : val)),
 

--- a/lib/storage/providers/IDBKeyVal.js
+++ b/lib/storage/providers/IDBKeyVal.js
@@ -102,7 +102,7 @@ const provider = {
      * @param {String} key
      * @return {Promise<*>}
      */
-    getItem: key => get(key, getCustomStore()),
+    getItem: key => get(key, getCustomStore()).then(val => (val != null ? val : null)),
 
     /**
      * Remove given key and it's value from storage


### PR DESCRIPTION
### Details

`getItem` is supposed to return null when the value doesn't exist in storage. This is what the native sqlite storage implementation does, as well as what the function documentation says.  However https://github.com/jakearchibald/idb-keyval#get returns undefined when the value doesn't exist so we need to convert it to null.

This caused some issues where some components would stay stuck in loading state because in onyx we assume undefined means the key value has not been loaded from storage, non-existing keys are represented by null. The issue was reported here https://github.com/Expensify/App/pull/29169#issuecomment-1783386090.

### Related Issues

https://github.com/Expensify/App/pull/29169

### Automated Tests

N/A

### Manual Tests

Tested in Expensify app with https://github.com/Expensify/App/pull/29169. On web, opening settings will cause a blank screen to open. After this fix it loads properly.

### Author Checklist

- [x] I linked the correct issue in the `### Related Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Chrome</summary>

Before:

<img width="933" alt="image" src="https://github.com/Expensify/react-native-onyx/assets/2677334/41bde0b7-5668-44ed-a034-aba8bae656e0">

After:

<img width="935" alt="image" src="https://github.com/Expensify/react-native-onyx/assets/2677334/a042f5bb-eaca-4d1a-beb5-cea07a0a0b6c">


</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

</details>
