### PR TITLE
Remove optimization that was supposed to help with infinite rendering…

### DIFF
--- a/lib/withOnyx.js
+++ b/lib/withOnyx.js
@@ -121,7 +121,7 @@ export default function (mapOnyxToState, shouldDelayUpdates = false) {
 
                 _.each(mapOnyxToState, (mapping, propName) => {
                     // Some properties can be ignored and also return early if the component is already reconnecting to Onyx
-                    if (_.includes(mappingPropertiesToIgnoreChangesTo, propName) || isReconnectingToOnyx) {
+                    if (_.includes(mappingPropertiesToIgnoreChangesTo, propName)) {
                         return;
                     }
 

--- a/lib/withOnyx.js
+++ b/lib/withOnyx.js
@@ -120,7 +120,7 @@ export default function (mapOnyxToState, shouldDelayUpdates = false) {
                 const prevOnyxDataFromState = getOnyxDataFromState(prevState, mapOnyxToState);
 
                 _.each(mapOnyxToState, (mapping, propName) => {
-                    // Some properties can be ignored and also return early if the component is already reconnecting to Onyx
+                    // Some properties can be ignored because they aren't related to onyx keys and they will never change
                     if (_.includes(mappingPropertiesToIgnoreChangesTo, propName)) {
                         return;
                     }

--- a/lib/withOnyx.js
+++ b/lib/withOnyx.js
@@ -12,7 +12,7 @@ import utils from './utils';
 
 // This is a list of keys that can exist on a `mapping`, but are not directly related to loading data from Onyx. When the keys of a mapping are looped over to check
 // if a key has changed, it's a good idea to skip looking at these properties since they would have unexpected results.
-const mappingPropertiesToIgnoreChangesTo = ['initialValue'];
+const mappingPropertiesToIgnoreChangesTo = ['initialValue', 'allowStaleData'];
 
 /**
  * Returns the display name of a component
@@ -119,9 +119,6 @@ export default function (mapOnyxToState, shouldDelayUpdates = false) {
                 const onyxDataFromState = getOnyxDataFromState(this.state, mapOnyxToState);
                 const prevOnyxDataFromState = getOnyxDataFromState(prevState, mapOnyxToState);
 
-                // This ensures that only one property is reconnecting at a time, or else it can lead to race conditions and infinite rendering loops. No fun!
-                let isReconnectingToOnyx = false;
-
                 _.each(mapOnyxToState, (mapping, propName) => {
                     // Some properties can be ignored and also return early if the component is already reconnecting to Onyx
                     if (_.includes(mappingPropertiesToIgnoreChangesTo, propName) || isReconnectingToOnyx) {
@@ -140,7 +137,6 @@ export default function (mapOnyxToState, shouldDelayUpdates = false) {
                         : Str.result(mapping.key, {...prevProps, ...prevOnyxDataFromState});
                     const newKey = Str.result(mapping.key, {...this.props, ...onyxDataFromState});
                     if (previousKey !== newKey) {
-                        isReconnectingToOnyx = true;
                         Onyx.disconnect(this.activeConnectionIDs[previousKey], previousKey);
                         delete this.activeConnectionIDs[previousKey];
                         this.connectMappingToOnyx(mapping, propName, newKey);


### PR DESCRIPTION
… loops

<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
What seems to happen is that `withOnyx` detects that the `reportActions_` key has changed, so it reconnects to Onyx. However, because of `isReconnectingToOnyx` it also misses the change to the `report_` key, so `withOnyx` never reconnects to that key.

### Related Issues
Part of https://github.com/Expensify/App/issues/30934

### Automated Tests
Covered by unit tests already

### Manual Tests
Easy test for web:
1. Sign into App
2. Manually edit the URL to remove the `/r/1234` from the path and press enter
3. The page will reload
4. Verify that the chat loads
5. Modify App `ReportScreen.js` to have a log at the top of the render method like `console.log('report screen')`
6. Switch between several chats, quickly, and verify there there is no infinite rendering loop for the report screen

For native platforms:
1. Sign out
2. Sign in
3. Verify the chat loads

### Author Checklist

- [x] I linked the correct issue in the `### Related Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->
<img width="579" alt="image" src="https://github.com/Expensify/react-native-onyx/assets/1228807/87fc6ae8-3b98-4471-9108-a7a34d5cf9e4">


</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->
<img width="488" alt="image" src="https://github.com/Expensify/react-native-onyx/assets/1228807/4d148968-781e-427b-825b-2469985c14f7">

</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->
<img width="825" alt="image" src="https://github.com/Expensify/react-native-onyx/assets/1228807/9ecbcb55-9f74-465f-b281-841c53752c3f">

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->
<img width="488" alt="image" src="https://github.com/Expensify/react-native-onyx/assets/1228807/c3a51af5-0430-4e29-bea9-a45a5ee5aacf">

</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

</details>
