### PR TITLE
fix: remove postinstall script

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,5 +410,6 @@ To continuously work on Onyx we have to set up a task that copies content to par
 
 There are Playwright e2e tests implemented for the web. To run them:
 
+- in the tests/e2e/app directory, run `npm install`
 - `npm run e2e` to run the e2e tests
 - or `npm run e2e-ui` to run the e2e tests in UI mode 

--- a/package.json
+++ b/package.json
@@ -39,8 +39,7 @@
     "build": "webpack --config webpack.config.js",
     "build:docs": "node buildDocs.js",
     "e2e": "playwright test",
-    "e2e-ui": "playwright test --ui",
-    "postinstall": "cd tests/e2e/app && npm install"
+    "e2e-ui": "playwright test --ui"
   },
   "dependencies": {
     "ascii-table": "0.0.9",


### PR DESCRIPTION
### Details
<!-- Explanation of the change or anything fishy that is going on -->
While trying to bump the version in Expensify App I got an error:
<img width="748" alt="Screenshot 2023-12-04 at 11 00 58" src="https://github.com/Expensify/react-native-onyx/assets/28020445/af1d244b-e2d8-48b4-80df-2217aec85505">


### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK: https://github.com/Expensify/react-native-onyx/pull/382


