### PR TITLE
feat: add integration with Redux DevTools

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,44 @@ Sample output of `Onyx.printMetrics()`
 
 It can be useful to log why Onyx is calling `setState()` on a particular React component so that we can understand which key changed, what changed about the value, and the connected component that ultimately rendered as a result. When used correctly this can help isolate problem areas and unnecessary renders in the code. To enable this feature, pass `debugSetState: true` to the config and grep JS console logs for `[Onyx-Debug]`.
 
+# Redux DevTools Extension
+
+If you want to debug updates made to the local storage on the web app, you can use Redux DevTools Extension, which provides an easy to use GUI.
+This extension provides the following features:
+
+- Each update (merge/set/clear/etc) made to the local storage is logged with the data that was written or erased.
+- Check the state of the local storage at a certain point in time and compare it with it's  previous state.
+
+Currently this tool is only available on Web.
+
+### Installing the extension
+
+To use the extension, simply install it from your favorite web browser store:
+
+- [Google Chrome](https://chromewebstore.google.com/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?pli=1)
+- [Microsoft Edge](https://microsoftedge.microsoft.com/addons/detail/redux-devtools/nnkgneoiohoecpdiaponcejilbhhikei)
+- [Mozilla Firefox](https://addons.mozilla.org/en-US/firefox/addon/reduxdevtools/)
+
+After installing the extension, Onyx will automatically connect to it and start logging any updates made to the local storage.
+
+### Usage
+
+The extension interface is pretty simple, on the left sidebar you can see all the updates made to the local storage, in ascending order, and on the right pane you can see the whole the current state, payload of an action and the diff between the previous state and the current state after the action was triggered.
+
+The action logs use this naming convention:
+
+`@@INIT` - Initial action which is triggered when Onyx connects to the extension. It's payload consists of the initial state.
+
+`merge/<KEY>` - Merge action which is triggered when `Onyx.merge()` is called.
+
+`mergecollection/<KEY>` - Merge action which is triggered when `Onyx.mergeCollection()` is called.
+
+`set/<KEY>` - Set action which is triggered when `Onyx.set()` is called.
+
+`multiset/<KEY>` - Set action which is triggered when `Onyx.multiSet()` is called.
+
+`CLEAR` - Clear action which is triggered when `Onyx.clear()` is called.
+
 # Development
 
 `react-native` bundles source using the `metro` bundler. `metro` does not follow symlinks, so we can't use `npm link` to

--- a/lib/DevTools.js
+++ b/lib/DevTools.js
@@ -4,6 +4,8 @@ import _ from 'underscore';
 class DevTools {
     constructor() {
         this.remoteDev = this.connectViaExtension();
+        this.state = {};
+        this.defaultState = {};
     }
 
     connectViaExtension(options) {
@@ -21,18 +23,24 @@ class DevTools {
      * @param {object} stateChanges - partial state that got updated after the changes
      */
     registerAction(type, payload = undefined, stateChanges = {}) {
+        if (!this.remoteDev) {
+            return;
+        }
         const newState = {
             ...this.state,
             ...stateChanges,
         };
-
         this.remoteDev.send({type, payload}, newState);
         this.state = newState;
     }
 
     initState(initialState = {}) {
+        if (!this.remoteDev) {
+            return;
+        }
         this.remoteDev.init(initialState);
         this.state = initialState;
+        this.defaultState = initialState;
     }
 
     /**
@@ -41,7 +49,8 @@ class DevTools {
      * @param {string[]} keysToPreserve
      */
     clearState(keysToPreserve = []) {
-        this.registerAction('CLEAR', undefined, _.pick(this.state, keysToPreserve));
+        const newState = _.mapObject(this.state, (value, key) => (keysToPreserve.includes(key) ? value : this.defaultState[key]));
+        this.registerAction('CLEAR', undefined, newState);
     }
 }
 

--- a/lib/DevTools.js
+++ b/lib/DevTools.js
@@ -1,0 +1,48 @@
+import _ from 'underscore';
+
+/* eslint-disable no-underscore-dangle */
+class DevTools {
+    constructor() {
+        this.remoteDev = this.connectViaExtension();
+    }
+
+    connectViaExtension(options) {
+        if ((options && options.remote) || typeof window === 'undefined' || !window.__REDUX_DEVTOOLS_EXTENSION__) {
+            return;
+        }
+        return window.__REDUX_DEVTOOLS_EXTENSION__.connect(options);
+    }
+
+    /**
+     * Registers an action that updated the current state of the storage
+     *
+     * @param {string} type - name of the action
+     * @param {any} payload - data written to the storage
+     * @param {object} stateChanges - partial state that got updated after the changes
+     */
+    registerAction(type, payload = undefined, stateChanges = {}) {
+        const newState = {
+            ...this.state,
+            ...stateChanges,
+        };
+
+        this.remoteDev.send({type, payload}, newState);
+        this.state = newState;
+    }
+
+    initState(initialState = {}) {
+        this.remoteDev.init(initialState);
+        this.state = initialState;
+    }
+
+    /**
+     * This clears the internal state of the DevTools, preserving the keys included in `keysToPreserve`
+     *
+     * @param {string[]} keysToPreserve
+     */
+    clearState(keysToPreserve = []) {
+        this.registerAction('CLEAR', undefined, _.pick(this.state, keysToPreserve));
+    }
+}
+
+export default new DevTools();

--- a/lib/DevTools.js
+++ b/lib/DevTools.js
@@ -1,5 +1,7 @@
 import _ from 'underscore';
 
+const ERROR_LABEL = 'Onyx DevTools - Error: ';
+
 /* eslint-disable no-underscore-dangle */
 class DevTools {
     constructor() {
@@ -9,10 +11,14 @@ class DevTools {
     }
 
     connectViaExtension(options) {
-        if ((options && options.remote) || typeof window === 'undefined' || !window.__REDUX_DEVTOOLS_EXTENSION__) {
-            return;
+        try {
+            if ((options && options.remote) || typeof window === 'undefined' || !window.__REDUX_DEVTOOLS_EXTENSION__) {
+                return;
+            }
+            return window.__REDUX_DEVTOOLS_EXTENSION__.connect(options);
+        } catch (e) {
+            console.error(ERROR_LABEL, e);
         }
-        return window.__REDUX_DEVTOOLS_EXTENSION__.connect(options);
     }
 
     /**
@@ -23,24 +29,32 @@ class DevTools {
      * @param {object} stateChanges - partial state that got updated after the changes
      */
     registerAction(type, payload = undefined, stateChanges = {}) {
-        if (!this.remoteDev) {
-            return;
+        try {
+            if (!this.remoteDev) {
+                return;
+            }
+            const newState = {
+                ...this.state,
+                ...stateChanges,
+            };
+            this.remoteDev.send({type, payload}, newState);
+            this.state = newState;
+        } catch (e) {
+            console.error(ERROR_LABEL, e);
         }
-        const newState = {
-            ...this.state,
-            ...stateChanges,
-        };
-        this.remoteDev.send({type, payload}, newState);
-        this.state = newState;
     }
 
     initState(initialState = {}) {
-        if (!this.remoteDev) {
-            return;
+        try {
+            if (!this.remoteDev) {
+                return;
+            }
+            this.remoteDev.init(initialState);
+            this.state = initialState;
+            this.defaultState = initialState;
+        } catch (e) {
+            console.error(ERROR_LABEL, e);
         }
-        this.remoteDev.init(initialState);
-        this.state = initialState;
-        this.defaultState = initialState;
     }
 
     /**

--- a/lib/Onyx.d.ts
+++ b/lib/Onyx.d.ts
@@ -107,6 +107,7 @@ declare const METHOD: {
     readonly SET: 'set';
     readonly MERGE: 'merge';
     readonly MERGE_COLLECTION: 'mergecollection';
+    readonly MULTI_SET: 'multiset';
     readonly CLEAR: 'clear';
 };
 
@@ -315,9 +316,9 @@ declare const Onyx: {
     METHOD: typeof METHOD;
     setMemoryOnlyKeys: typeof setMemoryOnlyKeys;
     onClear: typeof onClear;
-    isClientManagerReady: typeof ActiveClientManager.isReady,
-    isClientTheLeader: typeof ActiveClientManager.isClientTheLeader,
-    subscribeToClientChange: typeof ActiveClientManager.subscribeToClientChange,
+    isClientManagerReady: typeof ActiveClientManager.isReady;
+    isClientTheLeader: typeof ActiveClientManager.isClientTheLeader;
+    subscribeToClientChange: typeof ActiveClientManager.subscribeToClientChange;
 };
 
 export default Onyx;

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -64,6 +64,18 @@ let batchUpdatesPromise = null;
 let batchUpdatesQueue = [];
 
 /**
+ * Sends an action to DevTools extension
+ *
+ * @param {string} method - Onyx method from METHOD
+ * @param {string} key - Onyx key that was changed
+ * @param {any} value - contains the change that was made by the method
+ * @param {any} mergedValue - (optional) value that was written in the storage after a merge method was executed.
+ */
+function sendActionToDevTools(method, key, value, mergedValue = undefined) {
+    DevTools.registerAction(utils.formatActionName(method, key), value, key ? {[key]: mergedValue || value} : value);
+}
+
+/**
  * We are batching together onyx updates. This helps with use cases where we schedule onyx updates after each other.
  * This happens for example in the Onyx.update function, where we process API responses that might contain a lot of
  * update operations. Instead of calling the subscribers for each update operation, we batch them together which will
@@ -1029,7 +1041,6 @@ function evictStorageAndRetry(error, onyxMethod, ...args) {
 function broadcastUpdate(key, value, hasChanged, method) {
     // Logging properties only since values could be sensitive things we don't want to log
     Logger.logInfo(`${method}() called for key: ${key}${_.isObject(value) ? ` properties: ${_.keys(value).join(',')}` : ''}`);
-    DevTools.registerAction(`${method.toUpperCase()}/${key}`, value, {[key]: value});
 
     // Update subscribers if the cached value has changed, or when the subscriber specifically requires
     // all updates regardless of value changes (indicated by initWithStoredValues set to false).
@@ -1090,6 +1101,7 @@ function set(key, value) {
     const valueWithoutNull = removeNullValues(key, value);
 
     if (valueWithoutNull === null) {
+        sendActionToDevTools(METHOD.SET, key, undefined);
         return Promise.resolve();
     }
 
@@ -1109,7 +1121,10 @@ function set(key, value) {
 
     return Storage.setItem(key, valueWithoutNull)
         .catch((error) => evictStorageAndRetry(error, set, key, valueWithoutNull))
-        .then(() => updatePromise);
+        .then(() => {
+            sendActionToDevTools(METHOD.SET, key, valueWithoutNull);
+            return updatePromise;
+        });
 }
 
 /**
@@ -1164,7 +1179,10 @@ function multiSet(data) {
 
     return Storage.multiSet(keyValuePairsWithoutNull)
         .catch((error) => evictStorageAndRetry(error, multiSet, data))
-        .then(() => Promise.all(updatePromises));
+        .then(() => {
+            sendActionToDevTools(METHOD.MULTI_SET, undefined, data);
+            return Promise.all(updatePromises);
+        });
 }
 
 /**
@@ -1280,7 +1298,10 @@ function merge(key, changes) {
                 return updatePromise;
             }
 
-            return Storage.mergeItem(key, batchedChanges, modifiedData).then(() => updatePromise);
+            return Storage.mergeItem(key, batchedChanges, modifiedData).then(() => {
+                sendActionToDevTools(METHOD.MERGE, key, changes, modifiedData);
+                return updatePromise;
+            });
         } catch (error) {
             Logger.logAlert(`An error occurred while applying merge for key: ${key}, Error: ${error}`);
             return Promise.resolve();
@@ -1328,8 +1349,6 @@ function initializeWithDefaultKeyStates() {
  * @returns {Promise<void>}
  */
 function clear(keysToPreserve = []) {
-    DevTools.clearState(keysToPreserve);
-
     if (!ActiveClientManager.isClientTheLeader()) {
         Broadcast.sendMessage({type: METHOD.CLEAR, keysToPreserve});
         return Promise.resolve();
@@ -1403,6 +1422,7 @@ function clear(keysToPreserve = []) {
             .then(() => {
                 isClearing = false;
                 Broadcast.sendMessage({type: METHOD.CLEAR, keysToPreserve});
+                DevTools.clearState(keysToPreserve);
                 return Promise.all(updatePromises);
             });
     });
@@ -1488,7 +1508,10 @@ function mergeCollection(collectionKey, collection) {
 
         return Promise.all(promises)
             .catch((error) => evictStorageAndRetry(error, mergeCollection, collection))
-            .then(() => promiseUpdate);
+            .then(() => {
+                sendActionToDevTools(METHOD.MERGE_COLLECTION, undefined, collection);
+                return promiseUpdate;
+            });
     });
 }
 

--- a/lib/Onyx.js
+++ b/lib/Onyx.js
@@ -11,6 +11,7 @@ import * as Broadcast from './broadcast';
 import * as ActiveClientManager from './ActiveClientManager';
 import utils from './utils';
 import unstable_batchedUpdates from './batch';
+import DevTools from './DevTools';
 
 // Method constants
 const METHOD = {
@@ -1028,6 +1029,7 @@ function evictStorageAndRetry(error, onyxMethod, ...args) {
 function broadcastUpdate(key, value, hasChanged, method) {
     // Logging properties only since values could be sensitive things we don't want to log
     Logger.logInfo(`${method}() called for key: ${key}${_.isObject(value) ? ` properties: ${_.keys(value).join(',')}` : ''}`);
+    DevTools.registerAction(`${method.toUpperCase()}/${key}`, value, {[key]: value});
 
     // Update subscribers if the cached value has changed, or when the subscriber specifically requires
     // all updates regardless of value changes (indicated by initWithStoredValues set to false).
@@ -1326,6 +1328,8 @@ function initializeWithDefaultKeyStates() {
  * @returns {Promise<void>}
  */
 function clear(keysToPreserve = []) {
+    DevTools.clearState(keysToPreserve);
+
     if (!ActiveClientManager.isClientTheLeader()) {
         Broadcast.sendMessage({type: METHOD.CLEAR, keysToPreserve});
         return Promise.resolve();
@@ -1662,6 +1666,8 @@ function init({
 
     // Set our default key states to use when initializing and clearing Onyx data
     defaultKeyStates = initialKeyStates;
+
+    DevTools.initState(initialKeyStates);
 
     // Let Onyx know about which keys are safe to evict
     evictionAllowList = safeEvictionKeys;

--- a/lib/utils.d.ts
+++ b/lib/utils.d.ts
@@ -1,3 +1,5 @@
+import { OnyxKey } from './types';
+
 /**
  * Merges two objects and removes null values if "shouldRemoveNullObjectValues" is set to true
  *
@@ -7,4 +9,9 @@
  */
 declare function fastMerge<T>(target: T, source: T, shouldRemoveNullObjectValues: boolean = true): T;
 
-export default {fastMerge};
+/**
+ * Returns a formatted action name to be send to DevTools, given the method and optionally the key that was changed
+ */
+declare function formatActionName(method: string, key?: OnyxKey): string;
+
+export default { fastMerge, formatActionName };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -105,4 +105,8 @@ function removeNestedNullValues(value) {
     return value;
 }
 
-export default {areObjectsEmpty, fastMerge, removeNestedNullValues};
+function formatActionName(method, key) {
+    return key ? `${method.toUpperCase()}/${key}` : method.toUpperCase();
+}
+
+export default {areObjectsEmpty, fastMerge, formatActionName, removeNestedNullValues};

--- a/tests/unit/DevToolsTest.js
+++ b/tests/unit/DevToolsTest.js
@@ -1,0 +1,126 @@
+/* eslint-disable @lwc/lwc/no-async-await */
+/* eslint-disable no-underscore-dangle */
+import Onyx from '../../lib';
+import DevTools from '../../lib/DevTools';
+import utils from '../../lib/utils';
+
+const ONYX_KEYS = {
+    NUM_KEY: 'numKey',
+    OBJECT_KEY: 'objectKey',
+    SOME_KEY: 'someKey',
+    COLLECTION: {
+        NUM_KEY: 'test_',
+        TEST_CONNECT_COLLECTION: 'testConnectCollection_',
+        TEST_POLICY: 'testPolicy_',
+        TEST_UPDATE: 'testUpdate_',
+    },
+};
+
+const initialKeyStates = {
+    [ONYX_KEYS.NUM_KEY]: 1,
+    [ONYX_KEYS.OBJECT_KEY]: {id: 42},
+};
+
+const exampleCollection = {
+    [`${ONYX_KEYS.COLLECTION.NUM_KEY}1`]: 1,
+    [`${ONYX_KEYS.COLLECTION.NUM_KEY}2`]: 2,
+};
+
+const exampleObject = {name: 'Pedro'};
+
+const mergedCollection = {...initialKeyStates, ...exampleCollection};
+
+const mergedObject = {...initialKeyStates, [ONYX_KEYS.OBJECT_KEY]: {...exampleObject, id: 42}};
+
+describe('DevTools', () => {
+    let initMock;
+    let sendMock;
+
+    beforeEach(() => {
+        // Mock DevTools
+        initMock = jest.fn();
+        sendMock = jest.fn();
+        DevTools.remoteDev = {init: initMock, send: sendMock};
+        Onyx.init({
+            keys: ONYX_KEYS,
+            registerStorageEventListener: () => {},
+            initialKeyStates,
+        });
+    });
+    afterEach(() => {
+        Onyx.clear();
+    });
+
+    describe('Init', () => {
+        it('Sends the initial state correctly to the extension', () => {
+            expect(initMock).toHaveBeenCalledWith(initialKeyStates);
+        });
+        it('Sets the default state correctly', () => {
+            expect(DevTools.defaultState).toEqual(initialKeyStates);
+        });
+        it('Sets the internal state correctly', () => {
+            expect(DevTools.state).toEqual(initialKeyStates);
+        });
+    });
+
+    describe('Set', () => {
+        it('Sends the set state correctly to the extension', async () => {
+            await Onyx.set(ONYX_KEYS.SOME_KEY, 3);
+            expect(sendMock).toHaveBeenCalledWith({payload: 3, type: utils.formatActionName(Onyx.METHOD.SET, ONYX_KEYS.SOME_KEY)}, {...initialKeyStates, [ONYX_KEYS.SOME_KEY]: 3});
+        });
+        it('Sets the internal state correctly', async () => {
+            await Onyx.set(ONYX_KEYS.SOME_KEY, 3);
+            expect(DevTools.state).toEqual({...initialKeyStates, [ONYX_KEYS.SOME_KEY]: 3});
+        });
+    });
+
+    describe('Merge', () => {
+        it('Sends the merged state correctly to the extension', async () => {
+            await Onyx.merge(ONYX_KEYS.OBJECT_KEY, exampleObject);
+            expect(sendMock).toHaveBeenCalledWith({payload: exampleObject, type: utils.formatActionName(Onyx.METHOD.MERGE, ONYX_KEYS.OBJECT_KEY)}, mergedObject);
+        });
+        it('Sets the internal state correctly', async () => {
+            await Onyx.merge(ONYX_KEYS.OBJECT_KEY, exampleObject);
+            expect(DevTools.state).toEqual(mergedObject);
+        });
+    });
+
+    describe('MergeCollection', () => {
+        it('Sends the mergecollection state correctly to the extension', async () => {
+            await Onyx.mergeCollection(ONYX_KEYS.COLLECTION.NUM_KEY, exampleCollection);
+            expect(sendMock).toHaveBeenCalledWith({payload: exampleCollection, type: utils.formatActionName(Onyx.METHOD.MERGE_COLLECTION)}, mergedCollection);
+        });
+        it('Sets the internal state correctly', async () => {
+            await Onyx.mergeCollection(ONYX_KEYS.COLLECTION.NUM_KEY, exampleCollection);
+            expect(DevTools.state).toEqual(mergedCollection);
+        });
+    });
+
+    describe('MultiSet', () => {
+        it('Sends the multiset state correctly to the extension', async () => {
+            await Onyx.multiSet(exampleCollection);
+            expect(sendMock).toHaveBeenCalledWith({payload: exampleCollection, type: utils.formatActionName(Onyx.METHOD.MULTI_SET)}, mergedCollection);
+        });
+        it('Sets the internal state correctly', async () => {
+            await Onyx.multiSet(exampleCollection);
+            expect(DevTools.state).toEqual(mergedCollection);
+        });
+    });
+
+    describe('Clear', () => {
+        it('Sends the clear state correctly to the extension when no keys should be preserved', async () => {
+            await Onyx.clear();
+            expect(sendMock).toHaveBeenCalledWith({payload: undefined, type: 'CLEAR'}, initialKeyStates);
+        });
+        it('Sends the clear state correctly to the extension when there are keys that should be preserved', async () => {
+            await Onyx.merge(ONYX_KEYS.NUM_KEY, 2);
+            await Onyx.clear([ONYX_KEYS.NUM_KEY]);
+            expect(sendMock).toHaveBeenCalledWith({payload: undefined, type: 'CLEAR'}, {...initialKeyStates, [ONYX_KEYS.NUM_KEY]: 2});
+        });
+        it('Clears internal state correctly', async () => {
+            await Onyx.merge(ONYX_KEYS.NUM_KEY, 2);
+            await Onyx.clear([ONYX_KEYS.NUM_KEY]);
+            expect(DevTools.state).toEqual({...initialKeyStates, [ONYX_KEYS.NUM_KEY]: 2});
+        });
+    });
+});


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
This PR adds the ability to use React Native Onyx with Redux DevTools extension to debug writes made to the web storage.

At this time, it's not possible to jump between states from the Redux DevTools extension.

This functionality is only available in web apps.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
N/A

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
I added integration tests that check if all Onyx methods are registering their actions correctly on the Redux DevTools extension.

### Manual Tests
<!---
Each set of changes should be tested against the Expensify/App repo on all platforms to verify it does not break our staging App.
--->
N/A

### Author Checklist

- [x] I linked the correct issue in the `### Related Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
