### PR TITLE
Setup prettier

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,6 +3,7 @@ module.exports = {
     rules: {
         // Overwriting this for now because web-e will conflict with this
         'react/jsx-filename-extension': [1, {extensions: ['.js']}],
+        'rulesdir/no-multiple-onyx-in-file': 'off',
     },
     env: {
         jest: true,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-    extends: 'expensify',
+    extends: ['expensify', 'prettier'],
     rules: {
         // Overwriting this for now because web-e will conflict with this
         'react/jsx-filename-extension': [1, {extensions: ['.js']}],

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,9 @@
+dist/**/*.js
+package.json
+package-lock.json
+*.html
+*.yml
+*.yaml
+*.css
+*.scss
+*.md

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,9 @@
+module.exports = {
+    tabWidth: 4,
+    singleQuote: true,
+    trailingComma: 'all',
+    bracketSpacing: false,
+    arrowParens: 'always',
+    printWidth: 190,
+    singleAttributePerLine: true,
+};

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,5 +1,5 @@
 module.exports = (api) => {
-    const isWeb = api.caller(caller => caller && caller.target === 'web');
+    const isWeb = api.caller((caller) => caller && caller.target === 'web');
     if (isWeb) {
         return {
             // Default browser list is a reasonable preset covering a wide list of non-dead browsers

--- a/jestSetup.js
+++ b/jestSetup.js
@@ -12,4 +12,3 @@ jest.useRealTimers();
 
 const unstable_batchedUpdates_jest = require('react-test-renderer').unstable_batchedUpdates;
 require('./lib/batch.native').default = unstable_batchedUpdates_jest;
-

--- a/lib/Logger.js
+++ b/lib/Logger.js
@@ -28,8 +28,4 @@ function logInfo(message) {
     logger({message: `[Onyx] ${message}`, level: 'info'});
 }
 
-export {
-    registerLogger,
-    logInfo,
-    logAlert,
-};
+export {registerLogger, logInfo, logAlert};

--- a/lib/MDTable.js
+++ b/lib/MDTable.js
@@ -24,17 +24,16 @@ class MDTable extends AsciTable {
     toString() {
         // Ignore modifying the first |---| for titled tables
         let idx = this.getTitle() ? -2 : -1;
-        const ascii = super.toString()
-            .replace(/-\|/g, () => {
-                /* we replace "----|" with "---:|" to align the data to the right in MD */
-                idx++;
+        const ascii = super.toString().replace(/-\|/g, () => {
+            /* we replace "----|" with "---:|" to align the data to the right in MD */
+            idx++;
 
-                if (idx < 0 || this.leftAlignedCols.includes(idx)) {
-                    return '-|';
-                }
+            if (idx < 0 || this.leftAlignedCols.includes(idx)) {
+                return '-|';
+            }
 
-                return ':|';
-            });
+            return ':|';
+        });
 
         // strip the top and the bottom row (----) to make an MD table
         const md = ascii.split('\n').slice(1, -1).join('\n');
@@ -52,16 +51,14 @@ class MDTable extends AsciTable {
  * @param {Array} [options.rows] The table can be initialized with row. Rows can also be added by `addRow`
  * @returns {MDTable}
  */
-MDTable.factory = ({
-    title, heading, leftAlignedCols = [], rows = [],
-}) => {
+MDTable.factory = ({title, heading, leftAlignedCols = [], rows = []}) => {
     const table = new MDTable({title, heading, rows});
     table.leftAlignedCols = leftAlignedCols;
 
     /* By default we want everything aligned to the right as most values are numbers
-         * we just override the columns that are not right aligned */
+     * we just override the columns that are not right aligned */
     heading.forEach((name, idx) => table.setAlign(idx, AsciTable.RIGHT));
-    leftAlignedCols.forEach(idx => table.setAlign(idx, AsciTable.LEFT));
+    leftAlignedCols.forEach((idx) => table.setAlign(idx, AsciTable.LEFT));
 
     return table;
 };

--- a/lib/Onyx.d.ts
+++ b/lib/Onyx.d.ts
@@ -244,10 +244,7 @@ declare function clear(keysToPreserve?: OnyxKey[]): Promise<void>;
  * @param collectionKey e.g. `ONYXKEYS.COLLECTION.REPORT`
  * @param collection Object collection keyed by individual collection member keys and values
  */
-declare function mergeCollection<TKey extends CollectionKeyBase, TMap>(
-    collectionKey: TKey,
-    collection: Collection<TKey, TMap, NullishDeep<KeyValueMapping[TKey]>>,
-): Promise<void>;
+declare function mergeCollection<TKey extends CollectionKeyBase, TMap>(collectionKey: TKey, collection: Collection<TKey, TMap, NullishDeep<KeyValueMapping[TKey]>>): Promise<void>;
 
 /**
  * Insert API responses and lifecycle data into Onyx

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -118,12 +118,17 @@ const getSubsetOfData = (sourceData, selector, withOnyxInstanceState) => selecto
  * @param {Object} [withOnyxInstanceState]
  * @returns {Object}
  */
-const reduceCollectionWithSelector = (collection, selector, withOnyxInstanceState) => _.reduce(collection, (finalCollection, item, key) => {
-    // eslint-disable-next-line no-param-reassign
-    finalCollection[key] = getSubsetOfData(item, selector, withOnyxInstanceState);
+const reduceCollectionWithSelector = (collection, selector, withOnyxInstanceState) =>
+    _.reduce(
+        collection,
+        (finalCollection, item, key) => {
+            // eslint-disable-next-line no-param-reassign
+            finalCollection[key] = getSubsetOfData(item, selector, withOnyxInstanceState);
 
-    return finalCollection;
-}, {});
+            return finalCollection;
+        },
+        {},
+    );
 
 /**
  * Get some data from the store
@@ -151,7 +156,7 @@ function get(key) {
             cache.set(key, val);
             return val;
         })
-        .catch(err => Logger.logInfo(`Unable to get item from persistent storage. Key: ${key} Error: ${err}`));
+        .catch((err) => Logger.logInfo(`Unable to get item from persistent storage. Key: ${key} Error: ${err}`));
 
     return cache.captureTask(taskName, promise);
 }
@@ -176,11 +181,10 @@ function getAllKeys() {
     }
 
     // Otherwise retrieve the keys from storage and capture a promise to aid concurrent usages
-    const promise = Storage.getAllKeys()
-        .then((keys) => {
-            _.each(keys, key => cache.addKey(key));
-            return keys;
-        });
+    const promise = Storage.getAllKeys().then((keys) => {
+        _.each(keys, (key) => cache.addKey(key));
+        return keys;
+    });
 
     return cache.captureTask(taskName, promise);
 }
@@ -216,9 +220,7 @@ function isCollectionMemberKey(collectionKey, key) {
  * @return {Boolean}
  */
 function isKeyMatch(configKey, key) {
-    return isCollectionKey(configKey)
-        ? Str.startsWith(key, configKey)
-        : configKey === key;
+    return isCollectionKey(configKey) ? Str.startsWith(key, configKey) : configKey === key;
 }
 
 /**
@@ -230,7 +232,7 @@ function isKeyMatch(configKey, key) {
  * @returns {Boolean}
  */
 function isSafeEvictionKey(testKey) {
-    return _.some(evictionAllowList, key => isKeyMatch(key, testKey));
+    return _.some(evictionAllowList, (key) => isKeyMatch(key, testKey));
 }
 
 /**
@@ -252,16 +254,20 @@ function tryGetCachedValue(key, mapping = {}) {
         if (allCacheKeys.length === 0) {
             return;
         }
-        const matchingKeys = _.filter(allCacheKeys, k => k.startsWith(key));
-        const values = _.reduce(matchingKeys, (finalObject, matchedKey) => {
-            const cachedValue = cache.getValue(matchedKey);
-            if (cachedValue) {
-                // This is permissible because we're in the process of constructing the final object in a reduce function.
-                // eslint-disable-next-line no-param-reassign
-                finalObject[matchedKey] = cachedValue;
-            }
-            return finalObject;
-        }, {});
+        const matchingKeys = _.filter(allCacheKeys, (k) => k.startsWith(key));
+        const values = _.reduce(
+            matchingKeys,
+            (finalObject, matchedKey) => {
+                const cachedValue = cache.getValue(matchedKey);
+                if (cachedValue) {
+                    // This is permissible because we're in the process of constructing the final object in a reduce function.
+                    // eslint-disable-next-line no-param-reassign
+                    finalObject[matchedKey] = cachedValue;
+                }
+                return finalObject;
+            },
+            {},
+        );
 
         val = values;
     }
@@ -349,17 +355,16 @@ function addToEvictionBlockList(key, connectionID) {
  * @returns {Promise}
  */
 function addAllSafeEvictionKeysToRecentlyAccessedList() {
-    return getAllKeys()
-        .then((keys) => {
-            _.each(evictionAllowList, (safeEvictionKey) => {
-                _.each(keys, (key) => {
-                    if (!isKeyMatch(safeEvictionKey, key)) {
-                        return;
-                    }
-                    addLastAccessedKey(key);
-                });
+    return getAllKeys().then((keys) => {
+        _.each(evictionAllowList, (safeEvictionKey) => {
+            _.each(keys, (key) => {
+                if (!isKeyMatch(safeEvictionKey, key)) {
+                    return;
+                }
+                addLastAccessedKey(key);
             });
         });
+    });
 }
 
 /**
@@ -368,20 +373,22 @@ function addAllSafeEvictionKeysToRecentlyAccessedList() {
  * @returns {Object}
  */
 function getCachedCollection(collectionKey) {
-    const collectionMemberKeys = _.filter(cache.getAllKeys(), (
-        storedKey => isCollectionMemberKey(collectionKey, storedKey)
-    ));
+    const collectionMemberKeys = _.filter(cache.getAllKeys(), (storedKey) => isCollectionMemberKey(collectionKey, storedKey));
 
-    return _.reduce(collectionMemberKeys, (prev, curr) => {
-        const cachedValue = cache.getValue(curr);
-        if (!cachedValue) {
+    return _.reduce(
+        collectionMemberKeys,
+        (prev, curr) => {
+            const cachedValue = cache.getValue(curr);
+            if (!cachedValue) {
+                return prev;
+            }
+
+            // eslint-disable-next-line no-param-reassign
+            prev[curr] = cachedValue;
             return prev;
-        }
-
-        // eslint-disable-next-line no-param-reassign
-        prev[curr] = cachedValue;
-        return prev;
-    }, {});
+        },
+        {},
+    );
 }
 
 /**
@@ -750,9 +757,7 @@ function addKeyToRecentlyAccessedIfNeeded(mapping) {
     if (mapping.withOnyxInstance && !isCollectionKey(mapping.key)) {
         // All React components subscribing to a key flagged as a safe eviction key must implement the canEvict property.
         if (_.isUndefined(mapping.canEvict)) {
-            throw new Error(
-                `Cannot subscribe to safe eviction key '${mapping.key}' without providing a canEvict value.`,
-            );
+            throw new Error(`Cannot subscribe to safe eviction key '${mapping.key}' without providing a canEvict value.`);
         }
 
         addLastAccessedKey(mapping.key);
@@ -767,13 +772,19 @@ function addKeyToRecentlyAccessedIfNeeded(mapping) {
  * @param {Object} mapping
  */
 function getCollectionDataAndSendAsObject(matchingKeys, mapping) {
-    Promise.all(_.map(matchingKeys, key => get(key)))
-        .then(values => _.reduce(values, (finalObject, value, i) => {
-            // eslint-disable-next-line no-param-reassign
-            finalObject[matchingKeys[i]] = value;
-            return finalObject;
-        }, {}))
-        .then(val => sendDataToConnection(mapping, val, undefined, true));
+    Promise.all(_.map(matchingKeys, (key) => get(key)))
+        .then((values) =>
+            _.reduce(
+                values,
+                (finalObject, value, i) => {
+                    // eslint-disable-next-line no-param-reassign
+                    finalObject[matchingKeys[i]] = value;
+                    return finalObject;
+                },
+                {},
+            ),
+        )
+        .then((val) => sendDataToConnection(mapping, val, undefined, true));
 }
 
 /**
@@ -820,11 +831,7 @@ function connect(mapping) {
             // Performance improvement
             // If the mapping is connected to an onyx key that is not a collection
             // we can skip the call to getAllKeys() and return an array with a single item
-            if (Boolean(mapping.key)
-                && typeof mapping.key === 'string'
-                && !(mapping.key.endsWith('_'))
-                && cache.storageKeys.has(mapping.key)
-            ) {
+            if (Boolean(mapping.key) && typeof mapping.key === 'string' && !mapping.key.endsWith('_') && cache.storageKeys.has(mapping.key)) {
                 return [mapping.key];
             }
             return getAllKeys();
@@ -833,7 +840,7 @@ function connect(mapping) {
             // We search all the keys in storage to see if any are a "match" for the subscriber we are connecting so that we
             // can send data back to the subscriber. Note that multiple keys can match as a subscriber could either be
             // subscribed to a "collection key" or a single key.
-            const matchingKeys = _.filter(keys, key => isKeyMatch(mapping.key, key));
+            const matchingKeys = _.filter(keys, (key) => isKeyMatch(mapping.key, key));
 
             // If the key being connected to does not exist we initialize the value with null. For subscribers that connected
             // directly via connect() they will simply get a null value sent to them without any information about which key matched
@@ -862,13 +869,13 @@ function connect(mapping) {
 
                     // We did not opt into using waitForCollectionCallback mode so the callback is called for every matching key.
                     for (let i = 0; i < matchingKeys.length; i++) {
-                        get(matchingKeys[i]).then(val => sendDataToConnection(mapping, val, matchingKeys[i], true));
+                        get(matchingKeys[i]).then((val) => sendDataToConnection(mapping, val, matchingKeys[i], true));
                     }
                     return;
                 }
 
                 // If we are not subscribed to a collection key then there's only a single key to send an update for.
-                get(mapping.key).then(val => sendDataToConnection(mapping, val, mapping.key, true));
+                get(mapping.key).then((val) => sendDataToConnection(mapping, val, mapping.key, true));
                 return;
             }
 
@@ -881,7 +888,7 @@ function connect(mapping) {
                 }
 
                 // If the subscriber is not using a collection key then we just send a single value back to the subscriber
-                get(mapping.key).then(val => sendDataToConnection(mapping, val, mapping.key, true));
+                get(mapping.key).then((val) => sendDataToConnection(mapping, val, mapping.key, true));
                 return;
             }
 
@@ -988,13 +995,13 @@ function reportStorageQuota() {
 function evictStorageAndRetry(error, onyxMethod, ...args) {
     Logger.logInfo(`Failed to save to storage. Error: ${error}. onyxMethod: ${onyxMethod.name}`);
 
-    if (error && Str.startsWith(error.message, 'Failed to execute \'put\' on \'IDBObjectStore\'')) {
+    if (error && Str.startsWith(error.message, "Failed to execute 'put' on 'IDBObjectStore'")) {
         Logger.logAlert('Attempted to set invalid data set in Onyx. Please ensure all data is serializable.');
         throw error;
     }
 
     // Find the first key that we can remove that has no subscribers in our blocklist
-    const keyForRemoval = _.find(recentlyAccessedKeys, key => !evictionBlocklist[key]);
+    const keyForRemoval = _.find(recentlyAccessedKeys, (key) => !evictionBlocklist[key]);
     if (!keyForRemoval) {
         // If we have no acceptable keys to remove then we are possibly trying to save mission critical data. If this is the case,
         // then we should stop retrying as there is not much the user can do to fix this. Instead of getting them stuck in an infinite loop we
@@ -1006,8 +1013,7 @@ function evictStorageAndRetry(error, onyxMethod, ...args) {
     // Remove the least recently viewed key that is not currently being accessed and retry.
     Logger.logInfo(`Out of storage. Evicting least recently accessed key (${keyForRemoval}) and retrying.`);
     reportStorageQuota();
-    return remove(keyForRemoval)
-        .then(() => onyxMethod(...args));
+    return remove(keyForRemoval).then(() => onyxMethod(...args));
 }
 
 /**
@@ -1031,7 +1037,7 @@ function broadcastUpdate(key, value, hasChanged, method) {
         cache.addToAccessedKeys(key);
     }
 
-    return scheduleSubscriberUpdate(key, value, subscriber => hasChanged || subscriber.initWithStoredValues === false);
+    return scheduleSubscriberUpdate(key, value, (subscriber) => hasChanged || subscriber.initWithStoredValues === false);
 }
 
 /**
@@ -1100,7 +1106,7 @@ function set(key, value) {
     }
 
     return Storage.setItem(key, valueWithoutNull)
-        .catch(error => evictStorageAndRetry(error, set, key, valueWithoutNull))
+        .catch((error) => evictStorageAndRetry(error, set, key, valueWithoutNull))
         .then(() => updatePromise);
 }
 
@@ -1142,17 +1148,20 @@ function multiSet(data) {
         return scheduleSubscriberUpdate(key, val);
     });
 
-    const keyValuePairsWithoutNull = _.filter(_.map(keyValuePairs, ([key, value]) => {
-        const valueWithoutNull = removeNullValues(key, value);
+    const keyValuePairsWithoutNull = _.filter(
+        _.map(keyValuePairs, ([key, value]) => {
+            const valueWithoutNull = removeNullValues(key, value);
 
-        if (valueWithoutNull === null) {
-            return;
-        }
-        return [key, valueWithoutNull];
-    }), Boolean);
+            if (valueWithoutNull === null) {
+                return;
+            }
+            return [key, valueWithoutNull];
+        }),
+        Boolean,
+    );
 
     return Storage.multiSet(keyValuePairsWithoutNull)
-        .catch(error => evictStorageAndRetry(error, multiSet, data))
+        .catch((error) => evictStorageAndRetry(error, multiSet, data))
         .then(() => Promise.all(updatePromises));
 }
 
@@ -1174,8 +1183,7 @@ function applyMerge(existingValue, changes, shouldRemoveNullObjectValues) {
 
     if (_.some(changes, _.isObject)) {
         // Object values are then merged one after the other
-        return _.reduce(changes, (modifiedData, change) => utils.fastMerge(modifiedData, change, shouldRemoveNullObjectValues),
-            existingValue || {});
+        return _.reduce(changes, (modifiedData, change) => utils.fastMerge(modifiedData, change, shouldRemoveNullObjectValues), existingValue || {});
     }
 
     // If we have anything else we can't merge it so we'll
@@ -1227,57 +1235,55 @@ function merge(key, changes) {
     }
     mergeQueue[key] = [changes];
 
-    mergeQueuePromise[key] = get(key)
-        .then((existingValue) => {
-            try {
-                // We first only merge the changes, so we can provide these to the native implementation (SQLite uses only delta changes in "JSON_PATCH" to merge)
-                // We don't want to remove null values from the "batchedChanges", because SQLite uses them to remove keys from storage natively.
-                let batchedChanges = applyMerge(undefined, mergeQueue[key], false);
+    mergeQueuePromise[key] = get(key).then((existingValue) => {
+        try {
+            // We first only merge the changes, so we can provide these to the native implementation (SQLite uses only delta changes in "JSON_PATCH" to merge)
+            // We don't want to remove null values from the "batchedChanges", because SQLite uses them to remove keys from storage natively.
+            let batchedChanges = applyMerge(undefined, mergeQueue[key], false);
 
-                // The presence of a `null` in the merge queue instructs us to drop the existing value.
-                // In this case, we can't simply merge the batched changes with the existing value, because then the null in the merge queue would have no effect
-                const shouldOverwriteExistingValue = _.includes(mergeQueue[key], null);
+            // The presence of a `null` in the merge queue instructs us to drop the existing value.
+            // In this case, we can't simply merge the batched changes with the existing value, because then the null in the merge queue would have no effect
+            const shouldOverwriteExistingValue = _.includes(mergeQueue[key], null);
 
-                // Clean up the write queue, so we don't apply these changes again
-                delete mergeQueue[key];
-                delete mergeQueuePromise[key];
+            // Clean up the write queue, so we don't apply these changes again
+            delete mergeQueue[key];
+            delete mergeQueuePromise[key];
 
-                // If the batched changes equal null, we want to remove the key from storage, to reduce storage size
-                if (_.isNull(batchedChanges)) {
-                    remove(key);
-                    return;
-                }
-
-                // After that we merge the batched changes with the existing value
-                // We can remove null values from the "modifiedData", because "null" implicates that the user wants to remove a value from storage.
-                // The "modifiedData" will be directly "set" in storage instead of being merged
-                const modifiedData = shouldOverwriteExistingValue ? batchedChanges : applyMerge(existingValue, [batchedChanges], true);
-
-                // On native platforms we use SQLite which utilises JSON_PATCH to merge changes.
-                // JSON_PATCH generally removes null values from the stored object.
-                // When there is no existing value though, SQLite will just insert the changes as a new value and thus the null values won't be removed.
-                // Therefore we need to remove null values from the `batchedChanges` which are sent to the SQLite, if no existing value is present.
-                if (!existingValue) {
-                    batchedChanges = applyMerge(undefined, [batchedChanges], true);
-                }
-
-                const hasChanged = cache.hasValueChanged(key, modifiedData);
-
-                // This approach prioritizes fast UI changes without waiting for data to be stored in device storage.
-                const updatePromise = broadcastUpdate(key, modifiedData, hasChanged, 'merge');
-
-                // If the value has not changed, calling Storage.setItem() would be redundant and a waste of performance, so return early instead.
-                if (!hasChanged || isClearing) {
-                    return updatePromise;
-                }
-
-                return Storage.mergeItem(key, batchedChanges, modifiedData)
-                    .then(() => updatePromise);
-            } catch (error) {
-                Logger.logAlert(`An error occurred while applying merge for key: ${key}, Error: ${error}`);
-                return Promise.resolve();
+            // If the batched changes equal null, we want to remove the key from storage, to reduce storage size
+            if (_.isNull(batchedChanges)) {
+                remove(key);
+                return;
             }
-        });
+
+            // After that we merge the batched changes with the existing value
+            // We can remove null values from the "modifiedData", because "null" implicates that the user wants to remove a value from storage.
+            // The "modifiedData" will be directly "set" in storage instead of being merged
+            const modifiedData = shouldOverwriteExistingValue ? batchedChanges : applyMerge(existingValue, [batchedChanges], true);
+
+            // On native platforms we use SQLite which utilises JSON_PATCH to merge changes.
+            // JSON_PATCH generally removes null values from the stored object.
+            // When there is no existing value though, SQLite will just insert the changes as a new value and thus the null values won't be removed.
+            // Therefore we need to remove null values from the `batchedChanges` which are sent to the SQLite, if no existing value is present.
+            if (!existingValue) {
+                batchedChanges = applyMerge(undefined, [batchedChanges], true);
+            }
+
+            const hasChanged = cache.hasValueChanged(key, modifiedData);
+
+            // This approach prioritizes fast UI changes without waiting for data to be stored in device storage.
+            const updatePromise = broadcastUpdate(key, modifiedData, hasChanged, 'merge');
+
+            // If the value has not changed, calling Storage.setItem() would be redundant and a waste of performance, so return early instead.
+            if (!hasChanged || isClearing) {
+                return updatePromise;
+            }
+
+            return Storage.mergeItem(key, batchedChanges, modifiedData).then(() => updatePromise);
+        } catch (error) {
+            Logger.logAlert(`An error occurred while applying merge for key: ${key}, Error: ${error}`);
+            return Promise.resolve();
+        }
+    });
 
     return mergeQueuePromise[key];
 }
@@ -1288,14 +1294,13 @@ function merge(key, changes) {
  * @returns {Promise}
  */
 function initializeWithDefaultKeyStates() {
-    return Storage.multiGet(_.keys(defaultKeyStates))
-        .then((pairs) => {
-            const asObject = _.object(pairs);
+    return Storage.multiGet(_.keys(defaultKeyStates)).then((pairs) => {
+        const asObject = _.object(pairs);
 
-            const merged = utils.fastMerge(asObject, defaultKeyStates);
-            cache.merge(merged);
-            _.each(merged, (val, key) => keyChanged(key, val));
-        });
+        const merged = utils.fastMerge(asObject, defaultKeyStates);
+        cache.merge(merged);
+        _.each(merged, (val, key) => keyChanged(key, val));
+    });
 }
 
 /**
@@ -1332,70 +1337,71 @@ function clear(keysToPreserve = []) {
 
     isClearing = true;
 
-    return getAllKeys()
-        .then((keys) => {
-            const keysToBeClearedFromStorage = [];
-            const keyValuesToResetAsCollection = {};
-            const keyValuesToResetIndividually = {};
+    return getAllKeys().then((keys) => {
+        const keysToBeClearedFromStorage = [];
+        const keyValuesToResetAsCollection = {};
+        const keyValuesToResetIndividually = {};
 
-            // The only keys that should not be cleared are:
-            // 1. Anything specifically passed in keysToPreserve (because some keys like language preferences, offline
-            //      status, or activeClients need to remain in Onyx even when signed out)
-            // 2. Any keys with a default state (because they need to remain in Onyx as their default, and setting them
-            //      to null would cause unknown behavior)
-            _.each(keys, (key) => {
-                const isKeyToPreserve = _.contains(keysToPreserve, key);
-                const isDefaultKey = _.has(defaultKeyStates, key);
+        // The only keys that should not be cleared are:
+        // 1. Anything specifically passed in keysToPreserve (because some keys like language preferences, offline
+        //      status, or activeClients need to remain in Onyx even when signed out)
+        // 2. Any keys with a default state (because they need to remain in Onyx as their default, and setting them
+        //      to null would cause unknown behavior)
+        _.each(keys, (key) => {
+            const isKeyToPreserve = _.contains(keysToPreserve, key);
+            const isDefaultKey = _.has(defaultKeyStates, key);
 
-                // If the key is being removed or reset to default:
-                // 1. Update it in the cache
-                // 2. Figure out whether it is a collection key or not,
-                //      since collection key subscribers need to be updated differently
-                if (!isKeyToPreserve) {
-                    const oldValue = cache.getValue(key);
-                    const newValue = _.get(defaultKeyStates, key, null);
-                    if (newValue !== oldValue) {
-                        cache.set(key, newValue);
-                        const collectionKey = key.substring(0, key.indexOf('_') + 1);
-                        if (collectionKey) {
-                            if (!keyValuesToResetAsCollection[collectionKey]) {
-                                keyValuesToResetAsCollection[collectionKey] = {};
-                            }
-                            keyValuesToResetAsCollection[collectionKey][key] = newValue;
-                        } else {
-                            keyValuesToResetIndividually[key] = newValue;
+            // If the key is being removed or reset to default:
+            // 1. Update it in the cache
+            // 2. Figure out whether it is a collection key or not,
+            //      since collection key subscribers need to be updated differently
+            if (!isKeyToPreserve) {
+                const oldValue = cache.getValue(key);
+                const newValue = _.get(defaultKeyStates, key, null);
+                if (newValue !== oldValue) {
+                    cache.set(key, newValue);
+                    const collectionKey = key.substring(0, key.indexOf('_') + 1);
+                    if (collectionKey) {
+                        if (!keyValuesToResetAsCollection[collectionKey]) {
+                            keyValuesToResetAsCollection[collectionKey] = {};
                         }
+                        keyValuesToResetAsCollection[collectionKey][key] = newValue;
+                    } else {
+                        keyValuesToResetIndividually[key] = newValue;
                     }
                 }
+            }
 
-                if (isKeyToPreserve || isDefaultKey) {
-                    return;
-                }
+            if (isKeyToPreserve || isDefaultKey) {
+                return;
+            }
 
-                // If it isn't preserved and doesn't have a default, we'll remove it
-                keysToBeClearedFromStorage.push(key);
-            });
+            // If it isn't preserved and doesn't have a default, we'll remove it
+            keysToBeClearedFromStorage.push(key);
+        });
 
-            const updatePromises = [];
+        const updatePromises = [];
 
-            // Notify the subscribers for each key/value group so they can receive the new values
-            _.each(keyValuesToResetIndividually, (value, key) => {
-                updatePromises.push(scheduleSubscriberUpdate(key, value));
-            });
-            _.each(keyValuesToResetAsCollection, (value, key) => {
-                updatePromises.push(scheduleNotifyCollectionSubscribers(key, value));
-            });
+        // Notify the subscribers for each key/value group so they can receive the new values
+        _.each(keyValuesToResetIndividually, (value, key) => {
+            updatePromises.push(scheduleSubscriberUpdate(key, value));
+        });
+        _.each(keyValuesToResetAsCollection, (value, key) => {
+            updatePromises.push(scheduleNotifyCollectionSubscribers(key, value));
+        });
 
-            const defaultKeyValuePairs = _.pairs(_.omit(defaultKeyStates, keysToPreserve));
+        const defaultKeyValuePairs = _.pairs(_.omit(defaultKeyStates, keysToPreserve));
 
-            // Remove only the items that we want cleared from storage, and reset others to default
-            _.each(keysToBeClearedFromStorage, key => cache.drop(key));
-            return Storage.removeItems(keysToBeClearedFromStorage).then(() => Storage.multiSet(defaultKeyValuePairs)).then(() => {
+        // Remove only the items that we want cleared from storage, and reset others to default
+        _.each(keysToBeClearedFromStorage, (key) => cache.drop(key));
+        return Storage.removeItems(keysToBeClearedFromStorage)
+            .then(() => Storage.multiSet(defaultKeyValuePairs))
+            .then(() => {
                 isClearing = false;
                 Broadcast.sendMessage({type: METHOD.CLEAR, keysToPreserve});
                 return Promise.all(updatePromises);
             });
-        });
+    });
 }
 
 /**
@@ -1438,49 +1444,48 @@ function mergeCollection(collectionKey, collection) {
         return Promise.resolve();
     }
 
-    return getAllKeys()
-        .then((persistedKeys) => {
-            // Split to keys that exist in storage and keys that don't
-            const [existingKeys, newKeys] = _.chain(collection)
-                .pick((value, key) => {
-                    if (_.isNull(value)) {
-                        remove(key);
-                        return false;
-                    }
-                    return true;
-                })
-                .keys()
-                .partition(key => persistedKeys.includes(key))
-                .value();
+    return getAllKeys().then((persistedKeys) => {
+        // Split to keys that exist in storage and keys that don't
+        const [existingKeys, newKeys] = _.chain(collection)
+            .pick((value, key) => {
+                if (_.isNull(value)) {
+                    remove(key);
+                    return false;
+                }
+                return true;
+            })
+            .keys()
+            .partition((key) => persistedKeys.includes(key))
+            .value();
 
-            const existingKeyCollection = _.pick(collection, existingKeys);
-            const newCollection = _.pick(collection, newKeys);
-            const keyValuePairsForExistingCollection = prepareKeyValuePairsForStorage(existingKeyCollection);
-            const keyValuePairsForNewCollection = prepareKeyValuePairsForStorage(newCollection);
+        const existingKeyCollection = _.pick(collection, existingKeys);
+        const newCollection = _.pick(collection, newKeys);
+        const keyValuePairsForExistingCollection = prepareKeyValuePairsForStorage(existingKeyCollection);
+        const keyValuePairsForNewCollection = prepareKeyValuePairsForStorage(newCollection);
 
-            const promises = [];
+        const promises = [];
 
-            // New keys will be added via multiSet while existing keys will be updated using multiMerge
-            // This is because setting a key that doesn't exist yet with multiMerge will throw errors
-            if (keyValuePairsForExistingCollection.length > 0) {
-                promises.push(Storage.multiMerge(keyValuePairsForExistingCollection));
-            }
+        // New keys will be added via multiSet while existing keys will be updated using multiMerge
+        // This is because setting a key that doesn't exist yet with multiMerge will throw errors
+        if (keyValuePairsForExistingCollection.length > 0) {
+            promises.push(Storage.multiMerge(keyValuePairsForExistingCollection));
+        }
 
-            if (keyValuePairsForNewCollection.length > 0) {
-                promises.push(Storage.multiSet(keyValuePairsForNewCollection));
-            }
+        if (keyValuePairsForNewCollection.length > 0) {
+            promises.push(Storage.multiSet(keyValuePairsForNewCollection));
+        }
 
-            // Prefill cache if necessary by calling get() on any existing keys and then merge original data to cache
-            // and update all subscribers
-            const promiseUpdate = Promise.all(_.map(existingKeys, get)).then(() => {
-                cache.merge(collection);
-                return scheduleNotifyCollectionSubscribers(collectionKey, collection);
-            });
-
-            return Promise.all(promises)
-                .catch(error => evictStorageAndRetry(error, mergeCollection, collection))
-                .then(() => promiseUpdate);
+        // Prefill cache if necessary by calling get() on any existing keys and then merge original data to cache
+        // and update all subscribers
+        const promiseUpdate = Promise.all(_.map(existingKeys, get)).then(() => {
+            cache.merge(collection);
+            return scheduleNotifyCollectionSubscribers(collectionKey, collection);
         });
+
+        return Promise.all(promises)
+            .catch((error) => evictStorageAndRetry(error, mergeCollection, collection))
+            .then(() => promiseUpdate);
+    });
 }
 
 /**
@@ -1530,7 +1535,7 @@ function update(data) {
         }
     });
 
-    return clearPromise.then(() => Promise.all(_.map(promises, p => p())));
+    return clearPromise.then(() => Promise.all(_.map(promises, (p) => p())));
 }
 
 /**
@@ -1646,10 +1651,14 @@ function init({
     // We need the value of the collection keys later for checking if a
     // key is a collection. We store it in a map for faster lookup.
     const collectionValues = _.values(keys.COLLECTION);
-    onyxCollectionKeyMap = _.reduce(collectionValues, (acc, val) => {
-        acc.set(val, true);
-        return acc;
-    }, new Map());
+    onyxCollectionKeyMap = _.reduce(
+        collectionValues,
+        (acc, val) => {
+            acc.set(val, true);
+            return acc;
+        },
+        new Map(),
+    );
 
     // Set our default key states to use when initializing and clearing Onyx data
     defaultKeyStates = initialKeyStates;
@@ -1658,11 +1667,7 @@ function init({
     evictionAllowList = safeEvictionKeys;
 
     // Initialize all of our keys with data provided then give green light to any pending connections
-    Promise.all([
-        addAllSafeEvictionKeysToRecentlyAccessedList(),
-        initializeWithDefaultKeyStates(),
-    ])
-        .then(deferredInitTask.resolve);
+    Promise.all([addAllSafeEvictionKeysToRecentlyAccessedList(), initializeWithDefaultKeyStates()]).then(deferredInitTask.resolve);
 
     if (shouldSyncMultipleInstances && _.isFunction(Storage.keepInstancesSync)) {
         Storage.keepInstancesSync((key, value) => {

--- a/lib/OnyxCache.js
+++ b/lib/OnyxCache.js
@@ -43,8 +43,17 @@ class OnyxCache {
         // bind all public methods to prevent problems with `this`
         _.bindAll(
             this,
-            'getAllKeys', 'getValue', 'hasCacheForKey', 'addKey', 'set', 'drop', 'merge',
-            'hasPendingTask', 'getTaskPromise', 'captureTask', 'removeLeastRecentlyUsedKeys',
+            'getAllKeys',
+            'getValue',
+            'hasCacheForKey',
+            'addKey',
+            'set',
+            'drop',
+            'merge',
+            'hasPendingTask',
+            'getTaskPromise',
+            'captureTask',
+            'removeLeastRecentlyUsedKeys',
             'setRecentKeysLimit',
         );
     }
@@ -126,7 +135,7 @@ class OnyxCache {
         const storageKeys = this.getAllKeys();
         const mergedKeys = _.keys(data);
         this.storageKeys = new Set([...storageKeys, ...mergedKeys]);
-        _.each(mergedKeys, key => this.addToAccessedKeys(key));
+        _.each(mergedKeys, (key) => this.addToAccessedKeys(key));
     }
 
     /**

--- a/lib/Str.js
+++ b/lib/Str.js
@@ -8,9 +8,7 @@ import _ from 'underscore';
  * @return {Boolean} Returns true if the haystack starts with the needle.
  */
 function startsWith(haystack, needle) {
-    return _.isString(haystack)
-                && _.isString(needle)
-                && haystack.startsWith(needle);
+    return _.isString(haystack) && _.isString(needle) && haystack.startsWith(needle);
 }
 
 /**

--- a/lib/compose.js
+++ b/lib/compose.js
@@ -18,7 +18,7 @@
  */
 export default function compose(...funcs) {
     if (funcs.length === 0) {
-        return arg => arg;
+        return (arg) => arg;
     }
 
     if (funcs.length === 1) {
@@ -26,5 +26,9 @@ export default function compose(...funcs) {
     }
 
     // eslint-disable-next-line rulesdir/prefer-underscore-method
-    return funcs.reduce((a, b) => (...args) => a(b(...args)));
+    return funcs.reduce(
+        (a, b) =>
+            (...args) =>
+                a(b(...args)),
+    );
 }

--- a/lib/metrics/PerformanceUtils.js
+++ b/lib/metrics/PerformanceUtils.js
@@ -26,9 +26,7 @@ function diffObject(object, base) {
             }
 
             // eslint-disable-next-line no-param-reassign
-            result[key] = (_.isObject(value) && _.isObject(comparisonObject[key]))
-                ? changes(value, comparisonObject[key])
-                : value;
+            result[key] = _.isObject(value) && _.isObject(comparisonObject[key]) ? changes(value, comparisonObject[key]) : value;
         });
     }
     return changes(object, base);
@@ -62,7 +60,4 @@ function logSetStateCall(mapping, previousValue, newValue, caller, keyThatChange
     console.debug(`[Onyx-Debug] ${mapping.displayName} setState() called. Subscribed to key '${mapping.key}' (${caller})`, logParams);
 }
 
-export {
-    logSetStateCall,
-    setShouldDebugSetState,
-};
+export {logSetStateCall, setShouldDebugSetState};

--- a/lib/metrics/index.native.js
+++ b/lib/metrics/index.native.js
@@ -47,9 +47,9 @@ function decorateWithMetrics(func, alias = func.name) {
         const originalPromise = func.apply(this, args);
 
         /*
-        * Then handlers added here are not affecting the original promise
-        * They create a separate chain that's not exposed (returned) to the original caller
-        * */
+         * Then handlers added here are not affecting the original promise
+         * They create a separate chain that's not exposed (returned) to the original caller
+         * */
         originalPromise
             .then((result) => {
                 measureMarkToNow(mark, {result});
@@ -84,26 +84,29 @@ function sum(list, prop) {
  */
 function getMetrics() {
     const summaries = _.chain(performance.getEntriesByType('measure'))
-        .filter(entry => entry.detail && decoratedAliases.has(entry.detail.alias))
-        .groupBy(entry => entry.detail.alias)
+        .filter((entry) => entry.detail && decoratedAliases.has(entry.detail.alias))
+        .groupBy((entry) => entry.detail.alias)
         .map((calls, methodName) => {
             const total = sum(calls, 'duration');
-            const avg = (total / calls.length) || 0;
+            const avg = total / calls.length || 0;
             const max = _.max(calls, 'duration').duration || 0;
             const min = _.min(calls, 'duration').duration || 0;
 
             // Latest complete call (by end time) for all the calls made to the current method
-            const lastCall = _.max(calls, call => call.startTime + call.duration);
+            const lastCall = _.max(calls, (call) => call.startTime + call.duration);
 
-            return [methodName, {
+            return [
                 methodName,
-                total,
-                max,
-                min,
-                avg,
-                lastCall,
-                calls,
-            }];
+                {
+                    methodName,
+                    total,
+                    max,
+                    min,
+                    avg,
+                    lastCall,
+                    calls,
+                },
+            ];
         })
         .object() // Create a map like methodName -> StatSummary
         .value();
@@ -111,10 +114,7 @@ function getMetrics() {
     const totalTime = sum(_.values(summaries), 'total');
 
     // Latest complete call (by end time) of all methods up to this point
-    const lastCompleteCall = _.max(
-        _.values(summaries),
-        summary => summary.lastCall.startTime + summary.lastCall.duration,
-    ).lastCall;
+    const lastCompleteCall = _.max(_.values(summaries), (summary) => summary.lastCall.startTime + summary.lastCall.duration).lastCall;
 
     return {
         totalTime,
@@ -177,7 +177,7 @@ function printMetrics({raw = false, format = 'console', methods} = {}) {
     const methodNames = _.isArray(methods) ? methods : _.keys(summaries);
 
     const methodCallTables = _.chain(methodNames)
-        .filter(methodName => summaries[methodName] && summaries[methodName].avg > 0)
+        .filter((methodName) => summaries[methodName] && summaries[methodName].avg > 0)
         .map((methodName) => {
             const {calls, ...methodStats} = summaries[methodName];
             tableSummary.addRow(
@@ -186,7 +186,7 @@ function printMetrics({raw = false, format = 'console', methods} = {}) {
                 toDuration(methodStats.max, raw),
                 toDuration(methodStats.min, raw),
                 toDuration(methodStats.avg, raw),
-                toDuration((methodStats.lastCall.startTime + methodStats.lastCall.duration) - timeOrigin, raw),
+                toDuration(methodStats.lastCall.startTime + methodStats.lastCall.duration - timeOrigin, raw),
                 calls.length,
             );
 
@@ -194,12 +194,12 @@ function printMetrics({raw = false, format = 'console', methods} = {}) {
                 title: methodName,
                 heading: ['start time', 'end time', 'duration', 'args'],
                 leftAlignedCols: [3],
-                rows: _.map(calls, call => ([
+                rows: _.map(calls, (call) => [
                     toDuration(call.startTime - performance.timeOrigin, raw),
-                    toDuration((call.startTime + call.duration) - timeOrigin, raw),
+                    toDuration(call.startTime + call.duration - timeOrigin, raw),
                     toDuration(call.duration, raw),
                     _.map(call.detail.args, String).join(', ').slice(0, 60), // Restrict cell width to 60 chars max
-                ])),
+                ]),
             });
         })
         .value();
@@ -219,17 +219,9 @@ function printMetrics({raw = false, format = 'console', methods} = {}) {
         }).join('\n\n');
     }
 
-    const lastComplete = lastCompleteCall && toDuration(
-        (lastCompleteCall.startTime + lastCompleteCall.duration) - timeOrigin, raw,
-    );
+    const lastComplete = lastCompleteCall && toDuration(lastCompleteCall.startTime + lastCompleteCall.duration - timeOrigin, raw);
 
-    const mainOutput = [
-        '### Onyx Benchmark',
-        `  - Total: ${toDuration(totalTime, raw)}`,
-        `  - Last call finished at: ${lastComplete || 'N/A'}`,
-        '',
-        tableSummary.toString(),
-    ];
+    const mainOutput = ['### Onyx Benchmark', `  - Total: ${toDuration(totalTime, raw)}`, `  - Last call finished at: ${lastComplete || 'N/A'}`, '', tableSummary.toString()];
 
     /* eslint-disable no-console */
     console.info(mainOutput.join('\n'));
@@ -248,7 +240,7 @@ function resetMetrics() {
     const {summaries} = getMetrics();
 
     _.chain(summaries)
-        .map(summary => summary.calls)
+        .map((summary) => summary.calls)
         .flatten()
         .each((measure) => {
             performance.clearMarks(measure.detail.alias);
@@ -256,9 +248,4 @@ function resetMetrics() {
         });
 }
 
-export {
-    decorateWithMetrics,
-    getMetrics,
-    resetMetrics,
-    printMetrics,
-};
+export {decorateWithMetrics, getMetrics, resetMetrics, printMetrics};

--- a/lib/metrics/index.web.js
+++ b/lib/metrics/index.web.js
@@ -1,13 +1,10 @@
 // For web-only implementations of Onyx, this module will just be a no-op
 
-function decorateWithMetrics(func) { return func; }
+function decorateWithMetrics(func) {
+    return func;
+}
 function getMetrics() {}
 function printMetrics() {}
 function resetMetrics() {}
 
-export {
-    decorateWithMetrics,
-    getMetrics,
-    resetMetrics,
-    printMetrics,
-};
+export {decorateWithMetrics, getMetrics, resetMetrics, printMetrics};

--- a/lib/storage/WebStorage.js
+++ b/lib/storage/WebStorage.js
@@ -31,17 +31,13 @@ const webStorage = {
      */
     keepInstancesSync(onStorageKeyChanged) {
         // Override set, remove and clear to raise storage events that we intercept in other tabs
-        this.setItem = (key, value) => Storage.setItem(key, value)
-            .then(() => raiseStorageSyncEvent(key));
+        this.setItem = (key, value) => Storage.setItem(key, value).then(() => raiseStorageSyncEvent(key));
 
-        this.removeItem = key => Storage.removeItem(key)
-            .then(() => raiseStorageSyncEvent(key));
+        this.removeItem = (key) => Storage.removeItem(key).then(() => raiseStorageSyncEvent(key));
 
-        this.removeItems = keys => Storage.removeItems(keys)
-            .then(() => raiseStorageSyncManyKeysEvent(keys));
+        this.removeItems = (keys) => Storage.removeItems(keys).then(() => raiseStorageSyncManyKeysEvent(keys));
 
-        this.mergeItem = (key, batchedChanges, modifiedData) => Storage.mergeItem(key, batchedChanges, modifiedData)
-            .then(() => raiseStorageSyncEvent(key));
+        this.mergeItem = (key, batchedChanges, modifiedData) => Storage.mergeItem(key, batchedChanges, modifiedData).then(() => raiseStorageSyncEvent(key));
 
         // If we just call Storage.clear other tabs will have no idea which keys were available previously
         // so that they can call keysChanged for them. That's why we iterate over every key and raise a storage sync
@@ -70,8 +66,7 @@ const webStorage = {
             }
 
             const onyxKey = event.newValue;
-            Storage.getItem(onyxKey)
-                .then(value => onStorageKeyChanged(onyxKey, value));
+            Storage.getItem(onyxKey).then((value) => onStorageKeyChanged(onyxKey, value));
         });
     },
 };

--- a/lib/storage/__mocks__/index.js
+++ b/lib/storage/__mocks__/index.js
@@ -14,13 +14,13 @@ const idbKeyvalMock = {
     },
     multiSet(pairs) {
         const setPromises = _.map(pairs, ([key, value]) => this.setItem(key, value));
-        return new Promise(resolve => Promise.all(setPromises).then(() => resolve(storageMapInternal)));
+        return new Promise((resolve) => Promise.all(setPromises).then(() => resolve(storageMapInternal)));
     },
     getItem(key) {
         return Promise.resolve(storageMapInternal[key]);
     },
     multiGet(keys) {
-        const getPromises = _.map(keys, key => new Promise(resolve => this.getItem(key).then(value => resolve([key, value]))));
+        const getPromises = _.map(keys, (key) => new Promise((resolve) => this.getItem(key).then((value) => resolve([key, value]))));
         return Promise.all(getPromises);
     },
     multiMerge(pairs) {

--- a/lib/storage/providers/IDBKeyVal.js
+++ b/lib/storage/providers/IDBKeyVal.js
@@ -1,15 +1,4 @@
-import {
-    set,
-    keys,
-    getMany,
-    setMany,
-    get,
-    clear,
-    del,
-    delMany,
-    createStore,
-    promisifyRequest,
-} from 'idb-keyval';
+import {set, keys, getMany, setMany, get, clear, del, delMany, createStore, promisifyRequest} from 'idb-keyval';
 import _ from 'underscore';
 import utils from '../../utils';
 
@@ -38,8 +27,7 @@ const provider = {
      * @param {String[]} keysParam
      * @return {Promise<Array<[key, value]>>}
      */
-    multiGet: keysParam => getMany(keysParam, getCustomStore())
-        .then(values => _.map(values, (value, index) => [keysParam[index], value])),
+    multiGet: (keysParam) => getMany(keysParam, getCustomStore()).then((values) => _.map(values, (value, index) => [keysParam[index], value])),
 
     /**
      * Multiple merging of existing and new values in a batch
@@ -47,21 +35,22 @@ const provider = {
      * This function also removes all nested null values from an object.
      * @return {Promise<void>}
      */
-    multiMerge: pairs => getCustomStore()('readwrite', (store) => {
-        // Note: we are using the manual store transaction here, to fit the read and update
-        // of the items in one transaction to achieve best performance.
+    multiMerge: (pairs) =>
+        getCustomStore()('readwrite', (store) => {
+            // Note: we are using the manual store transaction here, to fit the read and update
+            // of the items in one transaction to achieve best performance.
 
-        const getValues = Promise.all(_.map(pairs, ([key]) => promisifyRequest(store.get(key))));
+            const getValues = Promise.all(_.map(pairs, ([key]) => promisifyRequest(store.get(key))));
 
-        return getValues.then((values) => {
-            const upsertMany = _.map(pairs, ([key, value], index) => {
-                const prev = values[index];
-                const newValue = utils.fastMerge(prev, value);
-                return promisifyRequest(store.put(newValue, key));
+            return getValues.then((values) => {
+                const upsertMany = _.map(pairs, ([key, value], index) => {
+                    const prev = values[index];
+                    const newValue = utils.fastMerge(prev, value);
+                    return promisifyRequest(store.put(newValue, key));
+                });
+                return Promise.all(upsertMany);
             });
-            return Promise.all(upsertMany);
-        });
-    }),
+        }),
 
     /**
      * Merging an existing value with a new one
@@ -80,7 +69,7 @@ const provider = {
      * @param {Array<[key, value]>} pairs
      * @return {Promise<void>}
      */
-    multiSet: pairs => setMany(pairs, getCustomStore()),
+    multiSet: (pairs) => setMany(pairs, getCustomStore()),
 
     /**
      * Clear everything from storage and also stops the SyncQueue from adding anything more to storage
@@ -102,17 +91,17 @@ const provider = {
      * @param {String} key
      * @return {Promise<*>}
      */
-    getItem: key => get(key, getCustomStore())
-
-        // idb-keyval returns undefined for missing items, but this needs to return null so that idb-keyval does the same thing as SQLiteStorage.
-        .then(val => (val === undefined ? null : val)),
+    getItem: (key) =>
+        get(key, getCustomStore())
+            // idb-keyval returns undefined for missing items, but this needs to return null so that idb-keyval does the same thing as SQLiteStorage.
+            .then((val) => (val === undefined ? null : val)),
 
     /**
      * Remove given key and it's value from storage
      * @param {String} key
      * @returns {Promise<void>}
      */
-    removeItem: key => del(key, getCustomStore()),
+    removeItem: (key) => del(key, getCustomStore()),
 
     /**
      * Remove given keys and their values from storage
@@ -120,7 +109,7 @@ const provider = {
      * @param {Array} keysParam
      * @returns {Promise}
      */
-    removeItems: keysParam => delMany(keysParam, getCustomStore()),
+    removeItems: (keysParam) => delMany(keysParam, getCustomStore()),
 
     /**
      * Gets the total bytes of the database file
@@ -131,8 +120,9 @@ const provider = {
             throw new Error('StorageManager browser API unavailable');
         }
 
-        return window.navigator.storage.estimate()
-            .then(value => ({
+        return window.navigator.storage
+            .estimate()
+            .then((value) => ({
                 bytesUsed: value.usage,
                 bytesRemaining: value.quota - value.usage,
             }))

--- a/lib/storage/providers/SQLiteStorage.js
+++ b/lib/storage/providers/SQLiteStorage.js
@@ -19,10 +19,10 @@ db.execute('PRAGMA journal_mode=WAL;');
 
 const provider = {
     /**
-    * Get the value of a given key or return `null` if it's not available in storage
-    * @param {String} key
-    * @return {Promise<*>}
-    */
+     * Get the value of a given key or return `null` if it's not available in storage
+     * @param {String} key
+     * @return {Promise<*>}
+     */
     getItem(key) {
         return db.executeAsync('SELECT record_key, valueJSON FROM keyvaluepairs WHERE record_key = ?;', [key]).then(({rows}) => {
             if (rows.length === 0) {
@@ -34,41 +34,37 @@ const provider = {
     },
 
     /**
-    * Get multiple key-value pairs for the given array of keys in a batch
-    * @param {String[]} keys
-    * @return {Promise<Array<[key, value]>>}
-    */
+     * Get multiple key-value pairs for the given array of keys in a batch
+     * @param {String[]} keys
+     * @return {Promise<Array<[key, value]>>}
+     */
     multiGet(keys) {
         const placeholders = _.map(keys, () => '?').join(',');
         const command = `SELECT record_key, valueJSON FROM keyvaluepairs WHERE record_key IN (${placeholders});`;
-        return db.executeAsync(command, keys)
-            .then(({rows}) => {
-                // eslint-disable-next-line no-underscore-dangle
-                const result = _.map(rows._array, row => [row.record_key, JSON.parse(row.valueJSON)]);
-                return result;
-            });
+        return db.executeAsync(command, keys).then(({rows}) => {
+            // eslint-disable-next-line no-underscore-dangle
+            const result = _.map(rows._array, (row) => [row.record_key, JSON.parse(row.valueJSON)]);
+            return result;
+        });
     },
 
     /**
-    * Sets the value for a given key. The only requirement is that the value should be serializable to JSON string
-    * @param {String} key
-    * @param {*} value
-    * @return {Promise<void>}
-    */
+     * Sets the value for a given key. The only requirement is that the value should be serializable to JSON string
+     * @param {String} key
+     * @param {*} value
+     * @return {Promise<void>}
+     */
     setItem(key, value) {
         return db.executeAsync('REPLACE INTO keyvaluepairs (record_key, valueJSON) VALUES (?, ?);', [key, JSON.stringify(value)]);
     },
 
     /**
-    * Stores multiple key-value pairs in a batch
-    * @param {Array<[key, value]>} pairs
-    * @return {Promise<void>}
-    */
+     * Stores multiple key-value pairs in a batch
+     * @param {Array<[key, value]>} pairs
+     * @return {Promise<void>}
+     */
     multiSet(pairs) {
-        const stringifiedPairs = _.map(pairs, pair => [
-            pair[0],
-            JSON.stringify(_.isUndefined(pair[1]) ? null : pair[1]),
-        ]);
+        const stringifiedPairs = _.map(pairs, (pair) => [pair[0], JSON.stringify(_.isUndefined(pair[1]) ? null : pair[1])]);
         if (_.isEmpty(stringifiedPairs)) {
             return Promise.resolve();
         }
@@ -76,10 +72,10 @@ const provider = {
     },
 
     /**
-    * Multiple merging of existing and new values in a batch
-    * @param {Array<[key, value]>} pairs
-    * @return {Promise<void>}
-    */
+     * Multiple merging of existing and new values in a batch
+     * @param {Array<[key, value]>} pairs
+     * @return {Promise<void>}
+     */
     multiMerge(pairs) {
         // Note: We use `ON CONFLICT DO UPDATE` here instead of `INSERT OR REPLACE INTO`
         // so the new JSON value is merged into the old one if there's an existing value
@@ -89,7 +85,7 @@ const provider = {
              SET valueJSON = JSON_PATCH(valueJSON, JSON(:value));
         `;
 
-        const nonNullishPairs = _.filter(pairs, pair => !_.isUndefined(pair[1]));
+        const nonNullishPairs = _.filter(pairs, (pair) => !_.isUndefined(pair[1]));
         const queryArguments = _.map(nonNullishPairs, (pair) => {
             const value = JSON.stringify(pair[1]);
             return [pair[0], value];
@@ -99,31 +95,32 @@ const provider = {
     },
 
     /**
-    * Merges an existing value with a new one by leveraging JSON_PATCH
-    * @param {String} key
-    * @param {*} changes - the delta for a specific key
-    * @return {Promise<void>}
-    */
+     * Merges an existing value with a new one by leveraging JSON_PATCH
+     * @param {String} key
+     * @param {*} changes - the delta for a specific key
+     * @return {Promise<void>}
+     */
     mergeItem(key, changes) {
         return this.multiMerge([[key, changes]]);
     },
 
     /**
-    * Returns all keys available in storage
-    * @returns {Promise<String[]>}
-    */
-    getAllKeys: () => db.executeAsync('SELECT record_key FROM keyvaluepairs;').then(({rows}) => {
-        // eslint-disable-next-line no-underscore-dangle
-        const result = _.map(rows._array, row => row.record_key);
-        return result;
-    }),
+     * Returns all keys available in storage
+     * @returns {Promise<String[]>}
+     */
+    getAllKeys: () =>
+        db.executeAsync('SELECT record_key FROM keyvaluepairs;').then(({rows}) => {
+            // eslint-disable-next-line no-underscore-dangle
+            const result = _.map(rows._array, (row) => row.record_key);
+            return result;
+        }),
 
     /**
-    * Removes given key and it's value from storage
-    * @param {String} key
-    * @returns {Promise<void>}
-    */
-    removeItem: key => db.executeAsync('DELETE FROM keyvaluepairs WHERE record_key = ?;', [key]),
+     * Removes given key and it's value from storage
+     * @param {String} key
+     * @returns {Promise<void>}
+     */
+    removeItem: (key) => db.executeAsync('DELETE FROM keyvaluepairs WHERE record_key = ?;', [key]),
 
     /**
      * Removes given keys and their values from storage
@@ -138,9 +135,9 @@ const provider = {
     },
 
     /**
-    * Clears absolutely everything from storage
-    * @returns {Promise<void>}
-    */
+     * Clears absolutely everything from storage
+     * @returns {Promise<void>}
+     */
     clear: () => db.executeAsync('DELETE FROM keyvaluepairs;', []),
 
     /**
@@ -153,15 +150,14 @@ const provider = {
      * @returns {Promise}
      */
     getDatabaseSize() {
-        return Promise.all([db.executeAsync('PRAGMA page_size;'), db.executeAsync('PRAGMA page_count;'), getFreeDiskStorage()])
-            .then(([pageSizeResult, pageCountResult, bytesRemaining]) => {
-                const pageSize = pageSizeResult.rows.item(0).page_size;
-                const pageCount = pageCountResult.rows.item(0).page_count;
-                return {
-                    bytesUsed: pageSize * pageCount,
-                    bytesRemaining,
-                };
-            });
+        return Promise.all([db.executeAsync('PRAGMA page_size;'), db.executeAsync('PRAGMA page_count;'), getFreeDiskStorage()]).then(([pageSizeResult, pageCountResult, bytesRemaining]) => {
+            const pageSize = pageSizeResult.rows.item(0).page_size;
+            const pageCount = pageCountResult.rows.item(0).page_count;
+            return {
+                bytesUsed: pageSize * pageCount,
+                bytesRemaining,
+            };
+        });
     },
 
     /**

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -221,16 +221,4 @@ type NullishObjectDeep<ObjectType extends object> = {
     [KeyType in keyof ObjectType]?: NullishDeep<ObjectType[KeyType]> | null;
 };
 
-export {
-    CollectionKey,
-    CollectionKeyBase,
-    CustomTypeOptions,
-    DeepRecord,
-    Key,
-    KeyValueMapping,
-    OnyxCollection,
-    OnyxEntry,
-    OnyxKey,
-    Selector,
-    NullishDeep,
-};
+export {CollectionKey, CollectionKeyBase, CustomTypeOptions, DeepRecord, Key, KeyValueMapping, OnyxCollection, OnyxEntry, OnyxKey, Selector, NullishDeep};

--- a/lib/utils.d.ts
+++ b/lib/utils.d.ts
@@ -5,10 +5,6 @@
  * On native, when merging an existing value with new changes, SQLite will use JSON_PATCH, which removes top-level nullish values.
  * To be consistent with the behaviour for merge, we'll also want to remove null values for "set" operations.
  */
-declare function fastMerge<T>(
-    target: T,
-    source: T,
-    shouldRemoveNullObjectValues: boolean = true
-): T;
+declare function fastMerge<T>(target: T, source: T, shouldRemoveNullObjectValues: boolean = true): T;
 
-export default { fastMerge };
+export default {fastMerge};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,12 +1,7 @@
 import _ from 'underscore';
 
 function areObjectsEmpty(a, b) {
-    return (
-        typeof a === 'object'
-        && typeof b === 'object'
-        && _.isEmpty(a)
-        && _.isEmpty(b)
-    );
+    return typeof a === 'object' && typeof b === 'object' && _.isEmpty(a) && _.isEmpty(b);
 }
 
 // Mostly copied from https://medium.com/@lubaka.a/how-to-remove-lodash-performance-improvement-b306669ad0e1
@@ -14,22 +9,24 @@ function areObjectsEmpty(a, b) {
 /**
  * @param {mixed} val
  * @returns {boolean}
-*/
+ */
 function isMergeableObject(val) {
     const nonNullObject = val != null ? typeof val === 'object' : false;
-    return (nonNullObject
-        && Object.prototype.toString.call(val) !== '[object RegExp]'
-        && Object.prototype.toString.call(val) !== '[object Date]')
+    return (
+        nonNullObject &&
+        Object.prototype.toString.call(val) !== '[object RegExp]' &&
+        Object.prototype.toString.call(val) !== '[object Date]' &&
         // eslint-disable-next-line rulesdir/prefer-underscore-method
-        && !Array.isArray(val);
+        !Array.isArray(val)
+    );
 }
 
 /**
-* @param {Object} target
-* @param {Object} source
-* @param {Boolean} shouldRemoveNullObjectValues
-* @returns {Object}
-*/
+ * @param {Object} target
+ * @param {Object} source
+ * @param {Boolean} shouldRemoveNullObjectValues
+ * @returns {Object}
+ */
 function mergeObject(target, source, shouldRemoveNullObjectValues = true) {
     const destination = {};
     if (isMergeableObject(target)) {
@@ -65,7 +62,7 @@ function mergeObject(target, source, shouldRemoveNullObjectValues = true) {
             const isSourceKeyMergable = isMergeableObject(source[key]);
 
             if (isSourceKeyMergable && target[key]) {
-                if ((!shouldRemoveNullObjectValues || isSourceKeyMergable)) {
+                if (!shouldRemoveNullObjectValues || isSourceKeyMergable) {
                     // eslint-disable-next-line no-use-before-define
                     destination[key] = fastMerge(target[key], source[key], shouldRemoveNullObjectValues);
                 }
@@ -85,11 +82,11 @@ function mergeObject(target, source, shouldRemoveNullObjectValues = true) {
  * On native, when merging an existing value with new changes, SQLite will use JSON_PATCH, which removes top-level nullish values.
  * To be consistent with the behaviour for merge, we'll also want to remove null values for "set" operations.
  *
-* @param {Object|Array} target
-* @param {Object|Array} source
-* @param {Boolean} shouldRemoveNullObjectValues
-* @returns {Object|Array}
-*/
+ * @param {Object|Array} target
+ * @param {Object|Array} source
+ * @param {Boolean} shouldRemoveNullObjectValues
+ * @returns {Object|Array}
+ */
 function fastMerge(target, source, shouldRemoveNullObjectValues = true) {
     // We have to ignore arrays and nullish values here,
     // otherwise "mergeObject" will throw an error,

--- a/lib/withOnyx.d.ts
+++ b/lib/withOnyx.d.ts
@@ -40,13 +40,7 @@ type EntryBaseMapping<TOnyxKey extends OnyxKey> = {
  * },
  * ```
  */
-type BaseMappingKey<
-    TComponentProps,
-    TOnyxProps,
-    TOnyxProp extends keyof TOnyxProps,
-    TOnyxKey extends OnyxKey,
-    TOnyxValue
-> = IsEqual<TOnyxValue, TOnyxProps[TOnyxProp]> extends true
+type BaseMappingKey<TComponentProps, TOnyxProps, TOnyxProp extends keyof TOnyxProps, TOnyxKey extends OnyxKey, TOnyxValue> = IsEqual<TOnyxValue, TOnyxProps[TOnyxProp]> extends true
     ? {
           key: TOnyxKey | ((props: Omit<TComponentProps, keyof TOnyxProps>) => TOnyxKey);
       }
@@ -67,12 +61,7 @@ type BaseMappingKey<
  * },
  * ```
  */
-type BaseMappingStringKeyAndSelector<
-    TComponentProps,
-    TOnyxProps,
-    TOnyxProp extends keyof TOnyxProps,
-    TOnyxKey extends OnyxKey
-> = {
+type BaseMappingStringKeyAndSelector<TComponentProps, TOnyxProps, TOnyxProp extends keyof TOnyxProps, TOnyxKey extends OnyxKey> = {
     key: TOnyxKey;
     selector: Selector<TOnyxKey, TOnyxProps[TOnyxProp]>;
 };
@@ -92,12 +81,7 @@ type BaseMappingStringKeyAndSelector<
  * },
  * ```
  */
-type BaseMappingFunctionKeyAndSelector<
-    TComponentProps,
-    TOnyxProps,
-    TOnyxProp extends keyof TOnyxProps,
-    TOnyxKey extends OnyxKey
-> = {
+type BaseMappingFunctionKeyAndSelector<TComponentProps, TOnyxProps, TOnyxProp extends keyof TOnyxProps, TOnyxKey extends OnyxKey> = {
     key: (props: Omit<TComponentProps, keyof TOnyxProps>) => TOnyxKey;
     selector: Selector<TOnyxKey, TOnyxProps[TOnyxProp]>;
 };
@@ -105,10 +89,8 @@ type BaseMappingFunctionKeyAndSelector<
 /**
  * Represents the mapping options between an Onyx key and the component's prop with all its possibilities.
  */
-type Mapping<TComponentProps, TOnyxProps, TOnyxProp extends keyof TOnyxProps, TOnyxKey extends OnyxKey> = BaseMapping<
-    TComponentProps,
-    TOnyxProps
-> & EntryBaseMapping<TOnyxKey> &
+type Mapping<TComponentProps, TOnyxProps, TOnyxProp extends keyof TOnyxProps, TOnyxKey extends OnyxKey> = BaseMapping<TComponentProps, TOnyxProps> &
+    EntryBaseMapping<TOnyxKey> &
     (
         | BaseMappingKey<TComponentProps, TOnyxProps, TOnyxProp, TOnyxKey, OnyxEntry<KeyValueMapping[TOnyxKey]>>
         | BaseMappingStringKeyAndSelector<TComponentProps, TOnyxProps, TOnyxProp, TOnyxKey>
@@ -118,12 +100,8 @@ type Mapping<TComponentProps, TOnyxProps, TOnyxProp extends keyof TOnyxProps, TO
 /**
  * Represents the mapping options between an Onyx collection key without suffix and the component's prop with all its possibilities.
  */
-type CollectionMapping<
-    TComponentProps,
-    TOnyxProps,
-    TOnyxProp extends keyof TOnyxProps,
-    TOnyxKey extends CollectionKeyBase
-> = BaseMapping<TComponentProps, TOnyxProps> & CollectionBaseMapping<TOnyxKey> &
+type CollectionMapping<TComponentProps, TOnyxProps, TOnyxProp extends keyof TOnyxProps, TOnyxKey extends CollectionKeyBase> = BaseMapping<TComponentProps, TOnyxProps> &
+    CollectionBaseMapping<TOnyxKey> &
     (
         | BaseMappingKey<TComponentProps, TOnyxProps, TOnyxProp, TOnyxKey, OnyxCollection<KeyValueMapping[TOnyxKey]>>
         | BaseMappingStringKeyAndSelector<TComponentProps, TOnyxProps, TOnyxProp, TOnyxKey>
@@ -153,9 +131,7 @@ type OnyxPropCollectionMapping<TComponentProps, TOnyxProps, TOnyxProp extends ke
  */
 declare function withOnyx<TComponentProps, TOnyxProps>(
     mapping: {
-        [TOnyxProp in keyof TOnyxProps]:
-            | OnyxPropMapping<TComponentProps, TOnyxProps, TOnyxProp>
-            | OnyxPropCollectionMapping<TComponentProps, TOnyxProps, TOnyxProp>;
+        [TOnyxProp in keyof TOnyxProps]: OnyxPropMapping<TComponentProps, TOnyxProps, TOnyxProp> | OnyxPropCollectionMapping<TComponentProps, TOnyxProps, TOnyxProp>;
     },
     shouldDelayUpdates?: boolean,
 ): (component: React.ComponentType<TComponentProps>) => React.ComponentType<Omit<TComponentProps, keyof TOnyxProps>>;

--- a/lib/withOnyx.js
+++ b/lib/withOnyx.js
@@ -36,7 +36,7 @@ const getOnyxDataFromState = (state, onyxToStateMapping) => _.pick(state, _.keys
 export default function (mapOnyxToState, shouldDelayUpdates = false) {
     // A list of keys that must be present in tempState before we can render the WrappedComponent
     const requiredKeysForInit = _.chain(mapOnyxToState)
-        .omit(config => config.initWithStoredValues === false)
+        .omit((config) => config.initWithStoredValues === false)
         .keys()
         .value();
     return (WrappedComponent) => {
@@ -74,11 +74,7 @@ export default function (mapOnyxToState, shouldDelayUpdates = false) {
                          * In reality, Onyx.merge() will only update the subscriber after all merges have been batched and the previous value is retrieved via a get() (returns a promise).
                          * So, we won't use the cache optimization here as it will lead us to arbitrarily defer various actions in the application code.
                          */
-                        if (
-                            (value !== undefined
-                                && !Onyx.hasPendingMergeForKey(key))
-                            || mapping.allowStaleData
-                        ) {
+                        if ((value !== undefined && !Onyx.hasPendingMergeForKey(key)) || mapping.allowStaleData) {
                             // eslint-disable-next-line no-param-reassign
                             resultObj[propertyName] = value;
                         }
@@ -132,9 +128,7 @@ export default function (mapOnyxToState, shouldDelayUpdates = false) {
                     // (eg. if a user switches chats really quickly). In this case, it's much more stable to always look at the changes to prevProp and prevState to derive the key.
                     // The second case cannot be used all the time because the onyx data doesn't change the first time that `componentDidUpdate()` runs after loading. In this case,
                     // the `mapping.previousKey` must be used for the comparison or else this logic never detects that onyx data could have changed during the loading process.
-                    const previousKey = isFirstTimeUpdatingAfterLoading
-                        ? mapping.previousKey
-                        : Str.result(mapping.key, {...prevProps, ...prevOnyxDataFromState});
+                    const previousKey = isFirstTimeUpdatingAfterLoading ? mapping.previousKey : Str.result(mapping.key, {...prevProps, ...prevOnyxDataFromState});
                     const newKey = Str.result(mapping.key, {...this.props, ...onyxDataFromState});
                     if (previousKey !== newKey) {
                         Onyx.disconnect(this.activeConnectionIDs[previousKey], previousKey);
@@ -202,7 +196,7 @@ export default function (mapOnyxToState, shouldDelayUpdates = false) {
                 this.tempState[statePropertyName] = val;
 
                 // If some key does not have a value yet, do not update the state yet
-                const tempStateIsMissingKey = _.some(requiredKeysForInit, key => _.isUndefined(this.tempState[key]));
+                const tempStateIsMissingKey = _.some(requiredKeysForInit, (key) => _.isUndefined(this.tempState[key]));
                 if (tempStateIsMissingKey) {
                     return;
                 }
@@ -212,29 +206,33 @@ export default function (mapOnyxToState, shouldDelayUpdates = false) {
 
                 // Full of hacky workarounds to prevent the race condition described above.
                 this.setState((prevState) => {
-                    const finalState = _.reduce(stateUpdate, (result, value, key) => {
-                        if (key === 'loading') {
+                    const finalState = _.reduce(
+                        stateUpdate,
+                        (result, value, key) => {
+                            if (key === 'loading') {
+                                return result;
+                            }
+
+                            const initialValue = mapOnyxToState[key].initialValue;
+
+                            // If initialValue is there and the state contains something different it means
+                            // an update has already been received and we can discard the value we are trying to hydrate
+                            if (!_.isUndefined(initialValue) && !_.isUndefined(prevState[key]) && prevState[key] !== initialValue) {
+                                // eslint-disable-next-line no-param-reassign
+                                result[key] = prevState[key];
+
+                                // if value is already there (without initial value) then we can discard the value we are trying to hydrate
+                            } else if (!_.isUndefined(prevState[key])) {
+                                // eslint-disable-next-line no-param-reassign
+                                result[key] = prevState[key];
+                            } else {
+                                // eslint-disable-next-line no-param-reassign
+                                result[key] = value;
+                            }
                             return result;
-                        }
-
-                        const initialValue = mapOnyxToState[key].initialValue;
-
-                        // If initialValue is there and the state contains something different it means
-                        // an update has already been received and we can discard the value we are trying to hydrate
-                        if (!_.isUndefined(initialValue) && !_.isUndefined(prevState[key]) && prevState[key] !== initialValue) {
-                            // eslint-disable-next-line no-param-reassign
-                            result[key] = prevState[key];
-
-                            // if value is already there (without initial value) then we can discard the value we are trying to hydrate
-                        } else if (!_.isUndefined(prevState[key])) {
-                            // eslint-disable-next-line no-param-reassign
-                            result[key] = prevState[key];
-                        } else {
-                            // eslint-disable-next-line no-param-reassign
-                            result[key] = value;
-                        }
-                        return result;
-                    }, {});
+                        },
+                        {},
+                    );
 
                     finalState.loading = false;
                     return finalState;
@@ -351,7 +349,12 @@ export default function (mapOnyxToState, shouldDelayUpdates = false) {
         return React.forwardRef((props, ref) => {
             const Component = withOnyx;
             // eslint-disable-next-line react/jsx-props-no-spreading
-            return <Component {...props} forwardedRef={ref} />;
+            return (
+                <Component
+                    {...props}
+                    forwardedRef={ref}
+                />
+            );
         });
     };
 }

--- a/lib/withOnyx.js
+++ b/lib/withOnyx.js
@@ -348,9 +348,9 @@ export default function (mapOnyxToState, shouldDelayUpdates = false) {
         withOnyx.displayName = `withOnyx(${displayName})`;
         return React.forwardRef((props, ref) => {
             const Component = withOnyx;
-            // eslint-disable-next-line react/jsx-props-no-spreading
             return (
                 <Component
+                    // eslint-disable-next-line react/jsx-props-no-spreading
                     {...props}
                     forwardedRef={ref}
                 />

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,8 @@
         "babel-jest": "^26.2.2",
         "babel-loader": "^8.2.5",
         "eslint": "^7.6.0",
-        "eslint-config-expensify": "^2.0.38",
+        "eslint-config-expensify": "^2.0.42",
+        "eslint-config-prettier": "^8.8.0",
         "eslint-plugin-jsx-a11y": "^6.6.1",
         "eslint-plugin-react": "^7.31.10",
         "idb-keyval": "^6.2.1",
@@ -36,6 +37,7 @@
         "jest-cli": "^26.5.2",
         "jsdoc-to-markdown": "^7.1.0",
         "metro-react-native-babel-preset": "^0.72.3",
+        "prettier": "^2.8.8",
         "prop-types": "^15.7.2",
         "react": "18.2.0",
         "react-dom": "^18.2.0",
@@ -3181,6 +3183,21 @@
       },
       "peerDependencies": {
         "eslint": ">=6"
+      }
+    },
+    "node_modules/@react-native-community/eslint-config/node_modules/eslint-config-prettier": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.15.0.tgz",
+      "integrity": "sha512-a1+kOYLR8wMGustcgAjdydMsQ2A/2ipRPwRKUmfYaSxc9ZPcrku080Ctl6zrZzZNs/U82MjSv+qKREkoq3bJaw==",
+      "dev": true,
+      "dependencies": {
+        "get-stdin": "^6.0.0"
+      },
+      "bin": {
+        "eslint-config-prettier-check": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=3.14.1"
       }
     },
     "node_modules/@react-native-community/eslint-plugin": {
@@ -6419,9 +6436,9 @@
       }
     },
     "node_modules/eslint-config-expensify": {
-      "version": "2.0.38",
-      "resolved": "https://registry.npmjs.org/eslint-config-expensify/-/eslint-config-expensify-2.0.38.tgz",
-      "integrity": "sha512-jAlrYSjkDV8YESUUPcaTjUM8Fgru+37FS+Hq6zzcRR0FbA5bLiOPguhJHo77XpYh5N+PEf4wrpgsS04sjdgDPg==",
+      "version": "2.0.42",
+      "resolved": "https://registry.npmjs.org/eslint-config-expensify/-/eslint-config-expensify-2.0.42.tgz",
+      "integrity": "sha512-TNwbfIGjOp4EjT6HKEpp10mr6dkBNCNMTeMmpuQyS0Nqv1tRGJltoU3GFmUHJywrLkEmu21iC0NNMmoJ1XzmLg==",
       "dev": true,
       "dependencies": {
         "@lwc/eslint-plugin-lwc": "^0.11.0",
@@ -6812,18 +6829,15 @@
       }
     },
     "node_modules/eslint-config-prettier": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.15.0.tgz",
-      "integrity": "sha512-a1+kOYLR8wMGustcgAjdydMsQ2A/2ipRPwRKUmfYaSxc9ZPcrku080Ctl6zrZzZNs/U82MjSv+qKREkoq3bJaw==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.10.0.tgz",
+      "integrity": "sha512-SM8AMJdeQqRYT9O9zguiruQZaN7+z+E4eAP9oiLNGKMtomwaB1E9dcgUD6ZAn/eQAb52USbvezbiljfZUhbJcg==",
       "dev": true,
-      "dependencies": {
-        "get-stdin": "^6.0.0"
-      },
       "bin": {
-        "eslint-config-prettier-check": "bin/cli.js"
+        "eslint-config-prettier": "bin/cli.js"
       },
       "peerDependencies": {
-        "eslint": ">=3.14.1"
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-import-resolver-node": {
@@ -13207,15 +13221,18 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
-      "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
       "engines": {
         "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prettier-linter-helpers": {
@@ -19511,6 +19528,17 @@
         "eslint-plugin-react-hooks": "^4.0.4",
         "eslint-plugin-react-native": "^3.8.1",
         "prettier": "^2.0.2"
+      },
+      "dependencies": {
+        "eslint-config-prettier": {
+          "version": "6.15.0",
+          "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.15.0.tgz",
+          "integrity": "sha512-a1+kOYLR8wMGustcgAjdydMsQ2A/2ipRPwRKUmfYaSxc9ZPcrku080Ctl6zrZzZNs/U82MjSv+qKREkoq3bJaw==",
+          "dev": true,
+          "requires": {
+            "get-stdin": "^6.0.0"
+          }
+        }
       }
     },
     "@react-native-community/eslint-plugin": {
@@ -22081,9 +22109,9 @@
       }
     },
     "eslint-config-expensify": {
-      "version": "2.0.38",
-      "resolved": "https://registry.npmjs.org/eslint-config-expensify/-/eslint-config-expensify-2.0.38.tgz",
-      "integrity": "sha512-jAlrYSjkDV8YESUUPcaTjUM8Fgru+37FS+Hq6zzcRR0FbA5bLiOPguhJHo77XpYh5N+PEf4wrpgsS04sjdgDPg==",
+      "version": "2.0.42",
+      "resolved": "https://registry.npmjs.org/eslint-config-expensify/-/eslint-config-expensify-2.0.42.tgz",
+      "integrity": "sha512-TNwbfIGjOp4EjT6HKEpp10mr6dkBNCNMTeMmpuQyS0Nqv1tRGJltoU3GFmUHJywrLkEmu21iC0NNMmoJ1XzmLg==",
       "dev": true,
       "requires": {
         "@lwc/eslint-plugin-lwc": "^0.11.0",
@@ -22377,13 +22405,11 @@
       }
     },
     "eslint-config-prettier": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.15.0.tgz",
-      "integrity": "sha512-a1+kOYLR8wMGustcgAjdydMsQ2A/2ipRPwRKUmfYaSxc9ZPcrku080Ctl6zrZzZNs/U82MjSv+qKREkoq3bJaw==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.10.0.tgz",
+      "integrity": "sha512-SM8AMJdeQqRYT9O9zguiruQZaN7+z+E4eAP9oiLNGKMtomwaB1E9dcgUD6ZAn/eQAb52USbvezbiljfZUhbJcg==",
       "dev": true,
-      "requires": {
-        "get-stdin": "^6.0.0"
-      }
+      "requires": {}
     },
     "eslint-import-resolver-node": {
       "version": "0.3.6",
@@ -27389,9 +27415,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
-      "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true
     },
     "prettier-linter-helpers": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "build:docs": "node buildDocs.js",
     "e2e": "playwright test",
     "e2e-ui": "playwright test --ui",
-    "postinstall": "cd tests/e2e/app && npm install"
+    "postinstall": "cd tests/e2e/app && npm install",
+    "prettier": "prettier --write ."
   },
   "dependencies": {
     "ascii-table": "0.0.9",
@@ -61,7 +62,8 @@
     "babel-jest": "^26.2.2",
     "babel-loader": "^8.2.5",
     "eslint": "^7.6.0",
-    "eslint-config-expensify": "^2.0.38",
+    "eslint-config-expensify": "^2.0.42",
+    "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-jsx-a11y": "^6.6.1",
     "eslint-plugin-react": "^7.31.10",
     "idb-keyval": "^6.2.1",
@@ -69,6 +71,7 @@
     "jest-cli": "^26.5.2",
     "jsdoc-to-markdown": "^7.1.0",
     "metro-react-native-babel-preset": "^0.72.3",
+    "prettier": "^2.8.8",
     "prop-types": "^15.7.2",
     "react": "18.2.0",
     "react-dom": "^18.2.0",

--- a/tests/components/ViewWithCollections.js
+++ b/tests/components/ViewWithCollections.js
@@ -5,9 +5,11 @@ import {View, Text} from 'react-native';
 import _ from 'underscore';
 
 const propTypes = {
-    collections: PropTypes.objectOf(PropTypes.shape({
-        ID: PropTypes.number,
-    })),
+    collections: PropTypes.objectOf(
+        PropTypes.shape({
+            ID: PropTypes.number,
+        }),
+    ),
     testObject: PropTypes.shape({
         ID: PropTypes.number,
     }),

--- a/tests/unit/cacheEvictionTest.js
+++ b/tests/unit/cacheEvictionTest.js
@@ -43,15 +43,13 @@ test('Cache eviction', () => {
 
             // When we set a new key we want to add and force the first attempt to fail
             const originalSetItem = StorageMock.setItem;
-            const setItemMock = jest.fn(originalSetItem)
-                .mockImplementationOnce(() => new Promise((_resolve, reject) => reject()));
+            const setItemMock = jest.fn(originalSetItem).mockImplementationOnce(() => new Promise((_resolve, reject) => reject()));
             StorageMock.setItem = setItemMock;
 
-            return Onyx.set(`${ONYX_KEYS.COLLECTION.TEST_KEY}${RECORD_TO_ADD}`, {test: 'add'})
-                .then(() => {
-                    // Then our collection should no longer contain the evictable key
-                    expect(collection[`${ONYX_KEYS.COLLECTION.TEST_KEY}${RECORD_TO_EVICT}`]).toBe(undefined);
-                    expect(collection[`${ONYX_KEYS.COLLECTION.TEST_KEY}${RECORD_TO_ADD}`]).toStrictEqual({test: 'add'});
-                });
+            return Onyx.set(`${ONYX_KEYS.COLLECTION.TEST_KEY}${RECORD_TO_ADD}`, {test: 'add'}).then(() => {
+                // Then our collection should no longer contain the evictable key
+                expect(collection[`${ONYX_KEYS.COLLECTION.TEST_KEY}${RECORD_TO_EVICT}`]).toBe(undefined);
+                expect(collection[`${ONYX_KEYS.COLLECTION.TEST_KEY}${RECORD_TO_ADD}`]).toStrictEqual({test: 'add'});
+            });
         });
 });

--- a/tests/unit/metricsTest.js
+++ b/tests/unit/metricsTest.js
@@ -2,7 +2,9 @@ import _ from 'underscore';
 import waitForPromisesToResolve from '../utils/waitForPromisesToResolve';
 
 describe('decorateWithMetrics', () => {
-    let decorateWithMetrics; let getMetrics; let resetMetrics;
+    let decorateWithMetrics;
+    let getMetrics;
+    let resetMetrics;
 
     beforeEach(() => {
         jest.resetModules();
@@ -21,22 +23,23 @@ describe('decorateWithMetrics', () => {
         mockFn = decorateWithMetrics(mockFn, 'mockFn');
         mockFn('mockedKey');
 
-        return waitForPromisesToResolve()
-            .then(() => {
-                // Then stats should contain expected data regarding the call: timings, args and result
-                const metrics = getMetrics();
-                expect(metrics).toEqual(expect.objectContaining({
+        return waitForPromisesToResolve().then(() => {
+            // Then stats should contain expected data regarding the call: timings, args and result
+            const metrics = getMetrics();
+            expect(metrics).toEqual(
+                expect.objectContaining({
                     totalTime: expect.any(Number),
                     lastCompleteCall: expect.any(Object),
                     summaries: expect.objectContaining({mockFn: expect.any(Object)}),
-                }));
+                }),
+            );
 
-                expect(_.keys(metrics.summaries)).toHaveLength(1);
+            expect(_.keys(metrics.summaries)).toHaveLength(1);
 
-                const firstCall = metrics.summaries.mockFn.calls[0];
-                expect(firstCall.startTime).toEqual(expect.any(Number));
-                expect(firstCall.detail.args).toEqual(['mockedKey']);
-            });
+            const firstCall = metrics.summaries.mockFn.calls[0];
+            expect(firstCall.startTime).toEqual(expect.any(Number));
+            expect(firstCall.detail.args).toEqual(['mockedKey']);
+        });
     });
 
     it('Should use function.name when alias was not provided', () => {
@@ -50,24 +53,18 @@ describe('decorateWithMetrics', () => {
         mockFunc = decorateWithMetrics(mockFunc);
         mockFunc();
 
-        return waitForPromisesToResolve()
-            .then(() => {
-                // Then the alias should be inferred from the function name
-                const stats = getMetrics();
-                const result = stats.summaries.mockFunc;
-                expect(result).not.toBeUndefined();
-                expect(result).toEqual(
-                    expect.objectContaining({methodName: 'mockFunc'}),
-                );
-            });
+        return waitForPromisesToResolve().then(() => {
+            // Then the alias should be inferred from the function name
+            const stats = getMetrics();
+            const result = stats.summaries.mockFunc;
+            expect(result).not.toBeUndefined();
+            expect(result).toEqual(expect.objectContaining({methodName: 'mockFunc'}));
+        });
     });
 
     it('Should collect metrics for multiple calls', () => {
         // Given an async function that resolves with an object
-        let mockFn = jest.fn()
-            .mockResolvedValueOnce({mock: 'value'})
-            .mockResolvedValueOnce({mock: 'value'})
-            .mockResolvedValueOnce({mock: 'value'});
+        let mockFn = jest.fn().mockResolvedValueOnce({mock: 'value'}).mockResolvedValueOnce({mock: 'value'}).mockResolvedValueOnce({mock: 'value'});
 
         // When it is decorated and executed
         mockFn = decorateWithMetrics(mockFn, 'mockFn');
@@ -75,50 +72,46 @@ describe('decorateWithMetrics', () => {
         mockFn('mockedKey3');
         mockFn('mockedKey2');
 
-        return waitForPromisesToResolve()
-            .then(() => {
-                // Then stats should have data regarding each call
-                const calls = getMetrics().summaries.mockFn.calls;
-                expect(calls).toHaveLength(3);
-                expect(calls).toEqual([
-                    expect.objectContaining({
-                        detail: expect.objectContaining({args: ['mockedKey']}),
-                    }),
-                    expect.objectContaining({
-                        detail: expect.objectContaining({args: ['mockedKey3']}),
-                    }),
-                    expect.objectContaining({
-                        detail: expect.objectContaining({args: ['mockedKey2']}),
-                    }),
-                ]);
-            });
+        return waitForPromisesToResolve().then(() => {
+            // Then stats should have data regarding each call
+            const calls = getMetrics().summaries.mockFn.calls;
+            expect(calls).toHaveLength(3);
+            expect(calls).toEqual([
+                expect.objectContaining({
+                    detail: expect.objectContaining({args: ['mockedKey']}),
+                }),
+                expect.objectContaining({
+                    detail: expect.objectContaining({args: ['mockedKey3']}),
+                }),
+                expect.objectContaining({
+                    detail: expect.objectContaining({args: ['mockedKey2']}),
+                }),
+            ]);
+        });
     });
 
     it('Should work for methods that return Promise<void>', () => {
         // Given an async function that resolves with no data
-        let mockFn = jest.fn()
-            .mockResolvedValueOnce()
-            .mockResolvedValueOnce();
+        let mockFn = jest.fn().mockResolvedValueOnce().mockResolvedValueOnce();
 
         // When it is decorated and executed
         mockFn = decorateWithMetrics(mockFn, 'mockFn');
         mockFn('mockedKey', {ids: [1, 2, 3]});
         mockFn('mockedKey', {ids: [4, 5, 6]});
 
-        return waitForPromisesToResolve()
-            .then(() => {
-                // Then stats should still contain data about the calls
-                const calls = getMetrics().summaries.mockFn.calls;
-                expect(calls).toHaveLength(2);
-                expect(calls).toEqual([
-                    expect.objectContaining({
-                        detail: {args: ['mockedKey', {ids: [1, 2, 3]}], alias: 'mockFn'},
-                    }),
-                    expect.objectContaining({
-                        detail: {args: ['mockedKey', {ids: [4, 5, 6]}], alias: 'mockFn'},
-                    }),
-                ]);
-            });
+        return waitForPromisesToResolve().then(() => {
+            // Then stats should still contain data about the calls
+            const calls = getMetrics().summaries.mockFn.calls;
+            expect(calls).toHaveLength(2);
+            expect(calls).toEqual([
+                expect.objectContaining({
+                    detail: {args: ['mockedKey', {ids: [1, 2, 3]}], alias: 'mockFn'},
+                }),
+                expect.objectContaining({
+                    detail: {args: ['mockedKey', {ids: [4, 5, 6]}], alias: 'mockFn'},
+                }),
+            ]);
+        });
     });
 
     it('Should not affect the returned value from the original method', () => {
@@ -149,32 +142,32 @@ describe('decorateWithMetrics', () => {
         mockGet('mockedKey');
         mockGetAllKeys();
 
-        return waitForPromisesToResolve()
-            .then(() => {
-                // Then stats should contain data for each function and each call under the correct function alias
-                const stats = getMetrics().summaries;
-                expect(_.keys(stats)).toHaveLength(2);
+        return waitForPromisesToResolve().then(() => {
+            // Then stats should contain data for each function and each call under the correct function alias
+            const stats = getMetrics().summaries;
+            expect(_.keys(stats)).toHaveLength(2);
 
-                expect(stats).toEqual(expect.objectContaining({
+            expect(stats).toEqual(
+                expect.objectContaining({
                     mockGet: expect.any(Object),
                     mockGetAllKeys: expect.any(Object),
-                }));
+                }),
+            );
 
-                expect(stats.mockGet.calls).toHaveLength(1);
-                expect(stats.mockGetAllKeys.calls).toHaveLength(1);
-            });
+            expect(stats.mockGet.calls).toHaveLength(1);
+            expect(stats.mockGetAllKeys.calls).toHaveLength(1);
+        });
     });
 
     it('Should collect metrics for a multiple functions, multiple call', () => {
         // Given multiple async functions that resolves with objects
-        let mockGetAllKeys = jest.fn()
+        let mockGetAllKeys = jest
+            .fn()
             .mockResolvedValueOnce(['my', 'mock', 'keys'])
             .mockResolvedValueOnce(['my', 'mock', 'keys', 'and'])
             .mockResolvedValueOnce(['my', 'mock', 'keys', 'and', 'more']);
 
-        let mockSetItem = jest.fn()
-            .mockResolvedValueOnce()
-            .mockResolvedValueOnce();
+        let mockSetItem = jest.fn().mockResolvedValueOnce().mockResolvedValueOnce();
 
         // When they are decorated
         mockGetAllKeys = decorateWithMetrics(mockGetAllKeys, 'mockGetAllKeys');
@@ -187,20 +180,21 @@ describe('decorateWithMetrics', () => {
         mockSetItem('more', 'Mock value');
         mockGetAllKeys();
 
-        return waitForPromisesToResolve()
-            .then(() => {
-                // Then stats should contain data for each function and each call under the correct function alias
-                const stats = getMetrics().summaries;
-                expect(_.keys(stats)).toHaveLength(2);
+        return waitForPromisesToResolve().then(() => {
+            // Then stats should contain data for each function and each call under the correct function alias
+            const stats = getMetrics().summaries;
+            expect(_.keys(stats)).toHaveLength(2);
 
-                expect(stats).toEqual(expect.objectContaining({
+            expect(stats).toEqual(
+                expect.objectContaining({
                     mockGetAllKeys: expect.any(Object),
                     mockSetItem: expect.any(Object),
-                }));
+                }),
+            );
 
-                expect(stats.mockGetAllKeys.calls).toHaveLength(3);
-                expect(stats.mockSetItem.calls).toHaveLength(2);
-            });
+            expect(stats.mockGetAllKeys.calls).toHaveLength(3);
+            expect(stats.mockSetItem.calls).toHaveLength(2);
+        });
     });
 
     it('Attempting to decorate already decorated method should throw', () => {
@@ -210,17 +204,13 @@ describe('decorateWithMetrics', () => {
 
         // When you try to decorate again the same function
         expect(() => decorateWithMetrics(mockFn, 'mockFn'))
-
             // Then it should throw an exception
             .toThrow('"mockFn" is already decorated');
     });
 
     it('Adding more data after clearing should work', () => {
         // Given an async function that is decorated
-        let mockFn = jest.fn()
-            .mockResolvedValueOnce()
-            .mockResolvedValueOnce()
-            .mockResolvedValueOnce();
+        let mockFn = jest.fn().mockResolvedValueOnce().mockResolvedValueOnce().mockResolvedValueOnce();
 
         mockFn = decorateWithMetrics(mockFn, 'mockFn');
 
@@ -261,9 +251,11 @@ describe('decorateWithMetrics', () => {
             .then(() => {
                 // Then stats should contain data regarding the calls under that custom alias
                 const stats = getMetrics().summaries;
-                expect(stats).toEqual(expect.objectContaining({
-                    'mock:get': expect.any(Object),
-                }));
+                expect(stats).toEqual(
+                    expect.objectContaining({
+                        'mock:get': expect.any(Object),
+                    }),
+                );
             })
             .finally(resetMetrics);
     });
@@ -287,8 +279,7 @@ describe('decorateWithMetrics', () => {
 
         // Given mocked performance than returns +250ms for each consecutive call
         let i = 0;
-        jest.spyOn(global.performance, 'now')
-            .mockImplementation(() => 250 * i++);
+        jest.spyOn(global.performance, 'now').mockImplementation(() => 250 * i++);
 
         // When it is decorated
         mockFn = decorateWithMetrics(mockFn, 'mockFn');
@@ -300,10 +291,12 @@ describe('decorateWithMetrics', () => {
                 // Then metrics should contain correctly calculated data
                 const metrics = getMetrics();
 
-                expect(metrics).toEqual(expect.objectContaining({
-                    totalTime: 250,
-                    averageTime: 250,
-                }));
+                expect(metrics).toEqual(
+                    expect.objectContaining({
+                        totalTime: 250,
+                        averageTime: 250,
+                    }),
+                );
             });
 
         // When the decorated function is executed again
@@ -313,10 +306,12 @@ describe('decorateWithMetrics', () => {
                 // Then metrics should contain correctly calculated data
                 const metrics = getMetrics();
 
-                expect(metrics).toEqual(expect.objectContaining({
-                    totalTime: 500,
-                    averageTime: 250,
-                }));
+                expect(metrics).toEqual(
+                    expect.objectContaining({
+                        totalTime: 500,
+                        averageTime: 250,
+                    }),
+                );
             });
 
         // When the decorated function is executed again
@@ -326,10 +321,12 @@ describe('decorateWithMetrics', () => {
                 // Then metrics should contain correctly calculated data
                 const metrics = getMetrics();
 
-                expect(metrics).toEqual(expect.objectContaining({
-                    totalTime: 750,
-                    averageTime: 250,
-                }));
+                expect(metrics).toEqual(
+                    expect.objectContaining({
+                        totalTime: 750,
+                        averageTime: 250,
+                    }),
+                );
             });
     });
 });

--- a/tests/unit/onyxCacheTest.js
+++ b/tests/unit/onyxCacheTest.js
@@ -256,9 +256,7 @@ describe('Onyx', () => {
                 });
 
                 // Then the arrays should be replaced as expected
-                expect(cache.getValue('mockKey')).toEqual([
-                    {ID: 3}, {added: 'field'}, {}, {ID: 1000},
-                ]);
+                expect(cache.getValue('mockKey')).toEqual([{ID: 3}, {added: 'field'}, {}, {ID: 1000}]);
             });
 
             it('Should merge arrays inside objects correctly', () => {
@@ -379,11 +377,10 @@ describe('Onyx', () => {
                 expect(cache.hasPendingTask('mockTask')).toBe(true);
 
                 // When the promise is completed
-                return waitForPromisesToResolve()
-                    .then(() => {
-                        // Then `hasPendingTask` should return false
-                        expect(cache.hasPendingTask('mockTask')).toBe(false);
-                    });
+                return waitForPromisesToResolve().then(() => {
+                    // Then `hasPendingTask` should return false
+                    expect(cache.hasPendingTask('mockTask')).toBe(false);
+                });
             });
         });
 
@@ -442,8 +439,7 @@ describe('Onyx', () => {
 
             // Onyx init introduces some side effects e.g. calls the getAllKeys
             // We're clearing mocks to have a fresh calls history
-            return waitForPromisesToResolve()
-                .then(() => jest.clearAllMocks());
+            return waitForPromisesToResolve().then(() => jest.clearAllMocks());
         }
 
         // Initialize clean modules before each test
@@ -520,9 +516,7 @@ describe('Onyx', () => {
             // Given Storage with 10 different keys
             StorageMock.getItem.mockResolvedValue('"mockValue"');
             const range = _.range(10);
-            StorageMock.getAllKeys.mockResolvedValue(
-                _.map(range, number => `${ONYX_KEYS.COLLECTION.MOCK_COLLECTION}${number}`),
-            );
+            StorageMock.getAllKeys.mockResolvedValue(_.map(range, (number) => `${ONYX_KEYS.COLLECTION.MOCK_COLLECTION}${number}`));
             let connections;
 
             // Given Onyx is configured with max 5 keys in cache
@@ -533,10 +527,10 @@ describe('Onyx', () => {
                     // Given 10 connections for different keys
                     connections = _.map(range, (number) => {
                         const key = `${ONYX_KEYS.COLLECTION.MOCK_COLLECTION}${number}`;
-                        return ({
+                        return {
                             key,
                             connectionId: Onyx.connect({key, callback: jest.fn()}),
-                        });
+                        };
                     });
                 })
                 .then(waitForPromisesToResolve)
@@ -571,24 +565,26 @@ describe('Onyx', () => {
             StorageMock.getItem.mockResolvedValue('"mockValue"');
             StorageMock.getAllKeys.mockResolvedValue([ONYX_KEYS.TEST_KEY]);
 
-            return initOnyx()
-                .then(() => {
-                    // When a component is rendered
-                    render(<TestComponentWithOnyx />);
-                })
-                .then(waitForPromisesToResolve)
-                .then(() => {
-                    // When the key was removed from cache
-                    cache.drop(ONYX_KEYS.TEST_KEY);
-                })
+            return (
+                initOnyx()
+                    .then(() => {
+                        // When a component is rendered
+                        render(<TestComponentWithOnyx />);
+                    })
+                    .then(waitForPromisesToResolve)
+                    .then(() => {
+                        // When the key was removed from cache
+                        cache.drop(ONYX_KEYS.TEST_KEY);
+                    })
 
-                // Then When another component using the same storage key is rendered
-                .then(() => render(<TestComponentWithOnyx />))
-                .then(waitForPromisesToResolve)
-                .then(() => {
-                    // Then Async storage `getItem` should be called twice
-                    expect(StorageMock.getItem).toHaveBeenCalledTimes(2);
-                });
+                    // Then When another component using the same storage key is rendered
+                    .then(() => render(<TestComponentWithOnyx />))
+                    .then(waitForPromisesToResolve)
+                    .then(() => {
+                        // Then Async storage `getItem` should be called twice
+                        expect(StorageMock.getItem).toHaveBeenCalledTimes(2);
+                    })
+            );
         });
 
         it('Expect multiple calls to getItem when multiple keys are used', () => {
@@ -632,7 +628,7 @@ describe('Onyx', () => {
             // Given storage with some data
             StorageMock.getItem.mockResolvedValue('"mockValue"');
             const range = _.range(1, 10);
-            StorageMock.getAllKeys.mockResolvedValue(_.map(range, n => `key${n}`));
+            StorageMock.getAllKeys.mockResolvedValue(_.map(range, (n) => `key${n}`));
 
             // Given Onyx with LRU size of 3
             return initOnyx({maxCachedKeysCount: 3})

--- a/tests/unit/onyxClearNativeStorageTest.js
+++ b/tests/unit/onyxClearNativeStorageTest.js
@@ -33,7 +33,7 @@ describe('Set data while storage is clearing', () => {
         connectionID = Onyx.connect({
             key: ONYX_KEYS.DEFAULT_KEY,
             initWithStoredValues: false,
-            callback: val => onyxValue = val,
+            callback: (val) => (onyxValue = val),
         });
         return waitForPromisesToResolve();
     });
@@ -50,15 +50,13 @@ describe('Set data while storage is clearing', () => {
         // When set then clear is called on a key with a default key state
         Onyx.set(ONYX_KEYS.DEFAULT_KEY, SET_VALUE);
         Onyx.clear();
-        return waitForPromisesToResolve()
-            .then(() => {
-                // Then the value in Onyx, the cache, and Storage is the default key state
-                expect(onyxValue).toBe(DEFAULT_VALUE);
-                const cachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
-                expect(cachedValue).toBe(DEFAULT_VALUE);
-                return StorageMock.getItem(ONYX_KEYS.DEFAULT_KEY)
-                    .then(storedValue => expect(parseInt(storedValue, 10)).toBe(DEFAULT_VALUE));
-            });
+        return waitForPromisesToResolve().then(() => {
+            // Then the value in Onyx, the cache, and Storage is the default key state
+            expect(onyxValue).toBe(DEFAULT_VALUE);
+            const cachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
+            expect(cachedValue).toBe(DEFAULT_VALUE);
+            return StorageMock.getItem(ONYX_KEYS.DEFAULT_KEY).then((storedValue) => expect(parseInt(storedValue, 10)).toBe(DEFAULT_VALUE));
+        });
     });
 
     it('should replace the value of Onyx.merge with the default key state in the cache', () => {
@@ -68,15 +66,13 @@ describe('Set data while storage is clearing', () => {
         // When merge then clear is called on a key with a default key state
         Onyx.merge(ONYX_KEYS.DEFAULT_KEY, MERGED_VALUE);
         Onyx.clear();
-        return waitForPromisesToResolve()
-            .then(() => {
-                // Then the value in Onyx, the cache, and Storage is the default key state
-                expect(onyxValue).toBe(DEFAULT_VALUE);
-                const cachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
-                expect(cachedValue).toBe(DEFAULT_VALUE);
-                return StorageMock.getItem(ONYX_KEYS.DEFAULT_KEY)
-                    .then(storedValue => expect(parseInt(storedValue, 10)).toBe(DEFAULT_VALUE));
-            });
+        return waitForPromisesToResolve().then(() => {
+            // Then the value in Onyx, the cache, and Storage is the default key state
+            expect(onyxValue).toBe(DEFAULT_VALUE);
+            const cachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
+            expect(cachedValue).toBe(DEFAULT_VALUE);
+            return StorageMock.getItem(ONYX_KEYS.DEFAULT_KEY).then((storedValue) => expect(parseInt(storedValue, 10)).toBe(DEFAULT_VALUE));
+        });
     });
 
     it('should preserve the value of any keysToPreserve passed in', () => {
@@ -87,21 +83,19 @@ describe('Set data while storage is clearing', () => {
         Onyx.connect({
             key: ONYX_KEYS.REGULAR_KEY,
             initWithStoredValues: false,
-            callback: val => regularKeyOnyxValue = val,
+            callback: (val) => (regularKeyOnyxValue = val),
         });
         Onyx.set(ONYX_KEYS.REGULAR_KEY, SET_VALUE).then(() => {
             // When clear is called with a key to preserve
             Onyx.clear([ONYX_KEYS.REGULAR_KEY]);
         });
 
-        return waitForPromisesToResolve()
-            .then(() => {
-                // Then the value of the preserved key is also still set in both the cache and storage
-                expect(regularKeyOnyxValue).toBe(SET_VALUE);
-                expect(cache.getValue(ONYX_KEYS.REGULAR_KEY)).toBe(SET_VALUE);
-                return StorageMock.getItem(ONYX_KEYS.REGULAR_KEY)
-                    .then(storedValue => expect(parseInt(storedValue, 10)).toBe(SET_VALUE));
-            });
+        return waitForPromisesToResolve().then(() => {
+            // Then the value of the preserved key is also still set in both the cache and storage
+            expect(regularKeyOnyxValue).toBe(SET_VALUE);
+            expect(cache.getValue(ONYX_KEYS.REGULAR_KEY)).toBe(SET_VALUE);
+            return StorageMock.getItem(ONYX_KEYS.REGULAR_KEY).then((storedValue) => expect(parseInt(storedValue, 10)).toBe(SET_VALUE));
+        });
     });
 
     it('should preserve the value of any keysToPreserve over any default key states', () => {
@@ -113,14 +107,12 @@ describe('Set data while storage is clearing', () => {
             Onyx.clear([ONYX_KEYS.DEFAULT_KEY]);
         });
 
-        return waitForPromisesToResolve()
-            .then(() => {
-                // Then the value in Onyx, the cache, and Storage is the set value
-                expect(onyxValue).toBe(SET_VALUE);
-                const cachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
-                expect(cachedValue).toBe(SET_VALUE);
-                return StorageMock.getItem(ONYX_KEYS.DEFAULT_KEY)
-                    .then(storedValue => expect(parseInt(storedValue, 10)).toBe(SET_VALUE));
-            });
+        return waitForPromisesToResolve().then(() => {
+            // Then the value in Onyx, the cache, and Storage is the set value
+            expect(onyxValue).toBe(SET_VALUE);
+            const cachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
+            expect(cachedValue).toBe(SET_VALUE);
+            return StorageMock.getItem(ONYX_KEYS.DEFAULT_KEY).then((storedValue) => expect(parseInt(storedValue, 10)).toBe(SET_VALUE));
+        });
     });
 });

--- a/tests/unit/onyxClearWebStorageTest.js
+++ b/tests/unit/onyxClearWebStorageTest.js
@@ -34,7 +34,7 @@ describe('Set data while storage is clearing', () => {
         connectionID = Onyx.connect({
             key: ONYX_KEYS.DEFAULT_KEY,
             initWithStoredValues: false,
-            callback: val => onyxValue = val,
+            callback: (val) => (onyxValue = val),
         });
         return waitForPromisesToResolve();
     });
@@ -51,15 +51,14 @@ describe('Set data while storage is clearing', () => {
         // When set then clear is called on a key with a default key state
         Onyx.set(ONYX_KEYS.DEFAULT_KEY, SET_VALUE);
         Onyx.clear();
-        return waitForPromisesToResolve()
-            .then(() => {
-                // Then the value in Onyx, the cache, and Storage is the default key state
-                expect(onyxValue).toBe(DEFAULT_VALUE);
-                const cachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
-                expect(cachedValue).toBe(DEFAULT_VALUE);
-                const storedValue = StorageMock.getItem(ONYX_KEYS.DEFAULT_KEY);
-                return expect(storedValue).resolves.toBe(DEFAULT_VALUE);
-            });
+        return waitForPromisesToResolve().then(() => {
+            // Then the value in Onyx, the cache, and Storage is the default key state
+            expect(onyxValue).toBe(DEFAULT_VALUE);
+            const cachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
+            expect(cachedValue).toBe(DEFAULT_VALUE);
+            const storedValue = StorageMock.getItem(ONYX_KEYS.DEFAULT_KEY);
+            return expect(storedValue).resolves.toBe(DEFAULT_VALUE);
+        });
     });
 
     it('should replace the value of Onyx.merge with the default key state in the cache', () => {
@@ -69,15 +68,14 @@ describe('Set data while storage is clearing', () => {
         // When merge then clear is called on a key with a default key state
         Onyx.merge(ONYX_KEYS.DEFAULT_KEY, MERGED_VALUE);
         Onyx.clear();
-        return waitForPromisesToResolve()
-            .then(() => {
-                // Then the value in Onyx, the cache, and Storage is the default key state
-                expect(onyxValue).toBe(DEFAULT_VALUE);
-                const cachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
-                expect(cachedValue).toBe(DEFAULT_VALUE);
-                const storedValue = StorageMock.getItem(ONYX_KEYS.DEFAULT_KEY);
-                return expect(storedValue).resolves.toBe(DEFAULT_VALUE);
-            });
+        return waitForPromisesToResolve().then(() => {
+            // Then the value in Onyx, the cache, and Storage is the default key state
+            expect(onyxValue).toBe(DEFAULT_VALUE);
+            const cachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
+            expect(cachedValue).toBe(DEFAULT_VALUE);
+            const storedValue = StorageMock.getItem(ONYX_KEYS.DEFAULT_KEY);
+            return expect(storedValue).resolves.toBe(DEFAULT_VALUE);
+        });
     });
 
     it('should preserve the value of any keysToPreserve passed in', () => {
@@ -88,22 +86,21 @@ describe('Set data while storage is clearing', () => {
         Onyx.connect({
             key: ONYX_KEYS.REGULAR_KEY,
             initWithStoredValues: false,
-            callback: val => regularKeyOnyxValue = val,
+            callback: (val) => (regularKeyOnyxValue = val),
         });
         Onyx.set(ONYX_KEYS.REGULAR_KEY, SET_VALUE).then(() => {
             // When clear is called with a key to preserve
             Onyx.clear([ONYX_KEYS.REGULAR_KEY]);
         });
 
-        return waitForPromisesToResolve()
-            .then(() => {
-                // Then the value of the preserved key is also still set in both the cache and storage
-                expect(regularKeyOnyxValue).toBe(SET_VALUE);
-                const regularKeyCachedValue = cache.getValue(ONYX_KEYS.REGULAR_KEY);
-                expect(regularKeyCachedValue).toBe(SET_VALUE);
-                const regularKeyStoredValue = StorageMock.getItem(ONYX_KEYS.REGULAR_KEY);
-                return expect(regularKeyStoredValue).resolves.toBe(SET_VALUE);
-            });
+        return waitForPromisesToResolve().then(() => {
+            // Then the value of the preserved key is also still set in both the cache and storage
+            expect(regularKeyOnyxValue).toBe(SET_VALUE);
+            const regularKeyCachedValue = cache.getValue(ONYX_KEYS.REGULAR_KEY);
+            expect(regularKeyCachedValue).toBe(SET_VALUE);
+            const regularKeyStoredValue = StorageMock.getItem(ONYX_KEYS.REGULAR_KEY);
+            return expect(regularKeyStoredValue).resolves.toBe(SET_VALUE);
+        });
     });
 
     it('should preserve the value of any keysToPreserve over any default key states', () => {
@@ -115,15 +112,14 @@ describe('Set data while storage is clearing', () => {
             Onyx.clear([ONYX_KEYS.DEFAULT_KEY]);
         });
 
-        return waitForPromisesToResolve()
-            .then(() => {
-                // Then the value in Onyx, the cache, and Storage is the set value
-                expect(onyxValue).toBe(SET_VALUE);
-                const cachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
-                expect(cachedValue).toBe(SET_VALUE);
-                const storedValue = StorageMock.getItem(ONYX_KEYS.DEFAULT_KEY);
-                return expect(storedValue).resolves.toBe(SET_VALUE);
-            });
+        return waitForPromisesToResolve().then(() => {
+            // Then the value in Onyx, the cache, and Storage is the set value
+            expect(onyxValue).toBe(SET_VALUE);
+            const cachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
+            expect(cachedValue).toBe(SET_VALUE);
+            const storedValue = StorageMock.getItem(ONYX_KEYS.DEFAULT_KEY);
+            return expect(storedValue).resolves.toBe(SET_VALUE);
+        });
     });
 
     it('should only trigger the connection callback once when using wait for collection callback', () => {
@@ -136,35 +132,39 @@ describe('Set data while storage is clearing', () => {
             waitForCollectionCallback: true,
             callback: collectionCallback,
         });
-        return waitForPromisesToResolve()
-            .then(() => Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST, {
-                [`${ONYX_KEYS.COLLECTION.TEST}1`]: 1,
-                [`${ONYX_KEYS.COLLECTION.TEST}2`]: 2,
-                [`${ONYX_KEYS.COLLECTION.TEST}3`]: 3,
-                [`${ONYX_KEYS.COLLECTION.TEST}4`]: 4,
-            }))
+        return (
+            waitForPromisesToResolve()
+                .then(() =>
+                    Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST, {
+                        [`${ONYX_KEYS.COLLECTION.TEST}1`]: 1,
+                        [`${ONYX_KEYS.COLLECTION.TEST}2`]: 2,
+                        [`${ONYX_KEYS.COLLECTION.TEST}3`]: 3,
+                        [`${ONYX_KEYS.COLLECTION.TEST}4`]: 4,
+                    }),
+                )
 
-            // When onyx is cleared
-            .then(Onyx.clear)
-            .then(() => {
-                Onyx.disconnect(testConnectionID);
-            })
-            .then(() => {
-                // Then the collection callback should only have been called three times:
-                // 1. connect()
-                // 2. merge()
-                // 3. clear()
-                expect(collectionCallback).toHaveBeenCalledTimes(3);
+                // When onyx is cleared
+                .then(Onyx.clear)
+                .then(() => {
+                    Onyx.disconnect(testConnectionID);
+                })
+                .then(() => {
+                    // Then the collection callback should only have been called three times:
+                    // 1. connect()
+                    // 2. merge()
+                    // 3. clear()
+                    expect(collectionCallback).toHaveBeenCalledTimes(3);
 
-                // And it should be called with the expected parameters each time
-                expect(collectionCallback).toHaveBeenNthCalledWith(1, null, undefined);
-                expect(collectionCallback).toHaveBeenNthCalledWith(2, {
-                    test_1: 1,
-                    test_2: 2,
-                    test_3: 3,
-                    test_4: 4,
-                });
-                expect(collectionCallback).toHaveBeenLastCalledWith({});
-            });
+                    // And it should be called with the expected parameters each time
+                    expect(collectionCallback).toHaveBeenNthCalledWith(1, null, undefined);
+                    expect(collectionCallback).toHaveBeenNthCalledWith(2, {
+                        test_1: 1,
+                        test_2: 2,
+                        test_3: 3,
+                        test_4: 4,
+                    });
+                    expect(collectionCallback).toHaveBeenLastCalledWith({});
+                })
+        );
     });
 });

--- a/tests/unit/onyxMetricsDecorationTest.js
+++ b/tests/unit/onyxMetricsDecorationTest.js
@@ -64,17 +64,16 @@ describe('Onyx', () => {
 
             // When calling decorated methods through Onyx[methodName]
             const methods = ['set', 'multiSet', 'clear', 'merge', 'mergeCollection'];
-            methods.forEach(name => Onyx[name]('mockKey', {mockKey: {mockValue: 'mockValue'}}));
+            methods.forEach((name) => Onyx[name]('mockKey', {mockKey: {mockValue: 'mockValue'}}));
 
-            return waitForPromisesToResolve()
-                .then(() => {
+            return waitForPromisesToResolve().then(() => {
                 // Then metrics should have captured data for each method
-                    const summaries = Onyx.getMetrics().summaries;
+                const summaries = Onyx.getMetrics().summaries;
 
-                    methods.forEach((name) => {
-                        expect(summaries[`Onyx:${name}`].total).toBeGreaterThan(0);
-                    });
+                methods.forEach((name) => {
+                    expect(summaries[`Onyx:${name}`].total).toBeGreaterThan(0);
                 });
+            });
         });
     });
 });

--- a/tests/unit/onyxMultiMergeWebStorageTest.js
+++ b/tests/unit/onyxMultiMergeWebStorageTest.js
@@ -60,22 +60,25 @@ describe('Onyx.mergeCollection() and WebStorage', () => {
             test_3: additionalDataTwo,
         });
 
-        return waitForPromisesToResolve()
-            .then(() => {
-                const finalObject = {
-                    a: 'a', b: 'b', c: 'c', d: 'd', e: [2],
-                };
+        return waitForPromisesToResolve().then(() => {
+            const finalObject = {
+                a: 'a',
+                b: 'b',
+                c: 'c',
+                d: 'd',
+                e: [2],
+            };
 
-                // Then our new data should merge with the existing data in the cache
-                expect(OnyxCache.getValue('test_1')).toEqual(finalObject);
-                expect(OnyxCache.getValue('test_2')).toEqual(finalObject);
-                expect(OnyxCache.getValue('test_3')).toEqual(finalObject);
+            // Then our new data should merge with the existing data in the cache
+            expect(OnyxCache.getValue('test_1')).toEqual(finalObject);
+            expect(OnyxCache.getValue('test_2')).toEqual(finalObject);
+            expect(OnyxCache.getValue('test_3')).toEqual(finalObject);
 
-                // And the storage should reflect the same state
-                expect(StorageMock.getStorageMap().test_1).toEqual(finalObject);
-                expect(StorageMock.getStorageMap().test_2).toEqual(finalObject);
-                expect(StorageMock.getStorageMap().test_3).toEqual(finalObject);
-            });
+            // And the storage should reflect the same state
+            expect(StorageMock.getStorageMap().test_1).toEqual(finalObject);
+            expect(StorageMock.getStorageMap().test_2).toEqual(finalObject);
+            expect(StorageMock.getStorageMap().test_3).toEqual(finalObject);
+        });
     });
 
     it('cache updates correctly when accessed again if keys are removed or evicted', () => {
@@ -123,7 +126,9 @@ describe('Onyx.mergeCollection() and WebStorage', () => {
             })
             .then(() => {
                 const finalObject = {
-                    a: 'a', b: 'b', c: 'c',
+                    a: 'a',
+                    b: 'b',
+                    c: 'c',
                 };
 
                 // Then our new data should merge with the existing data in the cache
@@ -158,14 +163,18 @@ describe('Onyx.mergeCollection() and WebStorage', () => {
 
         // Last call
         Onyx.merge('test_1', {f: 'f'});
-        return waitForPromisesToResolve()
-            .then(() => {
-                const finalObject = {
-                    a: 'a', b: 'b', c: 'c', d: 'd', e: 'e', f: 'f',
-                };
+        return waitForPromisesToResolve().then(() => {
+            const finalObject = {
+                a: 'a',
+                b: 'b',
+                c: 'c',
+                d: 'd',
+                e: 'e',
+                f: 'f',
+            };
 
-                expect(OnyxCache.getValue('test_1')).toEqual(finalObject);
-                expect(StorageMock.getStorageMap().test_1).toEqual(finalObject);
-            });
+            expect(OnyxCache.getValue('test_1')).toEqual(finalObject);
+            expect(StorageMock.getStorageMap().test_1).toEqual(finalObject);
+        });
     });
 });

--- a/tests/unit/onyxTest.js
+++ b/tests/unit/onyxTest.js
@@ -36,22 +36,23 @@ describe('Onyx', () => {
         return Onyx.clear();
     });
 
-    it('should remove key value from OnyxCache/Storage when set is called with null value', () => Onyx.set(ONYX_KEYS.OTHER_TEST, 42)
-        .then(() => Onyx.getAllKeys())
-        .then((keys) => {
-            expect(keys.includes(ONYX_KEYS.OTHER_TEST)).toBe(true);
-            return Onyx.set(ONYX_KEYS.OTHER_TEST, null);
-        })
-        .then(() => {
-            // Checks if cache value is removed.
-            expect(cache.getAllKeys().length).toBe(0);
+    it('should remove key value from OnyxCache/Storage when set is called with null value', () =>
+        Onyx.set(ONYX_KEYS.OTHER_TEST, 42)
+            .then(() => Onyx.getAllKeys())
+            .then((keys) => {
+                expect(keys.includes(ONYX_KEYS.OTHER_TEST)).toBe(true);
+                return Onyx.set(ONYX_KEYS.OTHER_TEST, null);
+            })
+            .then(() => {
+                // Checks if cache value is removed.
+                expect(cache.getAllKeys().length).toBe(0);
 
-            // When cache keys length is 0, we fetch the keys from storage.
-            return Onyx.getAllKeys();
-        })
-        .then((keys) => {
-            expect(keys.includes(ONYX_KEYS.OTHER_TEST)).toBe(false);
-        }));
+                // When cache keys length is 0, we fetch the keys from storage.
+                return Onyx.getAllKeys();
+            })
+            .then((keys) => {
+                expect(keys.includes(ONYX_KEYS.OTHER_TEST)).toBe(false);
+            }));
 
     it('should set a simple key', () => {
         let testKeyValue;
@@ -65,10 +66,9 @@ describe('Onyx', () => {
         });
 
         // Set a simple key
-        return Onyx.set(ONYX_KEYS.TEST_KEY, 'test')
-            .then(() => {
-                expect(testKeyValue).toBe('test');
-            });
+        return Onyx.set(ONYX_KEYS.TEST_KEY, 'test').then(() => {
+            expect(testKeyValue).toBe('test');
+        });
     });
 
     it('should merge an object with another object', () => {
@@ -347,15 +347,14 @@ describe('Onyx', () => {
         });
 
         Onyx.merge(ONYX_KEYS.COLLECTION.TEST_KEY, {test_1: {something: [1, 2, 3]}});
-        return Onyx.merge(ONYX_KEYS.COLLECTION.TEST_KEY, {test_1: {something: [4]}})
-            .then(() => {
-                expect(testKeyValue).toEqual({test_1: {something: [4]}});
-            });
+        return Onyx.merge(ONYX_KEYS.COLLECTION.TEST_KEY, {test_1: {something: [4]}}).then(() => {
+            expect(testKeyValue).toEqual({test_1: {something: [4]}});
+        });
     });
 
     it('should properly set and merge when using mergeCollection', () => {
         const valuesReceived = {};
-        const mockCallback = jest.fn(data => valuesReceived[data.ID] = data.value);
+        const mockCallback = jest.fn((data) => (valuesReceived[data.ID] = data.value));
         connectionID = Onyx.connect({
             key: ONYX_KEYS.COLLECTION.TEST_KEY,
             initWithStoredValues: false,
@@ -377,8 +376,7 @@ describe('Onyx', () => {
                 value: 'three',
             },
         })
-            .then(() => (
-
+            .then(() =>
                 // 2 key values to update and 2 new keys to add.
                 // MergeCollection will perform a mix of multiSet and multiMerge
                 Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
@@ -398,8 +396,8 @@ describe('Onyx', () => {
                         ID: 567,
                         value: 'one',
                     },
-                })
-            ))
+                }),
+            )
             .then(() => {
                 // 3 items on the first mergeCollection + 4 items the next mergeCollection
                 expect(mockCallback).toHaveBeenCalledTimes(7);
@@ -423,13 +421,12 @@ describe('Onyx', () => {
         connectionID = Onyx.connect({
             key: ONYX_KEYS.COLLECTION.TEST_KEY,
             initWithStoredValues: false,
-            callback: (data, key) => valuesReceived[key] = data,
+            callback: (data, key) => (valuesReceived[key] = data),
         });
 
-        return Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {test_1: {ID: 123}, notMyTest: {beep: 'boop'}})
-            .then(() => {
-                expect(valuesReceived).toEqual({});
-            });
+        return Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {test_1: {ID: 123}, notMyTest: {beep: 'boop'}}).then(() => {
+            expect(valuesReceived).toEqual({});
+        });
     });
 
     it('should return full object to callback when calling mergeCollection()', () => {
@@ -437,7 +434,7 @@ describe('Onyx', () => {
         connectionID = Onyx.connect({
             key: ONYX_KEYS.COLLECTION.TEST_KEY,
             initWithStoredValues: false,
-            callback: (data, key) => valuesReceived[key] = data,
+            callback: (data, key) => (valuesReceived[key] = data),
         });
 
         return Onyx.multiSet({
@@ -448,16 +445,18 @@ describe('Onyx', () => {
                 existingData: 'test',
             },
         })
-            .then(() => Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
-                test_1: {
-                    ID: 123,
-                    value: 'one',
-                },
-                test_2: {
-                    ID: 234,
-                    value: 'two',
-                },
-            }))
+            .then(() =>
+                Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
+                    test_1: {
+                        ID: 123,
+                        value: 'one',
+                    },
+                    test_2: {
+                        ID: 234,
+                        value: 'two',
+                    },
+                }),
+            )
             .then(() => {
                 expect(valuesReceived).toEqual({
                     test_1: {
@@ -527,7 +526,7 @@ describe('Onyx', () => {
 
     it('should use update data object to merge a collection of keys', () => {
         const valuesReceived = {};
-        const mockCallback = jest.fn(data => valuesReceived[data.ID] = data.value);
+        const mockCallback = jest.fn((data) => (valuesReceived[data.ID] = data.value));
         connectionID = Onyx.connect({
             key: ONYX_KEYS.COLLECTION.TEST_KEY,
             initWithStoredValues: false,
@@ -631,7 +630,7 @@ describe('Onyx', () => {
         connectionID = Onyx.connect({
             key: ONYX_KEYS.COLLECTION.TEST_KEY,
             initWithStoredValues: false,
-            callback: (data, key) => valuesReceived[key] = data,
+            callback: (data, key) => (valuesReceived[key] = data),
         });
 
         return Onyx.multiSet({
@@ -642,21 +641,23 @@ describe('Onyx', () => {
                 existingData: 'test',
             },
         })
-            .then(() => Onyx.update([
-                {
-                    onyxMethod: 'multiset',
-                    value: {
-                        test_1: {
-                            ID: 123,
-                            value: 'one',
-                        },
-                        test_2: {
-                            ID: 234,
-                            value: 'two',
+            .then(() =>
+                Onyx.update([
+                    {
+                        onyxMethod: 'multiset',
+                        value: {
+                            test_1: {
+                                ID: 123,
+                                value: 'one',
+                            },
+                            test_2: {
+                                ID: 234,
+                                value: 'two',
+                            },
                         },
                     },
-                },
-            ]))
+                ]),
+            )
             .then(() => {
                 expect(valuesReceived).toEqual({
                     test_1: {
@@ -689,8 +690,7 @@ describe('Onyx', () => {
                 },
             ]);
         } catch (error) {
-            expect(error.message)
-                .toEqual('Invalid value provided in Onyx multiSet. Onyx multiSet value must be of type object.');
+            expect(error.message).toEqual('Invalid value provided in Onyx multiSet. Onyx multiSet value must be of type object.');
         }
     });
 
@@ -743,20 +743,21 @@ describe('Onyx', () => {
             waitForCollectionCallback: true,
             callback: mockCallback,
         });
-        return waitForPromisesToResolve()
+        return (
+            waitForPromisesToResolve()
+                // When mergeCollection is called with an updated collection
+                .then(() => Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_POLICY, collectionUpdate))
+                .then(() => {
+                    // Then we expect the callback to have called twice, once for the initial connect call + once for the collection update
+                    expect(mockCallback).toHaveBeenCalledTimes(2);
 
-            // When mergeCollection is called with an updated collection
-            .then(() => Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_POLICY, collectionUpdate))
-            .then(() => {
-                // Then we expect the callback to have called twice, once for the initial connect call + once for the collection update
-                expect(mockCallback).toHaveBeenCalledTimes(2);
+                    // AND the value for the first call should be null since the collection was not initialized at that point
+                    expect(mockCallback).toHaveBeenNthCalledWith(1, null, undefined);
 
-                // AND the value for the first call should be null since the collection was not initialized at that point
-                expect(mockCallback).toHaveBeenNthCalledWith(1, null, undefined);
-
-                // AND the value for the second call should be collectionUpdate since the collection was updated
-                expect(mockCallback).toHaveBeenNthCalledWith(2, collectionUpdate);
-            });
+                    // AND the value for the second call should be collectionUpdate since the collection was updated
+                    expect(mockCallback).toHaveBeenNthCalledWith(2, collectionUpdate);
+                })
+        );
     });
 
     it('should send a value to Onyx.connect() when subscribing to a specific collection member key and keysChanged() is called', () => {
@@ -771,20 +772,21 @@ describe('Onyx', () => {
             key: `${ONYX_KEYS.COLLECTION.TEST_POLICY}${1}`,
             callback: mockCallback,
         });
-        return waitForPromisesToResolve()
+        return (
+            waitForPromisesToResolve()
+                // When mergeCollection is called with an updated collection
+                .then(() => Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_POLICY, collectionUpdate))
+                .then(() => {
+                    // Then we expect the callback to have called twice, once for the initial connect call + once for the collection update
+                    expect(mockCallback).toHaveBeenCalledTimes(2);
 
-            // When mergeCollection is called with an updated collection
-            .then(() => Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_POLICY, collectionUpdate))
-            .then(() => {
-                // Then we expect the callback to have called twice, once for the initial connect call + once for the collection update
-                expect(mockCallback).toHaveBeenCalledTimes(2);
+                    // AND the value for the first call should be null since the collection was not initialized at that point
+                    expect(mockCallback).toHaveBeenNthCalledWith(1, null, undefined);
 
-                // AND the value for the first call should be null since the collection was not initialized at that point
-                expect(mockCallback).toHaveBeenNthCalledWith(1, null, undefined);
-
-                // AND the value for the second call should be collectionUpdate since the collection was updated
-                expect(mockCallback).toHaveBeenNthCalledWith(2, collectionUpdate.testPolicy_1, 'testPolicy_1');
-            });
+                    // AND the value for the second call should be collectionUpdate since the collection was updated
+                    expect(mockCallback).toHaveBeenNthCalledWith(2, collectionUpdate.testPolicy_1, 'testPolicy_1');
+                })
+        );
     });
 
     it('should return all collection keys as a single object for subscriber using waitForCollectionCallback when a single collection member key is updated', () => {
@@ -799,27 +801,27 @@ describe('Onyx', () => {
             waitForCollectionCallback: true,
             callback: mockCallback,
         });
-        return waitForPromisesToResolve()
+        return (
+            waitForPromisesToResolve()
+                // When mergeCollection is called with an updated collection
+                .then(() => Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_POLICY}${1}`, collectionUpdate.testPolicy_1))
+                .then(() => {
+                    // Then we expect the callback to have called twice, once for the initial connect call + once for the collection update
+                    expect(mockCallback).toHaveBeenCalledTimes(2);
 
-            // When mergeCollection is called with an updated collection
-            .then(() => Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_POLICY}${1}`, collectionUpdate.testPolicy_1))
-            .then(() => {
-                // Then we expect the callback to have called twice, once for the initial connect call + once for the collection update
-                expect(mockCallback).toHaveBeenCalledTimes(2);
-
-                // AND the value for the second call should be collectionUpdate
-                expect(mockCallback).toHaveBeenLastCalledWith(collectionUpdate);
-            });
+                    // AND the value for the second call should be collectionUpdate
+                    expect(mockCallback).toHaveBeenLastCalledWith(collectionUpdate);
+                })
+        );
     });
 
     it('should return a promise when set() called with the same value and there is no change', () => {
         const promiseOne = Onyx.set('test', 'pizza');
         expect(promiseOne).toBeInstanceOf(Promise);
-        return promiseOne
-            .then(() => {
-                const promiseTwo = Onyx.set('test', 'pizza');
-                expect(promiseTwo).toBeInstanceOf(Promise);
-            });
+        return promiseOne.then(() => {
+            const promiseTwo = Onyx.set('test', 'pizza');
+            expect(promiseTwo).toBeInstanceOf(Promise);
+        });
     });
 
     it('should not update a subscriber if the value in the cache has not changed at all', () => {
@@ -834,31 +836,32 @@ describe('Onyx', () => {
             waitForCollectionCallback: true,
             callback: mockCallback,
         });
-        return waitForPromisesToResolve()
+        return (
+            waitForPromisesToResolve()
+                // When merge is called with an updated collection
+                .then(() => Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_POLICY}${1}`, collectionUpdate.testPolicy_1))
+                .then(() => {
+                    // Then we expect the callback to have called twice, once for the initial connect call + once for the collection update
+                    expect(mockCallback).toHaveBeenCalledTimes(2);
 
-            // When merge is called with an updated collection
-            .then(() => Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_POLICY}${1}`, collectionUpdate.testPolicy_1))
-            .then(() => {
-                // Then we expect the callback to have called twice, once for the initial connect call + once for the collection update
-                expect(mockCallback).toHaveBeenCalledTimes(2);
+                    // And the value for the second call should be collectionUpdate
+                    expect(mockCallback).toHaveBeenNthCalledWith(2, collectionUpdate);
+                })
 
-                // And the value for the second call should be collectionUpdate
-                expect(mockCallback).toHaveBeenNthCalledWith(2, collectionUpdate);
-            })
+                // When merge is called again with the same collection not modified
+                .then(() => Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_POLICY}${1}`, collectionUpdate.testPolicy_1))
+                .then(() => {
+                    // Then we should not expect another invocation of the callback
+                    expect(mockCallback).toHaveBeenCalledTimes(2);
+                })
 
-            // When merge is called again with the same collection not modified
-            .then(() => Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_POLICY}${1}`, collectionUpdate.testPolicy_1))
-            .then(() => {
-                // Then we should not expect another invocation of the callback
-                expect(mockCallback).toHaveBeenCalledTimes(2);
-            })
-
-            // When merge is called again with an object of equivalent value but not the same reference
-            .then(() => Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_POLICY}${1}`, _.clone(collectionUpdate.testPolicy_1)))
-            .then(() => {
-                // Then we should not expect another invocation of the callback
-                expect(mockCallback).toHaveBeenCalledTimes(2);
-            });
+                // When merge is called again with an object of equivalent value but not the same reference
+                .then(() => Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_POLICY}${1}`, _.clone(collectionUpdate.testPolicy_1)))
+                .then(() => {
+                    // Then we should not expect another invocation of the callback
+                    expect(mockCallback).toHaveBeenCalledTimes(2);
+                })
+        );
     });
 
     it('should update subscriber if the value in the cache has not changed at all but initWithStoredValues === false', () => {
@@ -874,31 +877,32 @@ describe('Onyx', () => {
             callback: mockCallback,
             initWithStoredValues: false,
         });
-        return waitForPromisesToResolve()
+        return (
+            waitForPromisesToResolve()
+                // When merge is called with an updated collection
+                .then(() => Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_POLICY}${1}`, collectionUpdate.testPolicy_1))
+                .then(() => {
+                    // Then we expect the callback to have called once. 0 times the initial connect call + 1 time for the merge()
+                    expect(mockCallback).toHaveBeenCalledTimes(1);
 
-            // When merge is called with an updated collection
-            .then(() => Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_POLICY}${1}`, collectionUpdate.testPolicy_1))
-            .then(() => {
-                // Then we expect the callback to have called once. 0 times the initial connect call + 1 time for the merge()
-                expect(mockCallback).toHaveBeenCalledTimes(1);
+                    // And the value for the second call should be collectionUpdate
+                    expect(mockCallback).toHaveBeenNthCalledWith(1, collectionUpdate);
+                })
 
-                // And the value for the second call should be collectionUpdate
-                expect(mockCallback).toHaveBeenNthCalledWith(1, collectionUpdate);
-            })
+                // When merge is called again with the same collection not modified
+                .then(() => Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_POLICY}${1}`, collectionUpdate.testPolicy_1))
+                .then(() => {
+                    // Then we should expect another invocation of the callback because initWithStoredValues = false
+                    expect(mockCallback).toHaveBeenCalledTimes(2);
+                })
 
-            // When merge is called again with the same collection not modified
-            .then(() => Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_POLICY}${1}`, collectionUpdate.testPolicy_1))
-            .then(() => {
-                // Then we should expect another invocation of the callback because initWithStoredValues = false
-                expect(mockCallback).toHaveBeenCalledTimes(2);
-            })
-
-            // When merge is called again with an object of equivalent value but not the same reference
-            .then(() => Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_POLICY}${1}`, _.clone(collectionUpdate.testPolicy_1)))
-            .then(() => {
-                // Then we should expect another invocation of the callback because initWithStoredValues = false
-                expect(mockCallback).toHaveBeenCalledTimes(3);
-            });
+                // When merge is called again with an object of equivalent value but not the same reference
+                .then(() => Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_POLICY}${1}`, _.clone(collectionUpdate.testPolicy_1)))
+                .then(() => {
+                    // Then we should expect another invocation of the callback because initWithStoredValues = false
+                    expect(mockCallback).toHaveBeenCalledTimes(3);
+                })
+        );
     });
 
     it('should return a promise that completes when all update() operations are done', () => {
@@ -916,13 +920,12 @@ describe('Onyx', () => {
             {onyxMethod: Onyx.METHOD.SET, key: ONYX_KEYS.TEST_KEY, value: 'taco'},
             {onyxMethod: Onyx.METHOD.MERGE, key: ONYX_KEYS.OTHER_TEST, value: 'pizza'},
             {onyxMethod: Onyx.METHOD.MERGE_COLLECTION, key: ONYX_KEYS.COLLECTION.TEST_UPDATE, value: {[itemKey]: {a: 'a'}}},
-        ])
-            .then(() => {
-                expect(collectionCallback).toHaveBeenNthCalledWith(1, {[itemKey]: {a: 'a'}});
-                expect(testCallback).toHaveBeenNthCalledWith(1, 'taco', ONYX_KEYS.TEST_KEY);
-                expect(otherTestCallback).toHaveBeenNthCalledWith(1, 'pizza', ONYX_KEYS.OTHER_TEST);
-                Onyx.disconnect(connectionIDs);
-            });
+        ]).then(() => {
+            expect(collectionCallback).toHaveBeenNthCalledWith(1, {[itemKey]: {a: 'a'}});
+            expect(testCallback).toHaveBeenNthCalledWith(1, 'taco', ONYX_KEYS.TEST_KEY);
+            expect(otherTestCallback).toHaveBeenNthCalledWith(1, 'pizza', ONYX_KEYS.OTHER_TEST);
+            Onyx.disconnect(connectionIDs);
+        });
     });
 
     it('should merge an object with a batch of objects and undefined', () => {
@@ -948,7 +951,10 @@ describe('Onyx', () => {
             })
             .then(() => {
                 expect(testKeyValue).toEqual({
-                    test1: 'test1', test2: 'test2', test3: 'test3', test4: 'test4',
+                    test1: 'test1',
+                    test2: 'test2',
+                    test3: 'test3',
+                    test4: 'test4',
                 });
             });
     });
@@ -1000,7 +1006,8 @@ describe('Onyx', () => {
             .then(() => {
                 expect(testKeyValue).toEqual(null);
                 return Onyx.merge(ONYX_KEYS.TEST_KEY, 2);
-            }).then(() => {
+            })
+            .then(() => {
                 expect(testKeyValue).toEqual(2);
             });
     });

--- a/tests/unit/storage/providers/IDBKeyvalProviderTest.js
+++ b/tests/unit/storage/providers/IDBKeyvalProviderTest.js
@@ -38,10 +38,9 @@ describe('storage/providers/IDBKeyVal', () => {
         IDBKeyValProviderMock.multiSet(SAMPLE_ITEMS);
 
         return waitForPromisesToResolve().then(() => {
-        // Then multi get should retrieve them
+            // Then multi get should retrieve them
             const keys = _.map(SAMPLE_ITEMS, _.head);
-            return IDBKeyValProviderMock.multiGet(keys)
-                .then(pairs => expect(pairs).toEqual(expect.arrayContaining(SAMPLE_ITEMS)));
+            return IDBKeyValProviderMock.multiGet(keys).then((pairs) => expect(pairs).toEqual(expect.arrayContaining(SAMPLE_ITEMS)));
         });
     });
 
@@ -59,7 +58,10 @@ describe('storage/providers/IDBKeyVal', () => {
             traits: {hair: 'black'},
         };
 
-        IDBKeyValProviderMock.multiSet([['@USER_1', USER_1], ['@USER_2', USER_2]]);
+        IDBKeyValProviderMock.multiSet([
+            ['@USER_1', USER_1],
+            ['@USER_2', USER_2],
+        ]);
 
         return waitForPromisesToResolve().then(() => {
             IDBKeyValProviderMock.idbKeyvalSet.mockClear();
@@ -81,24 +83,22 @@ describe('storage/providers/IDBKeyVal', () => {
                 ['@USER_2', USER_2_DELTA],
             ]).then(() => {
                 // Then each existing item should be set with the merged content
-                expect(IDBKeyValProviderMock.idbKeyvalSet).toHaveBeenNthCalledWith(1,
-                    '@USER_1', {
-                        name: 'Tom',
-                        age: 31,
-                        traits: {
-                            hair: 'brown',
-                            eyes: 'blue',
-                        },
-                    });
+                expect(IDBKeyValProviderMock.idbKeyvalSet).toHaveBeenNthCalledWith(1, '@USER_1', {
+                    name: 'Tom',
+                    age: 31,
+                    traits: {
+                        hair: 'brown',
+                        eyes: 'blue',
+                    },
+                });
 
-                expect(IDBKeyValProviderMock.idbKeyvalSet).toHaveBeenNthCalledWith(2,
-                    '@USER_2', {
-                        name: 'Sarah',
-                        age: 26,
-                        traits: {
-                            hair: 'green',
-                        },
-                    });
+                expect(IDBKeyValProviderMock.idbKeyvalSet).toHaveBeenNthCalledWith(2, '@USER_2', {
+                    name: 'Sarah',
+                    age: 26,
+                    traits: {
+                        hair: 'green',
+                    },
+                });
             });
         });
     });
@@ -108,7 +108,8 @@ describe('storage/providers/IDBKeyVal', () => {
         const task = createDeferredTask();
 
         // We configure idbKeyval.setItem to return this promise the first time it's called and to otherwise return resolved promises
-        IDBKeyValProviderMock.setItem = jest.fn()
+        IDBKeyValProviderMock.setItem = jest
+            .fn()
             .mockReturnValue(Promise.resolve()) // Default behavior
             .mockReturnValueOnce(task.promise); // First call behavior
 

--- a/tests/unit/subscribeToPropertiesTest.js
+++ b/tests/unit/subscribeToPropertiesTest.js
@@ -50,57 +50,73 @@ describe('Only the specific property changes when using withOnyx() and ', () => 
      * @returns {Promise}
      */
     const runAssertionsWithComponent = (TestComponentWithOnyx) => {
-        let renderedComponent = render(<ErrorBoundary><TestComponentWithOnyx /></ErrorBoundary>);
-        return waitForPromisesToResolve()
+        let renderedComponent = render(
+            <ErrorBoundary>
+                <TestComponentWithOnyx />
+            </ErrorBoundary>,
+        );
+        return (
+            waitForPromisesToResolve()
+                // When Onyx is updated with an object that has multiple properties
+                .then(() => Onyx.merge(ONYX_KEYS.TEST_KEY, {a: 'one', b: 'two'}))
+                .then(() => {
+                    renderedComponent = render(
+                        <ErrorBoundary>
+                            <TestComponentWithOnyx />
+                        </ErrorBoundary>,
+                    );
+                })
 
-            // When Onyx is updated with an object that has multiple properties
-            .then(() => Onyx.merge(ONYX_KEYS.TEST_KEY, {a: 'one', b: 'two'}))
-            .then(() => {
-                renderedComponent = render(<ErrorBoundary><TestComponentWithOnyx /></ErrorBoundary>);
-            })
+                // Then the props passed to the component should only include the property "a" that was specified
+                .then(() => {
+                    expect(renderedComponent.getByTestId('text-element').props.children).toEqual('{"propertyA":"one"}');
+                })
 
-            // Then the props passed to the component should only include the property "a" that was specified
-            .then(() => {
-                expect(renderedComponent.getByTestId('text-element').props.children).toEqual('{"propertyA":"one"}');
-            })
+                // When Onyx is updated with a change to property a
+                .then(() => Onyx.merge(ONYX_KEYS.TEST_KEY, {a: 'two'}))
+                .then(() => {
+                    renderedComponent = render(
+                        <ErrorBoundary>
+                            <TestComponentWithOnyx />
+                        </ErrorBoundary>,
+                    );
+                })
 
-            // When Onyx is updated with a change to property a
-            .then(() => Onyx.merge(ONYX_KEYS.TEST_KEY, {a: 'two'}))
-            .then(() => {
-                renderedComponent = render(<ErrorBoundary><TestComponentWithOnyx /></ErrorBoundary>);
-            })
+                // Then the props passed should have the new value of property "a"
+                .then(() => {
+                    expect(renderedComponent.getByTestId('text-element').props.children).toEqual('{"propertyA":"two"}');
+                })
 
-            // Then the props passed should have the new value of property "a"
-            .then(() => {
-                expect(renderedComponent.getByTestId('text-element').props.children).toEqual('{"propertyA":"two"}');
-            })
+                // When Onyx is updated with a change to property b
+                .then(() => Onyx.merge(ONYX_KEYS.TEST_KEY, {b: 'two'}))
+                .then(() => {
+                    renderedComponent = render(
+                        <ErrorBoundary>
+                            <TestComponentWithOnyx />
+                        </ErrorBoundary>,
+                    );
+                })
 
-            // When Onyx is updated with a change to property b
-            .then(() => Onyx.merge(ONYX_KEYS.TEST_KEY, {b: 'two'}))
-            .then(() => {
-                renderedComponent = render(<ErrorBoundary><TestComponentWithOnyx /></ErrorBoundary>);
-            })
-
-            // Then the props passed should not have changed
-            .then(() => {
-                expect(renderedComponent.getByTestId('text-element').props.children).toEqual('{"propertyA":"two"}');
-            });
+                // Then the props passed should not have changed
+                .then(() => {
+                    expect(renderedComponent.getByTestId('text-element').props.children).toEqual('{"propertyA":"two"}');
+                })
+        );
     };
 
     it('connecting to a single non-collection key with a selector function', () => {
-        const mockedSelector = jest.fn(obj => obj && obj.a);
+        const mockedSelector = jest.fn((obj) => obj && obj.a);
         const TestComponentWithOnyx = withOnyx({
             propertyA: {
                 key: ONYX_KEYS.TEST_KEY,
                 selector: mockedSelector,
             },
         })(ViewWithObject);
-        return runAssertionsWithComponent(TestComponentWithOnyx)
-            .then(() => {
-                // This checks to make sure a bug doesn't occur where the entire state object was being passed to
-                // the selector
-                expect(mockedSelector).not.toHaveBeenCalledWith({loading: false, propertyA: null});
-            });
+        return runAssertionsWithComponent(TestComponentWithOnyx).then(() => {
+            // This checks to make sure a bug doesn't occur where the entire state object was being passed to
+            // the selector
+            expect(mockedSelector).not.toHaveBeenCalledWith({loading: false, propertyA: null});
+        });
     });
 
     /**
@@ -110,65 +126,77 @@ describe('Only the specific property changes when using withOnyx() and ', () => 
      * @returns {Promise}
      */
     const runAllAssertionsForCollection = (TestComponentWithOnyx) => {
-        let renderedComponent = render(<ErrorBoundary><TestComponentWithOnyx /></ErrorBoundary>);
-        return waitForPromisesToResolve()
+        let renderedComponent = render(
+            <ErrorBoundary>
+                <TestComponentWithOnyx />
+            </ErrorBoundary>,
+        );
+        return (
+            waitForPromisesToResolve()
+                // When Onyx is updated with an object that has multiple properties
+                .then(() =>
+                    Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
+                        [`${ONYX_KEYS.COLLECTION.TEST_KEY}1`]: {a: 'one', b: 'two'},
+                        [`${ONYX_KEYS.COLLECTION.TEST_KEY}2`]: {c: 'three', d: 'four'},
+                    }),
+                )
+                .then(() => {
+                    renderedComponent = render(
+                        <ErrorBoundary>
+                            <TestComponentWithOnyx />
+                        </ErrorBoundary>,
+                    );
+                })
 
-            // When Onyx is updated with an object that has multiple properties
-            .then(() => Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
-                [`${ONYX_KEYS.COLLECTION.TEST_KEY}1`]: {a: 'one', b: 'two'},
-                [`${ONYX_KEYS.COLLECTION.TEST_KEY}2`]: {c: 'three', d: 'four'},
-            }))
-            .then(() => {
-                renderedComponent = render(<ErrorBoundary><TestComponentWithOnyx /></ErrorBoundary>);
-            })
+                // Then the props passed to the component should only include the property "a" that was specified
+                .then(() => {
+                    expect(renderedComponent.getByTestId('text-element').props.children).toEqual('{"collectionWithPropertyA":{"test_1":"one"}}');
+                })
 
-            // Then the props passed to the component should only include the property "a" that was specified
-            .then(() => {
-                expect(renderedComponent.getByTestId('text-element').props.children).toEqual('{"collectionWithPropertyA":{"test_1":"one"}}');
-            })
+                // When Onyx is updated with a change to property a using merge()
+                // This uses merge() just to make sure that everything works as expected when mixing merge()
+                // and mergeCollection()
+                .then(() => Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_KEY}1`, {a: 'two'}))
 
-            // When Onyx is updated with a change to property a using merge()
-            // This uses merge() just to make sure that everything works as expected when mixing merge()
-            // and mergeCollection()
-            .then(() => Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_KEY}1`, {a: 'two'}))
+                // Then the props passed should have the new value of property "a"
+                .then(() => {
+                    expect(renderedComponent.getByTestId('text-element').props.children).toEqual('{"collectionWithPropertyA":{"test_1":"two"}}');
+                })
 
-            // Then the props passed should have the new value of property "a"
-            .then(() => {
-                expect(renderedComponent.getByTestId('text-element').props.children).toEqual('{"collectionWithPropertyA":{"test_1":"two"}}');
-            })
+                // When Onyx is updated with a change to property b using mergeCollection()
+                .then(() =>
+                    Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
+                        [`${ONYX_KEYS.COLLECTION.TEST_KEY}1`]: {b: 'three'},
+                    }),
+                )
 
-            // When Onyx is updated with a change to property b using mergeCollection()
-            .then(() => Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
-                [`${ONYX_KEYS.COLLECTION.TEST_KEY}1`]: {b: 'three'},
-            }))
-
-            // Then the props passed should not have changed
-            .then(() => {
-                expect(renderedComponent.getByTestId('text-element').props.children).toEqual('{"collectionWithPropertyA":{"test_1":"two"}}');
-            });
+                // Then the props passed should not have changed
+                .then(() => {
+                    expect(renderedComponent.getByTestId('text-element').props.children).toEqual('{"collectionWithPropertyA":{"test_1":"two"}}');
+                })
+        );
     };
 
     it('connecting to a collection with a selector function', () => {
-        const mockedSelector = jest.fn(obj => obj && obj.a);
+        const mockedSelector = jest.fn((obj) => obj && obj.a);
         const TestComponentWithOnyx = withOnyx({
             collectionWithPropertyA: {
                 key: ONYX_KEYS.COLLECTION.TEST_KEY,
                 selector: mockedSelector,
             },
         })(ViewWithObject);
-        return runAllAssertionsForCollection(TestComponentWithOnyx)
-            .then(() => {
-                // Expect that the selector always gets called with the full object
-                // from the onyx state, and not with the selector result value (string in this case).
-                for (let i = 0; i < mockedSelector.mock.calls.length; i++) {
-                    const firstArg = mockedSelector.mock.calls[i][0];
-                    expect(firstArg).toBeDefined();
-                    expect(firstArg).toBeInstanceOf(Object);
-                }
+        return runAllAssertionsForCollection(TestComponentWithOnyx).then(() => {
+            // Expect that the selector always gets called with the full object
+            // from the onyx state, and not with the selector result value (string in this case).
+            for (let i = 0; i < mockedSelector.mock.calls.length; i++) {
+                const firstArg = mockedSelector.mock.calls[i][0];
+                expect(firstArg).toBeDefined();
+                expect(firstArg).toBeInstanceOf(Object);
+            }
 
-                // Check to make sure that the selector was called with the props that are passed to the rendered component
-                expect(mockedSelector).toHaveBeenNthCalledWith(5, {a: 'two', b: 'two'}, {loading: false, collectionWithPropertyA: {test_1: 'one', test_2: undefined}});
-            });
+            // Check to make sure that the selector was called with the props that are passed to the rendered component
+            expect(mockedSelector).toHaveBeenNthCalledWith(5, {a: 'two', b: 'two'}, {loading: false, collectionWithPropertyA: {test_1: 'one', test_2: undefined}});
+        });
     });
 
     /**
@@ -178,49 +206,62 @@ describe('Only the specific property changes when using withOnyx() and ', () => 
      * @returns {Promise}
      */
     const runAllAssertionsForCollectionMemberKey = (TestComponentWithOnyx) => {
-        let renderedComponent = render(<ErrorBoundary><TestComponentWithOnyx /></ErrorBoundary>);
-        return waitForPromisesToResolve()
+        let renderedComponent = render(
+            <ErrorBoundary>
+                <TestComponentWithOnyx />
+            </ErrorBoundary>,
+        );
+        return (
+            waitForPromisesToResolve()
+                // When Onyx is updated with an object that has multiple properties
+                .then(() =>
+                    Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
+                        [`${ONYX_KEYS.COLLECTION.TEST_KEY}1`]: {a: 'one', b: 'two'},
+                        [`${ONYX_KEYS.COLLECTION.TEST_KEY}2`]: {c: 'three', d: 'four'},
+                    }),
+                )
+                .then(() => {
+                    renderedComponent = render(
+                        <ErrorBoundary>
+                            <TestComponentWithOnyx />
+                        </ErrorBoundary>,
+                    );
+                })
 
-            // When Onyx is updated with an object that has multiple properties
-            .then(() => Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
-                [`${ONYX_KEYS.COLLECTION.TEST_KEY}1`]: {a: 'one', b: 'two'},
-                [`${ONYX_KEYS.COLLECTION.TEST_KEY}2`]: {c: 'three', d: 'four'},
-            }))
-            .then(() => {
-                renderedComponent = render(<ErrorBoundary><TestComponentWithOnyx /></ErrorBoundary>);
-            })
+                // Then the props passed to the component should only include the property "a" that was specified
+                .then(() => {
+                    expect(renderedComponent.getByTestId('text-element').props.children).toEqual('{"itemWithPropertyA":"one"}');
+                })
 
-            // Then the props passed to the component should only include the property "a" that was specified
-            .then(() => {
-                expect(renderedComponent.getByTestId('text-element').props.children).toEqual('{"itemWithPropertyA":"one"}');
-            })
+                // When Onyx is updated with a change to property a using merge()
+                // This uses merge() just to make sure that everything works as expected when mixing merge()
+                // and mergeCollection()
+                .then(() => Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_KEY}1`, {a: 'two'}))
 
-            // When Onyx is updated with a change to property a using merge()
-            // This uses merge() just to make sure that everything works as expected when mixing merge()
-            // and mergeCollection()
-            .then(() => Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_KEY}1`, {a: 'two'}))
+                // Then the props passed should have the new value of property "a"
+                .then(() => {
+                    expect(renderedComponent.getByTestId('text-element').props.children).toEqual('{"itemWithPropertyA":"two"}');
+                })
 
-            // Then the props passed should have the new value of property "a"
-            .then(() => {
-                expect(renderedComponent.getByTestId('text-element').props.children).toEqual('{"itemWithPropertyA":"two"}');
-            })
+                // When Onyx is updated with a change to property b using mergeCollection()
+                .then(() =>
+                    Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
+                        [`${ONYX_KEYS.COLLECTION.TEST_KEY}1`]: {b: 'three'},
+                    }),
+                )
 
-            // When Onyx is updated with a change to property b using mergeCollection()
-            .then(() => Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
-                [`${ONYX_KEYS.COLLECTION.TEST_KEY}1`]: {b: 'three'},
-            }))
-
-            // Then the props passed should not have changed
-            .then(() => {
-                expect(renderedComponent.getByTestId('text-element').props.children).toEqual('{"itemWithPropertyA":"two"}');
-            });
+                // Then the props passed should not have changed
+                .then(() => {
+                    expect(renderedComponent.getByTestId('text-element').props.children).toEqual('{"itemWithPropertyA":"two"}');
+                })
+        );
     };
 
     it('connecting to a collection member with a selector function', () => {
         const TestComponentWithOnyx = withOnyx({
             itemWithPropertyA: {
                 key: `${ONYX_KEYS.COLLECTION.TEST_KEY}1`,
-                selector: obj => obj && obj.a,
+                selector: (obj) => obj && obj.a,
             },
         })(ViewWithObject);
         return runAllAssertionsForCollectionMemberKey(TestComponentWithOnyx);

--- a/tests/unit/webMetricsTest.js
+++ b/tests/unit/webMetricsTest.js
@@ -1,4 +1,3 @@
-
 describe('decorateWithMetrics', () => {
     let decorateWithMetrics;
 

--- a/tests/unit/withOnyxTest.js
+++ b/tests/unit/withOnyxTest.js
@@ -81,35 +81,39 @@ describe('withOnyxTest', () => {
             });
     });
 
-    it('should batch correctly together little khachapuris', () => Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
-        [`${ONYX_KEYS.COLLECTION.TEST_KEY}1`]: {ID: 999},
-    }).then(() => Onyx.merge(ONYX_KEYS.SIMPLE_KEY, 'prev_string')).then(() => Onyx.merge(ONYX_KEYS.SIMPLE_KEY_2, 'prev_string2')).then(() => {
-        const TestComponentWithOnyx = withOnyx({
-            testKey: {
-                key: `${ONYX_KEYS.COLLECTION.TEST_KEY}1`,
-            },
-            simpleKey: {
-                key: ONYX_KEYS.SIMPLE_KEY,
-            },
-            simpleKey2: {
-                key: ONYX_KEYS.SIMPLE_KEY_2,
-            },
-        })(ViewWithObject);
-        const onRender = jest.fn();
-        render(<TestComponentWithOnyx onRender={onRender} />);
+    it('should batch correctly together little khachapuris', () =>
+        Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
+            [`${ONYX_KEYS.COLLECTION.TEST_KEY}1`]: {ID: 999},
+        })
+            .then(() => Onyx.merge(ONYX_KEYS.SIMPLE_KEY, 'prev_string'))
+            .then(() => Onyx.merge(ONYX_KEYS.SIMPLE_KEY_2, 'prev_string2'))
+            .then(() => {
+                const TestComponentWithOnyx = withOnyx({
+                    testKey: {
+                        key: `${ONYX_KEYS.COLLECTION.TEST_KEY}1`,
+                    },
+                    simpleKey: {
+                        key: ONYX_KEYS.SIMPLE_KEY,
+                    },
+                    simpleKey2: {
+                        key: ONYX_KEYS.SIMPLE_KEY_2,
+                    },
+                })(ViewWithObject);
+                const onRender = jest.fn();
+                render(<TestComponentWithOnyx onRender={onRender} />);
 
-        return waitForPromisesToResolve()
-            .then(() => {
-                Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {test_1: {ID: 123}});
-                Onyx.merge(ONYX_KEYS.SIMPLE_KEY, 'string');
-                return Onyx.merge(ONYX_KEYS.SIMPLE_KEY_2, 'string2');
-            })
-            .then(() => {
-                // We expect it to be 2 as we first is initial render and second are 3 Onyx merges batched together.
-                // As you see onyx merges on the top of the function doesn't account they are done earlier
-                expect(onRender).toHaveBeenCalledTimes(2);
-            });
-    }));
+                return waitForPromisesToResolve()
+                    .then(() => {
+                        Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {test_1: {ID: 123}});
+                        Onyx.merge(ONYX_KEYS.SIMPLE_KEY, 'string');
+                        return Onyx.merge(ONYX_KEYS.SIMPLE_KEY_2, 'string2');
+                    })
+                    .then(() => {
+                        // We expect it to be 2 as we first is initial render and second are 3 Onyx merges batched together.
+                        // As you see onyx merges on the top of the function doesn't account they are done earlier
+                        expect(onRender).toHaveBeenCalledTimes(2);
+                    });
+            }));
 
     it('should update withOnyx subscriber just once when mergeCollection is used', () => {
         const TestComponentWithOnyx = withOnyx({
@@ -120,9 +124,13 @@ describe('withOnyxTest', () => {
         const onRender = jest.fn();
         render(<TestComponentWithOnyx onRender={onRender} />);
         return waitForPromisesToResolve()
-            .then(() => Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
-                test_1: {ID: 123}, test_2: {ID: 234}, test_3: {ID: 345},
-            }))
+            .then(() =>
+                Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
+                    test_1: {ID: 123},
+                    test_2: {ID: 234},
+                    test_3: {ID: 345},
+                }),
+            )
             .then(() => {
                 expect(onRender).toHaveBeenCalledTimes(2);
             });
@@ -138,9 +146,13 @@ describe('withOnyxTest', () => {
         const onRender = jest.fn();
         render(<TestComponentWithOnyx onRender={onRender} />);
         return waitForPromisesToResolve()
-            .then(() => Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
-                test_1: {ID: 123}, test_2: {ID: 234}, test_3: {ID: 345},
-            }))
+            .then(() =>
+                Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
+                    test_1: {ID: 123},
+                    test_2: {ID: 234},
+                    test_3: {ID: 345},
+                }),
+            )
             .then(() => {
                 expect(onRender).toHaveBeenCalledTimes(2);
             });
@@ -155,18 +167,31 @@ describe('withOnyxTest', () => {
         })(ViewWithCollections);
         const onRender = jest.fn();
         const markReadyForHydration = jest.fn();
-        render(<TestComponentWithOnyx onRender={onRender} markReadyForHydration={markReadyForHydration} />);
+        render(
+            <TestComponentWithOnyx
+                onRender={onRender}
+                markReadyForHydration={markReadyForHydration}
+            />,
+        );
         return waitForPromisesToResolve()
-            .then(() => Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
-                test_1: {list: [1, 2]},
-            }))
-            .then(() => Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
-                test_1: {list: [7]},
-            }))
+            .then(() =>
+                Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
+                    test_1: {list: [1, 2]},
+                }),
+            )
+            .then(() =>
+                Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
+                    test_1: {list: [7]},
+                }),
+            )
             .then(() => {
                 expect(onRender).toHaveBeenCalledTimes(3);
                 expect(onRender).toHaveBeenLastCalledWith({
-                    collections: {}, markReadyForHydration, onRender, testObject: {isDefaultProp: true}, text: {list: [7]},
+                    collections: {},
+                    markReadyForHydration,
+                    onRender,
+                    testObject: {isDefaultProp: true},
+                    text: {list: [7]},
                 });
             });
     });
@@ -180,18 +205,29 @@ describe('withOnyxTest', () => {
         })(ViewWithCollections);
         const onRender = jest.fn();
         const markReadyForHydration = jest.fn();
-        render(<TestComponentWithOnyx markReadyForHydration={markReadyForHydration} onRender={onRender} />);
+        render(
+            <TestComponentWithOnyx
+                markReadyForHydration={markReadyForHydration}
+                onRender={onRender}
+            />,
+        );
         return waitForPromisesToResolve()
             .then(() => Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {test_4: {ID: 456}, test_5: {ID: 567}}))
-            .then(() => Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
-                test_4: {Name: 'Test4'},
-                test_5: {Name: 'Test5'},
-                test_6: {ID: 678, Name: 'Test6'},
-            }))
+            .then(() =>
+                Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
+                    test_4: {Name: 'Test4'},
+                    test_5: {Name: 'Test5'},
+                    test_6: {ID: 678, Name: 'Test6'},
+                }),
+            )
             .then(() => {
                 expect(onRender).toHaveBeenCalledTimes(3);
                 expect(onRender).toHaveBeenLastCalledWith({
-                    collections: {}, markReadyForHydration, onRender, testObject: {isDefaultProp: true}, text: {ID: 456, Name: 'Test4'},
+                    collections: {},
+                    markReadyForHydration,
+                    onRender,
+                    testObject: {isDefaultProp: true},
+                    text: {ID: 456, Name: 'Test4'},
                 });
             });
     });
@@ -201,7 +237,7 @@ describe('withOnyxTest', () => {
         let getByTestId;
         const TestComponentWithOnyx = withOnyx({
             text: {
-                key: props => `${ONYX_KEYS.COLLECTION.TEST_KEY}${props.collectionID}`,
+                key: (props) => `${ONYX_KEYS.COLLECTION.TEST_KEY}${props.collectionID}`,
             },
         })(ViewWithText);
         Onyx.set(`${ONYX_KEYS.COLLECTION.TEST_KEY}1`, 'test_1');
@@ -239,11 +275,10 @@ describe('withOnyxTest', () => {
             text: INITIAL_VALUE,
         };
         Onyx.set('test_key', 'test_text');
-        return waitForPromisesToResolve()
-            .then(() => {
-                const {getByTestId} = render(<TestComponentWithOnyx collectionID="1" />);
-                expect(getByTestId('text-element').props.children).toEqual(INITIAL_VALUE);
-            });
+        return waitForPromisesToResolve().then(() => {
+            const {getByTestId} = render(<TestComponentWithOnyx collectionID="1" />);
+            expect(getByTestId('text-element').props.children).toEqual(INITIAL_VALUE);
+        });
     });
 
     it('should pass a prop from one connected component to another', () => {
@@ -275,47 +310,54 @@ describe('withOnyxTest', () => {
         });
 
         // When a component is rendered using withOnyx and several nested dependencies on the keys
-        return waitForPromisesToResolve()
-            .then(() => {
-                const TestComponentWithOnyx = withOnyx({
-                    staticObject: {
-                        key: `${ONYX_KEYS.COLLECTION.STATIC}1`,
-                    },
-                    dependentObject: {
-                        key: ({staticObject}) => `${ONYX_KEYS.COLLECTION.DEPENDS_ON_STATIC}${(staticObject && staticObject.id) || 0}`,
-                    },
-                    multiDependentObject: {
-                        key: ({dependentObject}) => `${ONYX_KEYS.COLLECTION.DEPENDS_ON_DEPENDS_ON_STATIC}${(dependentObject && dependentObject.id) || 0}`,
-                    },
-                    extremeMultiDependentObject: {
-                        key: ({multiDependentObject}) => `${ONYX_KEYS.COLLECTION.DEPENDS_ON_DEPENDS_ON_DEPENDS_ON_STATIC}${(multiDependentObject && multiDependentObject.id) || 0}`,
-                    },
-                })(ViewWithCollections);
-                render(<TestComponentWithOnyx markReadyForHydration={markReadyForHydration} onRender={onRender} />);
+        return (
+            waitForPromisesToResolve()
+                .then(() => {
+                    const TestComponentWithOnyx = withOnyx({
+                        staticObject: {
+                            key: `${ONYX_KEYS.COLLECTION.STATIC}1`,
+                        },
+                        dependentObject: {
+                            key: ({staticObject}) => `${ONYX_KEYS.COLLECTION.DEPENDS_ON_STATIC}${(staticObject && staticObject.id) || 0}`,
+                        },
+                        multiDependentObject: {
+                            key: ({dependentObject}) => `${ONYX_KEYS.COLLECTION.DEPENDS_ON_DEPENDS_ON_STATIC}${(dependentObject && dependentObject.id) || 0}`,
+                        },
+                        extremeMultiDependentObject: {
+                            key: ({multiDependentObject}) => `${ONYX_KEYS.COLLECTION.DEPENDS_ON_DEPENDS_ON_DEPENDS_ON_STATIC}${(multiDependentObject && multiDependentObject.id) || 0}`,
+                        },
+                    })(ViewWithCollections);
+                    render(
+                        <TestComponentWithOnyx
+                            markReadyForHydration={markReadyForHydration}
+                            onRender={onRender}
+                        />,
+                    );
 
-                // First promise is for the staticObject and dependentObject to load
-                return waitForPromisesToResolve();
-            })
+                    // First promise is for the staticObject and dependentObject to load
+                    return waitForPromisesToResolve();
+                })
 
-            // Second promise is for multiDependentObject to load
-            .then(waitForPromisesToResolve)
+                // Second promise is for multiDependentObject to load
+                .then(waitForPromisesToResolve)
 
-            // Third promise is for extremeMultiDependentObject to load
-            .then(waitForPromisesToResolve)
+                // Third promise is for extremeMultiDependentObject to load
+                .then(waitForPromisesToResolve)
 
-            // Then all of the data gets properly loaded into the component as expected with the nested dependencies resolved
-            .then(() => {
-                expect(onRender).toHaveBeenLastCalledWith({
-                    markReadyForHydration,
-                    onRender,
-                    collections: {},
-                    testObject: {isDefaultProp: true},
-                    staticObject: {name: 'Static 1', id: 1},
-                    dependentObject: {name: 'dependsOnStatic 1', id: 3},
-                    multiDependentObject: {name: 'dependsOnDependsOnStatic 1', id: 5},
-                    extremeMultiDependentObject: {name: 'dependsOnDependsOnDependsOnStatic 1'},
-                });
-            });
+                // Then all of the data gets properly loaded into the component as expected with the nested dependencies resolved
+                .then(() => {
+                    expect(onRender).toHaveBeenLastCalledWith({
+                        markReadyForHydration,
+                        onRender,
+                        collections: {},
+                        testObject: {isDefaultProp: true},
+                        staticObject: {name: 'Static 1', id: 1},
+                        dependentObject: {name: 'dependsOnStatic 1', id: 3},
+                        multiDependentObject: {name: 'dependsOnDependsOnStatic 1', id: 5},
+                        extremeMultiDependentObject: {name: 'dependsOnDependsOnDependsOnStatic 1'},
+                    });
+                })
+        );
     });
 
     it('using mergeCollection to modify one item should only effect one component', () => {
@@ -333,58 +375,89 @@ describe('withOnyxTest', () => {
             test_3: {ID: 3},
         });
 
-        return waitForPromisesToResolve()
-            .then(() => {
-                // When three components subscribe to each of the items in that collection
-                const TestComponentWithOnyx1 = withOnyx({
-                    testObject: {
-                        key: `${ONYX_KEYS.COLLECTION.TEST_KEY}1`,
-                    },
-                })(ViewWithCollections);
-                render(<TestComponentWithOnyx1 markReadyForHydration={markReadyForHydration1} onRender={onRender1} />);
+        return (
+            waitForPromisesToResolve()
+                .then(() => {
+                    // When three components subscribe to each of the items in that collection
+                    const TestComponentWithOnyx1 = withOnyx({
+                        testObject: {
+                            key: `${ONYX_KEYS.COLLECTION.TEST_KEY}1`,
+                        },
+                    })(ViewWithCollections);
+                    render(
+                        <TestComponentWithOnyx1
+                            markReadyForHydration={markReadyForHydration1}
+                            onRender={onRender1}
+                        />,
+                    );
 
-                const TestComponentWithOnyx2 = withOnyx({
-                    testObject: {
-                        key: `${ONYX_KEYS.COLLECTION.TEST_KEY}2`,
-                    },
-                })(ViewWithCollections);
-                render(<TestComponentWithOnyx2 markReadyForHydration={markReadyForHydration2} onRender={onRender2} />);
+                    const TestComponentWithOnyx2 = withOnyx({
+                        testObject: {
+                            key: `${ONYX_KEYS.COLLECTION.TEST_KEY}2`,
+                        },
+                    })(ViewWithCollections);
+                    render(
+                        <TestComponentWithOnyx2
+                            markReadyForHydration={markReadyForHydration2}
+                            onRender={onRender2}
+                        />,
+                    );
 
-                const TestComponentWithOnyx3 = withOnyx({
-                    testObject: {
-                        key: `${ONYX_KEYS.COLLECTION.TEST_KEY}3`,
-                    },
-                })(ViewWithCollections);
-                render(<TestComponentWithOnyx3 markReadyForHydration={markReadyForHydration3} onRender={onRender3} />);
-            })
+                    const TestComponentWithOnyx3 = withOnyx({
+                        testObject: {
+                            key: `${ONYX_KEYS.COLLECTION.TEST_KEY}3`,
+                        },
+                    })(ViewWithCollections);
+                    render(
+                        <TestComponentWithOnyx3
+                            markReadyForHydration={markReadyForHydration3}
+                            onRender={onRender3}
+                        />,
+                    );
+                })
 
-            // When a single item in the collection is updated with mergeCollection()
-            .then(() => Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
-                test_1: {ID: 1, newProperty: 'yay'},
-            }))
-            .then(() => {
-                // Then the component subscribed to the modified item should have the new version of the item
-                // and all other components should be unchanged.
-                // Note: each component is rendered twice. Once when it is initially rendered, and then again
-                // when the collection is updated. That's why there are two checks here for each component.
-                expect(onRender1).toHaveBeenCalledTimes(2);
-                expect(onRender1).toHaveBeenNthCalledWith(1, {
-                    collections: {}, markReadyForHydration: markReadyForHydration1, onRender: onRender1, testObject: {ID: 1},
-                });
-                expect(onRender1).toHaveBeenNthCalledWith(2, {
-                    collections: {}, markReadyForHydration: markReadyForHydration1, onRender: onRender1, testObject: {ID: 1, newProperty: 'yay'},
-                });
+                // When a single item in the collection is updated with mergeCollection()
+                .then(() =>
+                    Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
+                        test_1: {ID: 1, newProperty: 'yay'},
+                    }),
+                )
+                .then(() => {
+                    // Then the component subscribed to the modified item should have the new version of the item
+                    // and all other components should be unchanged.
+                    // Note: each component is rendered twice. Once when it is initially rendered, and then again
+                    // when the collection is updated. That's why there are two checks here for each component.
+                    expect(onRender1).toHaveBeenCalledTimes(2);
+                    expect(onRender1).toHaveBeenNthCalledWith(1, {
+                        collections: {},
+                        markReadyForHydration: markReadyForHydration1,
+                        onRender: onRender1,
+                        testObject: {ID: 1},
+                    });
+                    expect(onRender1).toHaveBeenNthCalledWith(2, {
+                        collections: {},
+                        markReadyForHydration: markReadyForHydration1,
+                        onRender: onRender1,
+                        testObject: {ID: 1, newProperty: 'yay'},
+                    });
 
-                expect(onRender2).toHaveBeenCalledTimes(1);
-                expect(onRender2).toHaveBeenNthCalledWith(1, {
-                    collections: {}, markReadyForHydration: markReadyForHydration2, onRender: onRender2, testObject: {ID: 2},
-                });
+                    expect(onRender2).toHaveBeenCalledTimes(1);
+                    expect(onRender2).toHaveBeenNthCalledWith(1, {
+                        collections: {},
+                        markReadyForHydration: markReadyForHydration2,
+                        onRender: onRender2,
+                        testObject: {ID: 2},
+                    });
 
-                expect(onRender3).toHaveBeenCalledTimes(1);
-                expect(onRender3).toHaveBeenNthCalledWith(1, {
-                    collections: {}, markReadyForHydration: markReadyForHydration3, onRender: onRender3, testObject: {ID: 3},
-                });
-            });
+                    expect(onRender3).toHaveBeenCalledTimes(1);
+                    expect(onRender3).toHaveBeenNthCalledWith(1, {
+                        collections: {},
+                        markReadyForHydration: markReadyForHydration3,
+                        onRender: onRender3,
+                        testObject: {ID: 3},
+                    });
+                })
+        );
     });
 
     it('mergeCollection should merge previous props correctly to the new state', () => {
@@ -396,33 +469,48 @@ describe('withOnyxTest', () => {
             test_1: {ID: 1, number: 1},
         });
 
-        return waitForPromisesToResolve()
-            .then(() => {
-                // When a component subscribes to the one item in that collection
-                const TestComponentWithOnyx = withOnyx({
-                    testObject: {
-                        key: `${ONYX_KEYS.COLLECTION.TEST_KEY}1`,
-                    },
-                })(ViewWithCollections);
-                render(<TestComponentWithOnyx markReadyForHydration={markReadyForHydration} onRender={onRender} />);
-            })
+        return (
+            waitForPromisesToResolve()
+                .then(() => {
+                    // When a component subscribes to the one item in that collection
+                    const TestComponentWithOnyx = withOnyx({
+                        testObject: {
+                            key: `${ONYX_KEYS.COLLECTION.TEST_KEY}1`,
+                        },
+                    })(ViewWithCollections);
+                    render(
+                        <TestComponentWithOnyx
+                            markReadyForHydration={markReadyForHydration}
+                            onRender={onRender}
+                        />,
+                    );
+                })
 
-            // When the `number` property is updated using mergeCollection to be 2
-            .then(() => Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
-                test_1: {number: 2},
-            }))
-            .then(() => {
-                // Then the component subscribed to the modified item should be rendered twice.
-                // The first time it will render with number === 1
-                // The second time it will render with number === 2
-                expect(onRender).toHaveBeenCalledTimes(2);
-                expect(onRender).toHaveBeenNthCalledWith(1, {
-                    collections: {}, markReadyForHydration, onRender, testObject: {ID: 1, number: 1},
-                });
-                expect(onRender).toHaveBeenNthCalledWith(2, {
-                    collections: {}, markReadyForHydration, onRender, testObject: {ID: 1, number: 2},
-                });
-            });
+                // When the `number` property is updated using mergeCollection to be 2
+                .then(() =>
+                    Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
+                        test_1: {number: 2},
+                    }),
+                )
+                .then(() => {
+                    // Then the component subscribed to the modified item should be rendered twice.
+                    // The first time it will render with number === 1
+                    // The second time it will render with number === 2
+                    expect(onRender).toHaveBeenCalledTimes(2);
+                    expect(onRender).toHaveBeenNthCalledWith(1, {
+                        collections: {},
+                        markReadyForHydration,
+                        onRender,
+                        testObject: {ID: 1, number: 1},
+                    });
+                    expect(onRender).toHaveBeenNthCalledWith(2, {
+                        collections: {},
+                        markReadyForHydration,
+                        onRender,
+                        testObject: {ID: 1, number: 2},
+                    });
+                })
+        );
     });
 
     it('merge with a simple value should not update a connected component unless the data has changed', () => {
@@ -431,32 +519,34 @@ describe('withOnyxTest', () => {
         // Given there is a simple key that is not an array or object value
         Onyx.merge(ONYX_KEYS.SIMPLE_KEY, 'string');
 
-        return waitForPromisesToResolve()
-            .then(() => {
-                // When a component subscribes to the simple key
-                const TestComponentWithOnyx = withOnyx({
-                    simple: {
-                        key: ONYX_KEYS.SIMPLE_KEY,
-                    },
-                })(ViewWithCollections);
-                render(<TestComponentWithOnyx onRender={onRender} />);
-            })
+        return (
+            waitForPromisesToResolve()
+                .then(() => {
+                    // When a component subscribes to the simple key
+                    const TestComponentWithOnyx = withOnyx({
+                        simple: {
+                            key: ONYX_KEYS.SIMPLE_KEY,
+                        },
+                    })(ViewWithCollections);
+                    render(<TestComponentWithOnyx onRender={onRender} />);
+                })
 
-            // And we set the value to the same value it was before
-            .then(() => Onyx.merge(ONYX_KEYS.SIMPLE_KEY, 'string'))
-            .then(() => {
-                // Then the component subscribed to the modified item should only render once
-                expect(onRender).toHaveBeenCalledTimes(1);
-                expect(onRender.mock.calls[0][0].simple).toBe('string');
+                // And we set the value to the same value it was before
+                .then(() => Onyx.merge(ONYX_KEYS.SIMPLE_KEY, 'string'))
+                .then(() => {
+                    // Then the component subscribed to the modified item should only render once
+                    expect(onRender).toHaveBeenCalledTimes(1);
+                    expect(onRender.mock.calls[0][0].simple).toBe('string');
 
-                // If we change the value to something new
-                return Onyx.merge(ONYX_KEYS.SIMPLE_KEY, 'long_string');
-            })
-            .then(() => {
-                // Then the component subscribed to the modified item should only render once
-                expect(onRender).toHaveBeenCalledTimes(2);
-                expect(onRender.mock.calls[1][0].simple).toBe('long_string');
-            });
+                    // If we change the value to something new
+                    return Onyx.merge(ONYX_KEYS.SIMPLE_KEY, 'long_string');
+                })
+                .then(() => {
+                    // Then the component subscribed to the modified item should only render once
+                    expect(onRender).toHaveBeenCalledTimes(2);
+                    expect(onRender.mock.calls[1][0].simple).toBe('long_string');
+                })
+        );
     });
 
     it('initialValue should be fed into component', () => {
@@ -472,13 +562,22 @@ describe('withOnyxTest', () => {
                         initialValue: 'initialValue',
                     },
                 })(ViewWithCollections);
-                render(<TestComponentWithOnyx markReadyForHydration={markReadyForHydration} onRender={onRender} />);
+                render(
+                    <TestComponentWithOnyx
+                        markReadyForHydration={markReadyForHydration}
+                        onRender={onRender}
+                    />,
+                );
             })
             .then(() => {
                 // Then the component subscribed to the modified item should only render once
                 expect(onRender).toHaveBeenCalledTimes(1);
                 expect(onRender).toHaveBeenLastCalledWith({
-                    collections: {}, markReadyForHydration, onRender, testObject: {isDefaultProp: true}, simple: 'initialValue',
+                    collections: {},
+                    markReadyForHydration,
+                    onRender,
+                    testObject: {isDefaultProp: true},
+                    simple: 'initialValue',
                 });
             });
     });
