### PR TITLE
Include a more stable way of detecting when withOnyx keys change

### DIFF
--- a/lib/withOnyx.js
+++ b/lib/withOnyx.js
@@ -10,8 +10,8 @@ import Onyx from './Onyx';
 import * as Str from './Str';
 import utils from './utils';
 
-// This is a list of keys that can exist on a `mapping`, but are not directly related to loading data from Onyx. When the keys of a mapping are looped over to check if a key has changed, it's a good idea
-// to skip looking at these properties since they would have unexpected results.
+// This is a list of keys that can exist on a `mapping`, but are not directly related to loading data from Onyx. When the keys of a mapping are looped over to check
+// if a key has changed, it's a good idea to skip looking at these properties since they would have unexpected results.
 const mappingPropertiesToIgnoreChangesTo = ['initialValue'];
 
 /**

--- a/lib/withOnyx.js
+++ b/lib/withOnyx.js
@@ -118,14 +118,6 @@ export default function (mapOnyxToState, shouldDelayUpdates = false) {
                 const isFirstTimeUpdatingAfterLoading = prevState.loading && !this.state.loading;
                 const onyxDataFromState = getOnyxDataFromState(this.state, mapOnyxToState);
                 const prevOnyxDataFromState = getOnyxDataFromState(prevState, mapOnyxToState);
-                const onyxStateDataChanged = !_.isEqual(onyxDataFromState, prevOnyxDataFromState);
-
-                // Return early if the state data related to Onyx hasn't changed which saves some processing from re-renderers not related to Onyx.
-                // The only exception to this is the first time this.state.loading transitions from true to false. In this case, the code below still needs to run
-                // so that it can detect if any of the keys changed during the loading process.
-                if (!isFirstTimeUpdatingAfterLoading && !onyxStateDataChanged) {
-                    return;
-                }
 
                 // This is ensure that only one property is reconnecting at a time, or else it can lead to race conditions and infinite rendering loops. No fun!
                 let isReconnectingToOnyx = false;

--- a/lib/withOnyx.js
+++ b/lib/withOnyx.js
@@ -10,6 +10,10 @@ import Onyx from './Onyx';
 import * as Str from './Str';
 import utils from './utils';
 
+// This is a list of keys that can exist on a `mapping`, but are not directly related to loading data from Onyx. When the keys of a mapping are looped over to check if a key has changed, it's a good idea
+// to skip looking at these properties since they would have unexpected results.
+const mappingPropertiesToIgnoreChangesTo = ['initialValue'];
+
 /**
  * Returns the display name of a component
  *
@@ -94,27 +98,60 @@ export default function (mapOnyxToState, shouldDelayUpdates = false) {
             }
 
             componentDidMount() {
+                const onyxDataFromState = getOnyxDataFromState(this.state, mapOnyxToState);
+
                 // Subscribe each of the state properties to the proper Onyx key
                 _.each(mapOnyxToState, (mapping, propertyName) => {
-                    this.connectMappingToOnyx(mapping, propertyName);
+                    if (_.includes(mappingPropertiesToIgnoreChangesTo, propertyName)) {
+                        return;
+                    }
+                    const key = Str.result(mapping.key, {...this.props, ...onyxDataFromState});
+                    this.connectMappingToOnyx(mapping, propertyName, key);
                 });
                 this.checkEvictableKeys();
             }
 
-            componentDidUpdate() {
-                // When the state is passed to the key functions with Str.result(), omit anything
-                // from state that was not part of the mapped keys.
+            componentDidUpdate(prevProps, prevState) {
+                // The while purpose of this method is to check to see if a key that is subscribed to Onyx has changed, and then Onyx needs to be disconnected from the old
+                // key and connected to the new key.
+                // For example, a key could change if KeyB depends on data loading from Onyx for KeyA.
+                const isFirstTimeUpdatingAfterLoading = prevState.loading && !this.state.loading;
                 const onyxDataFromState = getOnyxDataFromState(this.state, mapOnyxToState);
+                const prevOnyxDataFromState = getOnyxDataFromState(prevState, mapOnyxToState);
+                const onyxStateDataChanged = !_.isEqual(onyxDataFromState, prevOnyxDataFromState);
 
-                // If any of the mappings use data from the props, then when the props change, all the
-                // connections need to be reconnected with the new props
+                // Return early if the state data related to Onyx hasn't changed which saves some processing from re-renderers not related to Onyx.
+                // The only exception to this is the first time this.state.loading transitions from true to false. In this case, the code below still needs to run
+                // so that it can detect if any of the keys changed during the loading process.
+                if (!isFirstTimeUpdatingAfterLoading && !onyxStateDataChanged) {
+                    return;
+                }
+
+                // This is ensure that only one property is reconnecting at a time, or else it can lead to race conditions and infinite rendering loops. No fun!
+                let isReconnectingToOnyx = false;
+
                 _.each(mapOnyxToState, (mapping, propName) => {
-                    const previousKey = mapping.previousKey;
+                    // Some properties can be ignored and also return early if the component is already reconnecting to Onyx
+                    if (_.includes(mappingPropertiesToIgnoreChangesTo, propName) || isReconnectingToOnyx) {
+                        return;
+                    }
+
+                    // The previus key comes from either:
+                    // 1) The initial key that was connected to (ie. set from `componentDidMount()`)
+                    // 2) The updates props which caused `componentDidUpdate()` to run
+                    // The first case cannot be used all the time because of race conditions where `componentDidUpdate()` can be triggered before connectingMappingToOnyx() is done
+                    // (eg. if a user switches chats really quickly). In this case, it's much more stable to always look at the changes to prevProp and prevState to derive the key.
+                    // The second case cannot be used all the time because the onyx data doesn't change the first time that `componentDidUpdate()` runs after loading. In this case,
+                    // the `mapping.prevousKey` must be used for the comparison or else this logic never detects that onyx data could have changed during the loading process.
+                    const previousKey = isFirstTimeUpdatingAfterLoading
+                        ? mapping.previousKey
+                        : Str.result(mapping.key, {...prevProps, ...prevOnyxDataFromState});
                     const newKey = Str.result(mapping.key, {...this.props, ...onyxDataFromState});
                     if (previousKey !== newKey) {
+                        isReconnectingToOnyx = true;
                         Onyx.disconnect(this.activeConnectionIDs[previousKey], previousKey);
                         delete this.activeConnectionIDs[previousKey];
-                        this.connectMappingToOnyx(mapping, propName);
+                        this.connectMappingToOnyx(mapping, propName, newKey);
                     }
                 });
                 this.checkEvictableKeys();
@@ -254,16 +291,13 @@ export default function (mapOnyxToState, shouldDelayUpdates = false) {
              * @param {string} statePropertyName the name of the state property that Onyx will add the data to
              * @param {boolean} [mapping.initWithStoredValues] If set to false, then no data will be prefilled into the
              *  component
+             * @param {string} key to connect to Onyx with
              */
