### PR TITLE
Fix: Setting key to null prevents subsequent merges

### DIFF
--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -1197,11 +1197,6 @@ function merge(key, changes) {
                 // We don't want to remove null values from the "batchedChanges", because SQLite uses them to remove keys from storage natively.
                 let batchedChanges = applyMerge(undefined, mergeQueue[key], false);
 
-                if (_.isNull(batchedChanges)) {
-                    remove(key);
-                    return;
-                }
-
                 // The presence of a `null` in the merge queue instructs us to drop the existing value.
                 // In this case, we can't simply merge the batched changes with the existing value, because then the null in the merge queue would have no effect
                 const shouldOverwriteExistingValue = _.includes(mergeQueue[key], null);
@@ -1209,6 +1204,12 @@ function merge(key, changes) {
                 // Clean up the write queue, so we don't apply these changes again
                 delete mergeQueue[key];
                 delete mergeQueuePromise[key];
+
+                // If the batched changes equal null, we want to remove the key from storage, to reduce storage size
+                if (_.isNull(batchedChanges)) {
+                    remove(key);
+                    return;
+                }
 
                 // After that we merge the batched changes with the existing value
                 // We can remove null values from the "modifiedData", because "null" implicates that the user wants to remove a value from storage.

--- a/tests/unit/onyxTest.js
+++ b/tests/unit/onyxTest.js
@@ -979,4 +979,29 @@ describe('Onyx', () => {
                 });
             });
     });
+
+    it('should merge a key with null and allow subsequent updates', () => {
+        let testKeyValue;
+
+        connectionID = Onyx.connect({
+            key: ONYX_KEYS.TEST_KEY,
+            initWithStoredValues: false,
+            callback: (value) => {
+                testKeyValue = value;
+            },
+        });
+
+        return Onyx.set(ONYX_KEYS.TEST_KEY, 1)
+            .then(() => {
+                expect(testKeyValue).toEqual(1);
+                Onyx.merge(ONYX_KEYS.TEST_KEY, null);
+                return waitForPromisesToResolve();
+            })
+            .then(() => {
+                expect(testKeyValue).toEqual(null);
+                return Onyx.merge(ONYX_KEYS.TEST_KEY, 2);
+            }).then(() => {
+                expect(testKeyValue).toEqual(2);
+            });
+    });
 });


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

@arosiclair @tgolen @neil-marcellini 

### Details
<!-- Explanation of the change or anything fishy that is going on -->

This fixes a bug/regression in Onyx, where the merge queue is not cleared after we drop a key from storage, because the batched changes would have been `null`.

We generally want to remove `null` values from storage to decrease the size of the data in storage...

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/react-native-onyx/issues/425

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Manual Tests
<!---
Each set of changes should be tested against the Expensify/App repo on all platforms to verify it does not break our staging App.
--->

### Author Checklist

- [x] I linked the correct issue in the `### Related Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->



</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

![Screenshot_1699897933](https://github.com/Expensify/react-native-onyx/assets/20173411/176b452e-3ae3-4b65-b359-259e0d07e881)

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

![Simulator Screenshot - iPhone 15 Pro - 2023-11-13 at 18 46 55](https://github.com/Expensify/react-native-onyx/assets/20173411/82076351-7f06-49d2-9fae-9ea2a78f1fed)

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

![Simulator Screenshot - iPhone 15 Pro - 2023-11-13 at 18 49 01](https://github.com/Expensify/react-native-onyx/assets/20173411/9b4b7e42-b243-4954-bebf-d68760e334e2)

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

<img width="1440" alt="Screenshot 2023-11-13 at 18 37 33" src="https://github.com/Expensify/react-native-onyx/assets/20173411/6d9a94c7-7be3-4f0e-be20-6c9a7e5e5352">

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

<img width="1312" alt="Screenshot 2023-11-13 at 18 41 25" src="https://github.com/Expensify/react-native-onyx/assets/20173411/7143cf05-a581-4b08-98ea-2e07c8589a10">


</details>
