### PR TITLE
Fix `applyMerge` after Typescript migration

### DIFF
--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -1014,7 +1014,7 @@ function applyMerge(existingValue: OnyxValue<OnyxKey>, changes: Array<OnyxValue<
         return lastChange;
     }
 
-    if (changes.some((change) => typeof change === 'object')) {
+    if (changes.some((change) => change && typeof change === 'object')) {
         // Object values are then merged one after the other
         return changes.reduce(
             (modifiedData, change) => utils.fastMerge(modifiedData as Record<OnyxKey, unknown>, change as Record<OnyxKey, unknown>, shouldRemoveNullObjectValues),


### PR DESCRIPTION
@paultsimura reported the issue [here](https://github.com/Expensify/react-native-onyx/pull/490#issuecomment-2060665886), following up with a quick fix.

Underscore's `_.isObject` checks if the value is null, we have to mimic this in `applyMerge` function.