### PR TITLE
Revert "Re: Use initialValue when cached value is undefined"

### DIFF
--- a/lib/withOnyx.js
+++ b/lib/withOnyx.js
@@ -59,7 +59,7 @@ export default function (mapOnyxToState, shouldDelayUpdates = false) {
                     (resultObj, mapping, propertyName) => {
                         const key = Str.result(mapping.key, props);
                         let value = Onyx.tryGetCachedValue(key, mapping);
-                        if (value === undefined) {
+                        if (!value && mapping.initialValue) {
                             value = mapping.initialValue;
                         }
 

--- a/tests/unit/withOnyxTest.js
+++ b/tests/unit/withOnyxTest.js
@@ -561,10 +561,6 @@ describe('withOnyxTest', () => {
                         key: ONYX_KEYS.SIMPLE_KEY,
                         initialValue: 'initialValue',
                     },
-                    simple2: {
-                        key: ONYX_KEYS.SIMPLE_KEY_2,
-                        initialValue: false,
-                    },
                 })(ViewWithCollections);
                 render(
                     <TestComponentWithOnyx
@@ -582,7 +578,6 @@ describe('withOnyxTest', () => {
                     onRender,
                     testObject: {isDefaultProp: true},
                     simple: 'initialValue',
-                    simple2: false,
                 });
             });
     });


### PR DESCRIPTION
Reverts Expensify/react-native-onyx#480

This caused a regression as reported in https://github.com/Expensify/App/issues/37743 