-            connectMappingToOnyx(mapping, statePropertyName) {
-                const key = Str.result(mapping.key, {...this.props, ...getOnyxDataFromState(this.state, mapOnyxToState)});
-
-                // Remember the previous key so that if it ever changes, the component will reconnect to Onyx
-                // in componentDidUpdate
-                if (statePropertyName !== 'initialValue' && mapOnyxToState[statePropertyName]) {
-                    // eslint-disable-next-line no-param-reassign
-                    mapOnyxToState[statePropertyName].previousKey = key;
-                }
+            connectMappingToOnyx(mapping, statePropertyName, key) {
+                // Remember what the previous key was so that key changes can be detected when data is being loaded from Onyx. This will allow
+                // dependent keys to finish loading their data.
+                // eslint-disable-next-line no-param-reassign
+                mapOnyxToState[statePropertyName].previousKey = key;
 
                 // eslint-disable-next-line rulesdir/prefer-onyx-connect-in-libs
                 this.activeConnectionIDs[key] = Onyx.connect({

--- a/lib/withOnyx.js
+++ b/lib/withOnyx.js
@@ -112,14 +112,14 @@ export default function (mapOnyxToState, shouldDelayUpdates = false) {
             }
 
             componentDidUpdate(prevProps, prevState) {
-                // The while purpose of this method is to check to see if a key that is subscribed to Onyx has changed, and then Onyx needs to be disconnected from the old
+                // The whole purpose of this method is to check to see if a key that is subscribed to Onyx has changed, and then Onyx needs to be disconnected from the old
                 // key and connected to the new key.
                 // For example, a key could change if KeyB depends on data loading from Onyx for KeyA.
                 const isFirstTimeUpdatingAfterLoading = prevState.loading && !this.state.loading;
                 const onyxDataFromState = getOnyxDataFromState(this.state, mapOnyxToState);
                 const prevOnyxDataFromState = getOnyxDataFromState(prevState, mapOnyxToState);
 
-                // This is ensure that only one property is reconnecting at a time, or else it can lead to race conditions and infinite rendering loops. No fun!
+                // This ensures that only one property is reconnecting at a time, or else it can lead to race conditions and infinite rendering loops. No fun!
                 let isReconnectingToOnyx = false;
 
                 _.each(mapOnyxToState, (mapping, propName) => {
@@ -128,13 +128,13 @@ export default function (mapOnyxToState, shouldDelayUpdates = false) {
                         return;
                     }
 
-                    // The previus key comes from either:
+                    // The previous key comes from either:
                     // 1) The initial key that was connected to (ie. set from `componentDidMount()`)
-                    // 2) The updates props which caused `componentDidUpdate()` to run
+                    // 2) The updated props which caused `componentDidUpdate()` to run
                     // The first case cannot be used all the time because of race conditions where `componentDidUpdate()` can be triggered before connectingMappingToOnyx() is done
                     // (eg. if a user switches chats really quickly). In this case, it's much more stable to always look at the changes to prevProp and prevState to derive the key.
                     // The second case cannot be used all the time because the onyx data doesn't change the first time that `componentDidUpdate()` runs after loading. In this case,
-                    // the `mapping.prevousKey` must be used for the comparison or else this logic never detects that onyx data could have changed during the loading process.
+                    // the `mapping.previousKey` must be used for the comparison or else this logic never detects that onyx data could have changed during the loading process.
                     const previousKey = isFirstTimeUpdatingAfterLoading
                         ? mapping.previousKey
                         : Str.result(mapping.key, {...prevProps, ...prevOnyxDataFromState});


### PR DESCRIPTION
This is another take on the same fix that I did in https://github.com/Expensify/react-native-onyx/pull/407.

### Details
There are two cases that need to be handled slightly different in `componentDidUpdate()`:
1. The first time it runs, it is triggered by `this.state.loading` going from `true` to `false`
2. Every other time it runs, it is triggered by a change to the props or the state

This causes some differences in how the `previousKey` is calculated in order to compare if the key changed or not. Hopefully, the code comments explain this pretty well.

### Related Issues
NA

### Automated Tests
Yes, this is fully covered by automated tests and it was how I found that the solution in https://github.com/Expensify/react-native-onyx/pull/407 was not correct.

### Manual Tests
1. Run `npm run build` and copy the changes to the App's `node_modules/react-native-onyx` folder
2. In App, modify `ReportScreen.js` to have a log at the top of the render method like `console.log('Tim ReportScreen()');`
3. In App, run `npm run web` on App to start the app
4. Quickly click switch between multiple chats, especially ones that have money request previews in them (though, it's not really related to that)
5. Verify that in the JS console, you never see an infinite re-rendering of the ReportScreen

#### Now, to verify that the dependent keys are working:
1. Click the global + > Request Money > Scan
2. Once you have created the scan request, click the request preview to go to the report. Now click the request to go to the request details.
3. Verify in the header at the top of the page that it shows the `Scanning...` label. That label won't be there if the dependent data isn't loading properly

### Author Checklist

- [x] I linked the correct issue in the `### Related Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome Unable to test due to emulator not being able to load the site
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/react-native-onyx/assets/1228807/e494d298-bf70-4c73-9fe5-64e7706c2676

![2023-10-31_15-36-48](https://github.com/Expensify/react-native-onyx/assets/1228807/d720b935-4faf-4ca5-84d3-d3ddd5c93f8a)

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->
![image](https://github.com/Expensify/react-native-onyx/assets/1228807/ae83a120-f8d3-40f0-99aa-5ca773a0b36a)

</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/react-native-onyx/assets/1228807/8a17560a-5f78-4f82-a806-acf8c43ed4e1

![2023-10-31_15-45-56](https://github.com/Expensify/react-native-onyx/assets/1228807/7ec52edf-f0bf-4ffd-aafa-b28093faf678)

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/react-native-onyx/assets/1228807/29dfe716-4b89-4f0e-b16f-4b8465a4cee3

![2023-10-31_16-26-41](https://github.com/Expensify/react-native-onyx/assets/1228807/8fced372-55a6-42ef-89cc-6317edaf9bc7)

</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

Uploading 2023-11-01_10-00-27.mp4…


</details>