@@ -487,41 +586,50 @@ describe('withOnyxTest', () => {
         const onRender = jest.fn();
         const ref = React.createRef();
 
-        return waitForPromisesToResolve()
-            .then(() => {
-                // When a component subscribes to the simple key
-                const TestComponentWithOnyx = withOnyx({
-                    simple: {
-                        key: ONYX_KEYS.SIMPLE_KEY,
-                        initialValue: 'initialValue',
-                    },
-                },
-                true)(ViewWithCollections);
+        return (
+            waitForPromisesToResolve()
+                .then(() => {
+                    // When a component subscribes to the simple key
+                    const TestComponentWithOnyx = withOnyx(
+                        {
+                            simple: {
+                                key: ONYX_KEYS.SIMPLE_KEY,
+                                initialValue: 'initialValue',
+                            },
+                        },
+                        true,
+                    )(ViewWithCollections);
 
-                render(<TestComponentWithOnyx onRender={onRender} ref={ref} />);
-            })
+                    render(
+                        <TestComponentWithOnyx
+                            onRender={onRender}
+                            ref={ref}
+                        />,
+                    );
+                })
 
-            // component mounted with the initial value, while updates are queueing
-            .then(() => Onyx.merge(ONYX_KEYS.SIMPLE_KEY, 'string'))
-            .then(() => {
-                expect(onRender).toHaveBeenCalledTimes(1);
-                expect(onRender.mock.calls[0][0].simple).toBe('initialValue');
+                // component mounted with the initial value, while updates are queueing
+                .then(() => Onyx.merge(ONYX_KEYS.SIMPLE_KEY, 'string'))
+                .then(() => {
+                    expect(onRender).toHaveBeenCalledTimes(1);
+                    expect(onRender.mock.calls[0][0].simple).toBe('initialValue');
 
-                // just to test we change the value
-                return Onyx.merge(ONYX_KEYS.SIMPLE_KEY, 'long_string');
-            })
-            .then(() => {
-                // Component still has not updated
-                expect(onRender).toHaveBeenCalledTimes(1);
+                    // just to test we change the value
+                    return Onyx.merge(ONYX_KEYS.SIMPLE_KEY, 'long_string');
+                })
+                .then(() => {
+                    // Component still has not updated
+                    expect(onRender).toHaveBeenCalledTimes(1);
 
-                // We can now tell component to update
-                ref.current.markReadyForHydration();
-            })
-            .then(() => {
-                // Component still has not updated
-                expect(onRender).toHaveBeenCalledTimes(4);
-                expect(onRender.mock.calls[3][0].simple).toBe('long_string');
-            });
+                    // We can now tell component to update
+                    ref.current.markReadyForHydration();
+                })
+                .then(() => {
+                    // Component still has not updated
+                    expect(onRender).toHaveBeenCalledTimes(4);
+                    expect(onRender.mock.calls[3][0].simple).toBe('long_string');
+                })
+        );
     });
 
     it('should render immediately when a onyx component is mounted a 2nd time', () => {

--- a/tests/utils/waitForPromisesToResolve.js
+++ b/tests/utils/waitForPromisesToResolve.js
@@ -1,1 +1,1 @@
-export default () => new Promise(resolve => setTimeout(resolve, 0));
+export default () => new Promise((resolve) => setTimeout(resolve, 0));

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,12 +31,7 @@ const commonConfig = {
             },
         ],
     },
-    externals: [
-        'react-native',
-        /^lodash\/.+$/,
-        ..._.keys(pkg.peerDependencies),
-        ..._.keys(pkg.dependencies),
-    ],
+    externals: ['react-native', /^lodash\/.+$/, ..._.keys(pkg.peerDependencies), ..._.keys(pkg.dependencies)],
     output: {
         path: path.resolve(__dirname, 'dist'),
         library: {
@@ -68,7 +63,4 @@ const webDevConfig = merge(webConfig, {
     },
 });
 
-module.exports = [
-    webConfig,
-    webDevConfig,
-];
+module.exports = [webConfig, webDevConfig];


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details

This sets up prettier and update the eslint config to match expensify app.

### Related Issues

N/A

### Automated Tests

Run `npm run prettier` for format all files.

Check that there are no lint errors.

### Manual Tests

N/A

### Author Checklist

- [x] I linked the correct issue in the `### Related Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
