### PR TITLE
Remove null values from cache to improve Onyx read speed

### DIFF
--- a/lib/Onyx.ts
+++ b/lib/Onyx.ts
@@ -556,6 +556,8 @@ function mergeCollection<TKey extends CollectionKeyBase, TMap>(collectionKey: TK
 function clear(keysToPreserve: OnyxKey[] = []): Promise<void> {
     return OnyxUtils.getAllKeys()
         .then((keys) => {
+            cache.clearNullishStorageKeys();
+
             const keysToBeClearedFromStorage: OnyxKey[] = [];
             const keyValuesToResetAsCollection: Record<OnyxKey, OnyxCollection<KeyValueMapping[OnyxKey]>> = {};
             const keyValuesToResetIndividually: NullableKeyValueMapping = {};

--- a/lib/Onyx.ts
+++ b/lib/Onyx.ts
@@ -111,7 +111,7 @@ function connect<TKey extends OnyxKey>(connectOptions: ConnectOptions<TKey>): nu
             // Performance improvement
             // If the mapping is connected to an onyx key that is not a collection
             // we can skip the call to getAllKeys() and return an array with a single item
-            if (Boolean(mapping.key) && typeof mapping.key === 'string' && !mapping.key.endsWith('_') && cache.storageKeys.has(mapping.key)) {
+            if (Boolean(mapping.key) && typeof mapping.key === 'string' && !mapping.key.endsWith('_') && cache.getAllKeys().has(mapping.key)) {
                 return new Set([mapping.key]);
             }
             return OnyxUtils.getAllKeys();

--- a/lib/Onyx.ts
+++ b/lib/Onyx.ts
@@ -45,7 +45,7 @@ function init({
 
     if (shouldSyncMultipleInstances) {
         Storage.keepInstancesSync?.((key, value) => {
-            const prevValue = cache.getValue(key, false) as OnyxValue<typeof key>;
+            const prevValue = cache.get(key, false) as OnyxValue<typeof key>;
             cache.set(key, value);
             OnyxUtils.keyChanged(key, value as OnyxValue<typeof key>, prevValue);
         });
@@ -214,7 +214,7 @@ function set<TKey extends OnyxKey>(key: TKey, value: NonUndefined<OnyxEntry<KeyV
         delete OnyxUtils.getMergeQueue()[key];
     }
 
-    const existingValue = cache.getValue(key, false);
+    const existingValue = cache.get(key, false);
 
     // If the existing value as well as the new value are null, we can return early.
     if (value === null && existingValue === null) {
@@ -285,7 +285,7 @@ function multiSet(data: Partial<NullableKeyValueMapping>): Promise<void> {
     });
 
     const updatePromises = keyValuePairsToUpdate.map(([key, value]) => {
-        const prevValue = cache.getValue(key, false);
+        const prevValue = cache.get(key, false);
 
         // Update cache and optimistically inform subscribers on the next tick
         cache.set(key, value);
@@ -575,7 +575,7 @@ function clear(keysToPreserve: OnyxKey[] = []): Promise<void> {
                 // 2. Figure out whether it is a collection key or not,
                 //      since collection key subscribers need to be updated differently
                 if (!isKeyToPreserve) {
-                    const oldValue = cache.getValue(key);
+                    const oldValue = cache.get(key);
                     const newValue = defaultKeyStates[key] ?? null;
                     if (newValue !== oldValue) {
                         cache.set(key, newValue);
@@ -603,7 +603,7 @@ function clear(keysToPreserve: OnyxKey[] = []): Promise<void> {
 
             // Notify the subscribers for each key/value group so they can receive the new values
             Object.entries(keyValuesToResetIndividually).forEach(([key, value]) => {
-                updatePromises.push(OnyxUtils.scheduleSubscriberUpdate(key, value, cache.getValue(key, false)));
+                updatePromises.push(OnyxUtils.scheduleSubscriberUpdate(key, value, cache.get(key, false)));
             });
             Object.entries(keyValuesToResetAsCollection).forEach(([key, value]) => {
                 updatePromises.push(OnyxUtils.scheduleNotifyCollectionSubscribers(key, value));

--- a/lib/Onyx.ts
+++ b/lib/Onyx.ts
@@ -328,7 +328,7 @@ function merge<TKey extends OnyxKey>(key: TKey, changes: NonUndefined<OnyxEntry<
     mergeQueuePromise[key] = OnyxUtils.get(key).then((existingValue) => {
         // Calls to Onyx.set after a merge will terminate the current merge process and clear the merge queue
         if (mergeQueue[key] == null) {
-            return undefined;
+            return Promise.resolve();
         }
 
         try {
@@ -343,7 +343,7 @@ function merge<TKey extends OnyxKey>(key: TKey, changes: NonUndefined<OnyxEntry<
             });
 
             if (!validChanges.length) {
-                return undefined;
+                return Promise.resolve();
             }
             const batchedDeltaChanges = OnyxUtils.applyMerge(undefined, validChanges, false);
 

--- a/lib/Onyx.ts
+++ b/lib/Onyx.ts
@@ -128,10 +128,10 @@ function connect<TKey extends OnyxKey>(connectOptions: ConnectOptions<TKey>): nu
             // component. This null value will be filtered out so that the connected component can utilize defaultProps.
             if (matchingKeys.length === 0) {
                 if (mapping.key && !OnyxUtils.isCollectionKey(mapping.key)) {
-                    cache.addKey(mapping.key);
+                    cache.addNullishStorageKey(mapping.key);
                 }
 
-                // Here we cannot use batching because the null value is expected to be set immediately for default props
+                // Here we cannot use batching because the nullish value is expected to be set immediately for default props
                 // or they will be undefined.
                 OnyxUtils.sendDataToConnection(mapping, undefined as OnyxValue<TKey>, undefined, false);
                 return;

--- a/lib/Onyx.ts
+++ b/lib/Onyx.ts
@@ -133,7 +133,7 @@ function connect<TKey extends OnyxKey>(connectOptions: ConnectOptions<TKey>): nu
 
                 // Here we cannot use batching because the nullish value is expected to be set immediately for default props
                 // or they will be undefined.
-                OnyxUtils.sendDataToConnection(mapping, undefined as OnyxValue<TKey>, undefined, false);
+                OnyxUtils.sendDataToConnection(mapping, null, undefined, false);
                 return;
             }
 

--- a/lib/OnyxCache.ts
+++ b/lib/OnyxCache.ts
@@ -115,9 +115,14 @@ class OnyxCache {
         this.storageMap = {...utils.fastMerge(this.storageMap, data)};
 
         const storageKeys = this.getAllKeys();
-        const mergedKeys = Object.keys(data);
-        this.storageKeys = new Set([...storageKeys, ...mergedKeys]);
-        mergedKeys.forEach((key) => this.addToAccessedKeys(key));
+        const updatedKeys: string[] = [];
+        Object.entries(data).forEach(([key, value]) => {
+            this.addToAccessedKeys(key);
+
+            if (value === null) this.storageKeys.delete(key);
+            else updatedKeys.push(key);
+        });
+        this.storageKeys = new Set([...storageKeys, ...updatedKeys]);
     }
 
     /**

--- a/lib/OnyxCache.ts
+++ b/lib/OnyxCache.ts
@@ -69,7 +69,7 @@ class OnyxCache {
 
     /** Check whether cache has data for the given key */
     hasCacheForKey(key: OnyxKey): boolean {
-        return this.storageMap[key] !== undefined;
+        return this.storageKeys.has(key);
     }
 
     /** Saves a key in the storage keys list

--- a/lib/OnyxCache.ts
+++ b/lib/OnyxCache.ts
@@ -115,7 +115,7 @@ class OnyxCache {
         this.nullishStorageKeys.delete(key);
 
         if (value === null || value === undefined) {
-            this.drop(key);
+            delete this.storageMap[key];
             return undefined;
         }
 
@@ -142,12 +142,15 @@ class OnyxCache {
 
         this.storageMap = {...utils.fastMerge(this.storageMap, data)};
 
-        const storageKeys = this.getAllKeys();
-        const mergedKeys = Object.keys(data);
-        this.storageKeys = new Set([...storageKeys, ...mergedKeys]);
-        mergedKeys.forEach((key) => {
+        Object.entries(data).forEach(([key, value]) => {
+            this.addKey(key);
             this.addToAccessedKeys(key);
-            this.nullishStorageKeys.delete(key);
+
+            if (value === null || value === undefined) {
+                this.nullishStorageKeys.add(key);
+            } else {
+                this.nullishStorageKeys.delete(key);
+            }
         });
     }
 

--- a/lib/OnyxCache.ts
+++ b/lib/OnyxCache.ts
@@ -117,29 +117,12 @@ class OnyxCache {
         this.storageMap = {...utils.fastMerge(this.storageMap, data)};
 
         const storageKeys = this.getAllKeys();
-        const updatedKeys: string[] = [];
-        Object.entries(data).forEach(([key, value]) => {
+        const mergedKeys = Object.keys(data);
+        this.storageKeys = new Set([...storageKeys, ...mergedKeys]);
+        mergedKeys.forEach((key) => {
             this.addToAccessedKeys(key);
-
-            if (value === null) this.storageKeys.delete(key);
-            else updatedKeys.push(key);
+            this.nullishStorageKeys.delete(key);
         });
-        this.storageKeys = new Set([...storageKeys, ...updatedKeys]);
-    }
-
-    /**
-     * Allows to set all the keys at once.
-     * This is useful when we are getting
-     * all the keys from the storage provider
-     * and we want to keep the cache in sync.
-     *
-     * Previously, we had to call `addKey` in a loop
-     * to achieve the same result.
-     *
-     * @param keys - an array of keys
-     */
-    setAllKeys(keys: OnyxKey[]) {
-        this.storageKeys = new Set(keys);
     }
 
     /**

--- a/lib/OnyxCache.ts
+++ b/lib/OnyxCache.ts
@@ -2,7 +2,6 @@ import {deepEqual} from 'fast-equals';
 import bindAll from 'lodash/bindAll';
 import utils from './utils';
 import type {OnyxKey, OnyxValue} from './types';
-
 /**
  * In memory cache providing data by reference
  * Encapsulates Onyx cache related functionality

--- a/lib/OnyxCache.ts
+++ b/lib/OnyxCache.ts
@@ -84,7 +84,6 @@ class OnyxCache {
      * Adds the key to the storage keys list as well
      */
     set(key: OnyxKey, value: OnyxValue<OnyxKey>): OnyxValue<OnyxKey> {
-        this.addKey(key);
         this.addToAccessedKeys(key);
 
         if (value === null) {
@@ -92,7 +91,8 @@ class OnyxCache {
             return undefined;
         }
 
-        this.storageMap[key] = utils.removeNestedNullValues(value);
+        this.addKey(key);
+        this.storageMap[key] = value;
         return value;
     }
 

--- a/lib/OnyxCache.ts
+++ b/lib/OnyxCache.ts
@@ -88,7 +88,7 @@ class OnyxCache {
         this.addToAccessedKeys(key);
 
         if (value === null) {
-            delete this.storageMap[key];
+            this.drop(key);
             return undefined;
         }
 

--- a/lib/OnyxCache.ts
+++ b/lib/OnyxCache.ts
@@ -84,8 +84,7 @@ class OnyxCache {
         this.storageKeys.add(key);
     }
 
-    /** Used to set keys that are null/undefined in storage without addding null to the storage map
-     */
+    /** Used to set keys that are null/undefined in storage without adding null to the storage map */
     addNullishStorageKey(key: OnyxKey): void {
         this.nullishStorageKeys.add(key);
     }

--- a/lib/OnyxCache.ts
+++ b/lib/OnyxCache.ts
@@ -84,15 +84,17 @@ class OnyxCache {
      * Adds the key to the storage keys list as well
      */
     set(key: OnyxKey, value: OnyxValue<OnyxKey>): OnyxValue<OnyxKey> {
+        this.addKey(key);
         this.addToAccessedKeys(key);
+        this.nullishStorageKeys.delete(key);
 
-        if (value === null) {
+        if (value === null || value === undefined) {
             this.drop(key);
             return undefined;
         }
 
-        this.addKey(key);
         this.storageMap[key] = value;
+
         return value;
     }
 

--- a/lib/OnyxCache.ts
+++ b/lib/OnyxCache.ts
@@ -2,6 +2,7 @@ import {deepEqual} from 'fast-equals';
 import bindAll from 'lodash/bindAll';
 import utils from './utils';
 import type {OnyxKey, OnyxValue} from './types';
+
 /**
  * In memory cache providing data by reference
  * Encapsulates Onyx cache related functionality

--- a/lib/OnyxCache.ts
+++ b/lib/OnyxCache.ts
@@ -97,7 +97,7 @@ class OnyxCache {
      * Get a cached value from storage
      * @param [shouldReindexCache] – This is an LRU cache, and by default accessing a value will make it become last in line to be evicted. This flag can be used to skip that and just access the value directly without side-effects.
      */
-    getValue(key: OnyxKey, shouldReindexCache = true): OnyxValue<OnyxKey> {
+    get(key: OnyxKey, shouldReindexCache = true): OnyxValue<OnyxKey> {
         if (shouldReindexCache) {
             this.addToAccessedKeys(key);
         }

--- a/lib/OnyxCache.ts
+++ b/lib/OnyxCache.ts
@@ -43,6 +43,7 @@ class OnyxCache {
             'get',
             'hasCacheForKey',
             'addKey',
+            'addNullishStorageKey',
             'set',
             'drop',
             'merge',
@@ -82,7 +83,7 @@ class OnyxCache {
         this.storageKeys.add(key);
     }
 
-    /** Used to set keys that have been fetched before and were null
+    /** Used to set keys that are null/undefined in storage without addding null to the storage map
      */
     addNullishStorageKey(key: OnyxKey): void {
         this.nullishStorageKeys.add(key);

--- a/lib/OnyxCache.ts
+++ b/lib/OnyxCache.ts
@@ -90,8 +90,7 @@ class OnyxCache {
         this.nullishStorageKeys.add(key);
     }
 
-    /** Used to clear keys that are null/undefined in cache
-     */
+    /** Used to clear keys that are null/undefined in cache */
     clearNullishStorageKeys(): void {
         this.nullishStorageKeys = new Set();
     }

--- a/lib/OnyxCache.ts
+++ b/lib/OnyxCache.ts
@@ -44,6 +44,7 @@ class OnyxCache {
             'hasCacheForKey',
             'addKey',
             'addNullishStorageKey',
+            'clearNullishStorageKeys',
             'set',
             'drop',
             'merge',
@@ -87,6 +88,12 @@ class OnyxCache {
      */
     addNullishStorageKey(key: OnyxKey): void {
         this.nullishStorageKeys.add(key);
+    }
+
+    /** Used to clear keys that are null/undefined in cache
+     */
+    clearNullishStorageKeys(): void {
+        this.nullishStorageKeys = new Set();
     }
 
     /** Check whether cache has data for the given key */

--- a/lib/OnyxCache.ts
+++ b/lib/OnyxCache.ts
@@ -40,7 +40,7 @@ class OnyxCache {
         bindAll(
             this,
             'getAllKeys',
-            'getValue',
+            'get',
             'hasCacheForKey',
             'addKey',
             'set',

--- a/lib/OnyxCache.ts
+++ b/lib/OnyxCache.ts
@@ -86,8 +86,13 @@ class OnyxCache {
     set(key: OnyxKey, value: OnyxValue<OnyxKey>): OnyxValue<OnyxKey> {
         this.addKey(key);
         this.addToAccessedKeys(key);
-        this.storageMap[key] = value;
 
+        if (value === null) {
+            delete this.storageMap[key];
+            return undefined;
+        }
+
+        this.storageMap[key] = utils.removeNestedNullValues(value);
         return value;
     }
 
@@ -107,7 +112,7 @@ class OnyxCache {
             throw new Error('data passed to cache.merge() must be an Object of onyx key/value pairs');
         }
 
-        this.storageMap = {...utils.fastMerge(this.storageMap, data, false)};
+        this.storageMap = {...utils.fastMerge(this.storageMap, data)};
 
         const storageKeys = this.getAllKeys();
         const mergedKeys = Object.keys(data);

--- a/lib/OnyxCache.ts
+++ b/lib/OnyxCache.ts
@@ -11,7 +11,7 @@ class OnyxCache {
     /** Cache of all the storage keys available in persistent storage */
     private storageKeys: Set<OnyxKey>;
 
-    /** Cache of all the storage keys that have been fetched before and were not set */
+    /** A list of keys where a nullish value has been fetched from storage before, but the key still exists in cache */
     private nullishStorageKeys: Set<OnyxKey>;
 
     /** Unique list of keys maintained in access order (most recent at the end) */
@@ -117,6 +117,9 @@ class OnyxCache {
     set(key: OnyxKey, value: OnyxValue<OnyxKey>): OnyxValue<OnyxKey> {
         this.addKey(key);
         this.addToAccessedKeys(key);
+
+        // When a key is explicitly set in cache, we can remove it from the list of nullish keys,
+        // since it will either be set to a non nullish value or removed from the cache completely.
         this.nullishStorageKeys.delete(key);
 
         if (value === null || value === undefined) {
@@ -152,7 +155,7 @@ class OnyxCache {
             this.addToAccessedKeys(key);
 
             if (value === null || value === undefined) {
-                this.nullishStorageKeys.add(key);
+                this.addNullishStorageKey(key);
             } else {
                 this.nullishStorageKeys.delete(key);
             }

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -223,6 +223,11 @@ function get(key: OnyxKey): Promise<OnyxValue<OnyxKey>> {
     // Otherwise retrieve the value from storage and capture a promise to aid concurrent usages
     const promise = Storage.getItem(key)
         .then((val) => {
+            if (val === undefined) {
+                cache.addNullishStorageKey(key);
+                return val;
+            }
+
             cache.set(key, val);
             return val;
         })

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -239,9 +239,9 @@ function get(key: OnyxKey): Promise<OnyxValue<OnyxKey>> {
 /** Returns current key names stored in persisted storage */
 function getAllKeys(): Promise<Set<OnyxKey>> {
     // When we've already read stored keys, resolve right away
-    const storedKeys = cache.getAllKeys();
-    if (storedKeys.size > 0) {
-        return Promise.resolve(storedKeys);
+    const cachedKeys = cache.getAllKeys();
+    if (cachedKeys.size > 0) {
+        return Promise.resolve(cachedKeys);
     }
 
     const taskName = 'getAllKeys';
@@ -254,6 +254,7 @@ function getAllKeys(): Promise<Set<OnyxKey>> {
     // Otherwise retrieve the keys from storage and capture a promise to aid concurrent usages
     const promise = Storage.getAllKeys().then((keys) => {
         cache.setAllKeys(keys);
+
         // return the updated set of keys
         return cache.getAllKeys();
     });

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -755,7 +755,7 @@ function keyChanged<TKey extends OnyxKey>(
  *     - sets state on the withOnyxInstances
  *     - triggers the callback function
  */
-function sendDataToConnection<TKey extends OnyxKey>(mapping: Mapping<TKey>, value: OnyxValue<TKey>, matchedKey: TKey | undefined, isBatched: boolean): void {
+function sendDataToConnection<TKey extends OnyxKey>(mapping: Mapping<TKey>, value: OnyxValue<TKey> | null, matchedKey: TKey | undefined, isBatched: boolean): void {
     // If the mapping no longer exists then we should not send any data.
     // This means our subscriber disconnected or withOnyx wrapped component unmounted.
     if (!callbackToStateMapping[mapping.connectionID]) {
@@ -784,7 +784,7 @@ function sendDataToConnection<TKey extends OnyxKey>(mapping: Mapping<TKey>, valu
         return;
     }
 
-    (mapping as DefaultConnectOptions<TKey>).callback?.(value, matchedKey as TKey);
+    (mapping as DefaultConnectOptions<TKey>).callback?.(value === null ? undefined : value, matchedKey as TKey);
 }
 
 /**

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -427,17 +427,17 @@ function getCachedCollection<TKey extends CollectionKeyBase>(collectionKey: TKey
 function keysChanged<TKey extends CollectionKeyBase>(
     collectionKey: TKey,
     partialCollection: OnyxCollection<KeyValueMapping[TKey]>,
-    previousPartialCollection: OnyxCollection<KeyValueMapping[TKey]>,
+    partialPreviousCollection: OnyxCollection<KeyValueMapping[TKey]>,
     notifyRegularSubscibers = true,
     notifyWithOnyxSubscibers = true,
 ): void {
     // We prepare the "cached collection" which is the entire collection + the new partial data that
     // was merged in via mergeCollection().
     const cachedCollection = getCachedCollection(collectionKey);
-    const previousCollection = previousPartialCollection ?? {};
+    const previousCollection = partialPreviousCollection ?? {};
 
     // If the previous collection equals the new collection then we do not need to notify any subscribers.
-    if (previousPartialCollection !== undefined && deepEqual(cachedCollection, previousPartialCollection)) {
+    if (partialPreviousCollection !== undefined && deepEqual(cachedCollection, partialPreviousCollection)) {
         return;
     }
 

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -207,8 +207,7 @@ function reduceCollectionWithSelector<TKey extends CollectionKeyBase, TMap, TRet
 
 /** Get some data from the store */
 function get(key: OnyxKey): Promise<OnyxValue<OnyxKey>> {
-    // When we already have the value in cache (or the key has been set to null,
-    // and therefore no data is set in cache), resolve right away.
+    // When we already have the value in cache - resolve right away
     if (cache.hasCacheForKey(key)) {
         return Promise.resolve(cache.get(key));
     }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -178,7 +178,7 @@ type Selector<TKey extends OnyxKey, TOnyxProps, TReturnType> = (value: OnyxEntry
  * })(Component);
  * ```
  */
-type OnyxEntry<TOnyxValue> = TOnyxValue | null | undefined;
+type OnyxEntry<TOnyxValue> = TOnyxValue | undefined;
 
 /**
  * Represents an Onyx collection of entries, that can be either a record of `TOnyxValue`s or `null` / `undefined` if it is empty or doesn't exist.
@@ -208,7 +208,7 @@ type OnyxEntry<TOnyxValue> = TOnyxValue | null | undefined;
  * })(Component);
  * ```
  */
-type OnyxCollection<TOnyxValue> = OnyxEntry<Record<string, TOnyxValue | null | undefined>>;
+type OnyxCollection<TOnyxValue> = OnyxEntry<Record<string, TOnyxValue | undefined>>;
 
 /** Utility type to extract `TOnyxValue` from `OnyxCollection<TOnyxValue>` */
 type ExtractOnyxCollectionValue<TOnyxCollection> = TOnyxCollection extends NonNullable<OnyxCollection<infer U>> ? U : never;

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -104,7 +104,7 @@ function fastMerge<TObject extends Record<string, unknown>>(target: TObject | nu
 }
 
 /** Deep removes the nested null values from the given value. */
-function removeNestedNullValues<TObject extends Record<string, unknown>>(value: TObject | unknown | unknown[]): TObject | unknown | unknown[] {
+function removeNestedNullValues<TObject extends Record<string, unknown>>(value: TObject | unknown | unknown[] | null): TObject | unknown | unknown[] | null {
     if (typeof value === 'object' && !Array.isArray(value)) {
         const objectValue = value as Record<string, unknown> | null;
         return fastMerge(objectValue, objectValue);

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -104,12 +104,13 @@ function fastMerge<TObject extends Record<string, unknown>>(target: TObject | nu
 }
 
 /** Deep removes the nested null values from the given value. */
-function removeNestedNullValues<TObject extends Record<string, unknown>>(value: unknown | unknown[] | TObject): Record<string, unknown> | unknown[] | null {
+function removeNestedNullValues<TObject extends Record<string, unknown>>(value: TObject | unknown | unknown[]): TObject | unknown | unknown[] {
     if (typeof value === 'object' && !Array.isArray(value)) {
-        return fastMerge(value as Record<string, unknown> | null, value as Record<string, unknown> | null);
+        const objectValue = value as Record<string, unknown> | null;
+        return fastMerge(objectValue, objectValue);
     }
 
-    return value as Record<string, unknown> | null;
+    return value;
 }
 
 /** Formats the action name by uppercasing and adding the key if provided. */

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/prefer-for-of */
 
-import type {OnyxKey} from './types';
+import type {OnyxKey, OnyxValue} from './types';
 
 type EmptyObject = Record<string, never>;
 type EmptyValue = EmptyObject | null | undefined;
@@ -104,10 +104,10 @@ function fastMerge<TObject extends Record<string, unknown>>(target: TObject | nu
 }
 
 /** Deep removes the nested null values from the given value. */
-function removeNestedNullValues<TObject extends Record<string, unknown>>(value: TObject | unknown | unknown[] | null): TObject | unknown | unknown[] | null {
+function removeNestedNullValues<TValue extends OnyxValue<OnyxKey> | unknown | unknown[]>(value: TValue | null): TValue | null {
     if (typeof value === 'object' && !Array.isArray(value)) {
         const objectValue = value as Record<string, unknown> | null;
-        return fastMerge(objectValue, objectValue);
+        return fastMerge(objectValue, objectValue) as TValue | null;
     }
 
     return value;

--- a/lib/withOnyx.js
+++ b/lib/withOnyx.js
@@ -222,17 +222,13 @@ export default function (mapOnyxToState, shouldDelayUpdates = false) {
 
                             // If initialValue is there and the state contains something different it means
                             // an update has already been received and we can discard the value we are trying to hydrate
-                            if (!_.isUndefined(initialValue) && !_.isUndefined(prevState[key]) && prevState[key] !== initialValue) {
-                                if (prevState[key] !== null) {
-                                    // eslint-disable-next-line no-param-reassign
-                                    result[key] = prevState[key];
-                                }
-                            } else if (!_.isUndefined(prevState[key])) {
+                            if (initialValue !== undefined && prevState[key] !== undefined && prevState[key] !== initialValue && prevState[key] !== null) {
+                                // eslint-disable-next-line no-param-reassign
+                                result[key] = prevState[key];
+                            } else if (prevState[key] !== undefined && prevState[key] !== null) {
                                 // if value is already there (without initial value) then we can discard the value we are trying to hydrate
-                                if (prevState[key] !== null) {
-                                    // eslint-disable-next-line no-param-reassign
-                                    result[key] = prevState[key];
-                                }
+                                // eslint-disable-next-line no-param-reassign
+                                result[key] = prevState[key];
                             } else if (value !== null) {
                                 // eslint-disable-next-line no-param-reassign
                                 result[key] = value;
@@ -327,7 +323,8 @@ export default function (mapOnyxToState, shouldDelayUpdates = false) {
 
                 // Remove any internal state properties used by withOnyx
                 // that should not be passed to a wrapped component
-                const stateToPass = _.omit(this.state, 'loading');
+                let stateToPass = _.omit(this.state, 'loading');
+                stateToPass = _.omit(stateToPass, _.isNull);
 
                 // Spreading props and state is necessary in an HOC where the data cannot be predicted
                 return (

--- a/lib/withOnyx.js
+++ b/lib/withOnyx.js
@@ -61,7 +61,11 @@ export default function (mapOnyxToState, shouldDelayUpdates = false) {
                         const key = Str.result(mapping.key, props);
                         let value = OnyxUtils.tryGetCachedValue(key, mapping);
                         if (!value && mapping.initialValue) {
-                            value = mapping.initialValue;
+                            if (mapping.initialValue === null) {
+                                value = undefined;
+                            } else {
+                                value = mapping.initialValue;
+                            }
                         }
 
                         /**
@@ -219,17 +223,21 @@ export default function (mapOnyxToState, shouldDelayUpdates = false) {
                             // If initialValue is there and the state contains something different it means
                             // an update has already been received and we can discard the value we are trying to hydrate
                             if (!_.isUndefined(initialValue) && !_.isUndefined(prevState[key]) && prevState[key] !== initialValue) {
-                                // eslint-disable-next-line no-param-reassign
-                                result[key] = prevState[key];
-
-                                // if value is already there (without initial value) then we can discard the value we are trying to hydrate
+                                if (prevState[key] !== null) {
+                                    // eslint-disable-next-line no-param-reassign
+                                    result[key] = prevState[key];
+                                }
                             } else if (!_.isUndefined(prevState[key])) {
-                                // eslint-disable-next-line no-param-reassign
-                                result[key] = prevState[key];
-                            } else {
+                                // if value is already there (without initial value) then we can discard the value we are trying to hydrate
+                                if (prevState[key] !== null) {
+                                    // eslint-disable-next-line no-param-reassign
+                                    result[key] = prevState[key];
+                                }
+                            } else if (value !== null) {
                                 // eslint-disable-next-line no-param-reassign
                                 result[key] = value;
                             }
+
                             return result;
                         },
                         {},
@@ -319,10 +327,9 @@ export default function (mapOnyxToState, shouldDelayUpdates = false) {
 
                 // Remove any internal state properties used by withOnyx
                 // that should not be passed to a wrapped component
-                let stateToPass = _.omit(this.state, 'loading');
-                stateToPass = _.omit(stateToPass, _.isNull);
-                const stateToPassWithoutNestedNulls = utils.removeNestedNullValues(stateToPass);
+                const stateToPass = _.omit(this.state, 'loading');
 
+                console.log({stateToPass});
                 // Spreading props and state is necessary in an HOC where the data cannot be predicted
                 return (
                     <WrappedComponent
@@ -330,7 +337,7 @@ export default function (mapOnyxToState, shouldDelayUpdates = false) {
                         // eslint-disable-next-line react/jsx-props-no-spreading
                         {...propsToPass}
                         // eslint-disable-next-line react/jsx-props-no-spreading
-                        {...stateToPassWithoutNestedNulls}
+                        {...stateToPass}
                         ref={this.props.forwardedRef}
                     />
                 );

--- a/lib/withOnyx.js
+++ b/lib/withOnyx.js
@@ -182,7 +182,7 @@ export default function (mapOnyxToState, shouldDelayUpdates = false) {
              * @param {*} val
              */
             setWithOnyxState(statePropertyName, val) {
-                const prevValue = this.state[statePropertyName];
+                const prevVal = this.state[statePropertyName];
 
                 // If the component is not loading (read "mounting"), then we can just update the state
                 // There is a small race condition.
@@ -193,7 +193,7 @@ export default function (mapOnyxToState, shouldDelayUpdates = false) {
                 // This simply bypasses the loading check if the tempState is gone and the update can be safely queued with a normal setStateProxy.
                 if (!this.state.loading || !this.tempState) {
                     // Performance optimization, do not trigger update with same values
-                    if (prevValue === val || (utils.isEmptyObject(prevValue) && utils.isEmptyObject(val))) {
+                    if (prevVal === val || (utils.isEmptyObject(prevVal) && utils.isEmptyObject(val))) {
                         return;
                     }
 
@@ -216,23 +216,25 @@ export default function (mapOnyxToState, shouldDelayUpdates = false) {
                 this.setState((prevState) => {
                     const finalState = _.reduce(
                         stateUpdate,
-                        (result, value, key) => {
+                        (result, valueWithNull, key) => {
                             if (key === 'loading') {
                                 return result;
                             }
 
-                            const initialValue = mapOnyxToState[key].initialValue;
+                            const initialValue = mapOnyxToState[key].initialValue == null ? undefined : mapOnyxToState[key].initialValue;
+                            const prevValue = prevState[key] === null ? undefined : prevState[key];
+                            const value = valueWithNull === null ? undefined : valueWithNull;
 
                             // If initialValue is there and the state contains something different it means
                             // an update has already been received and we can discard the value we are trying to hydrate
-                            if (initialValue !== undefined && prevState[key] !== undefined && prevState[key] !== initialValue && prevState[key] !== null) {
+                            if (initialValue !== undefined && prevValue !== undefined && prevValue !== initialValue) {
                                 // eslint-disable-next-line no-param-reassign
-                                result[key] = prevState[key];
-                            } else if (prevState[key] !== undefined && prevState[key] !== null) {
+                                result[key] = prevValue;
+                            } else if (prevValue !== undefined) {
                                 // if value is already there (without initial value) then we can discard the value we are trying to hydrate
                                 // eslint-disable-next-line no-param-reassign
-                                result[key] = prevState[key];
-                            } else if (value !== null) {
+                                result[key] = prevValue;
+                            } else {
                                 // eslint-disable-next-line no-param-reassign
                                 result[key] = value;
                             }

--- a/lib/withOnyx.js
+++ b/lib/withOnyx.js
@@ -10,6 +10,7 @@ import Onyx from './Onyx';
 import * as Str from './Str';
 import utils from './utils';
 import OnyxUtils from './OnyxUtils';
+import cache from './OnyxCache';
 
 // This is a list of keys that can exist on a `mapping`, but are not directly related to loading data from Onyx. When the keys of a mapping are looped over to check
 // if a key has changed, it's a good idea to skip looking at these properties since they would have unexpected results.
@@ -60,12 +61,10 @@ export default function (mapOnyxToState, shouldDelayUpdates = false) {
                     (resultObj, mapping, propertyName) => {
                         const key = Str.result(mapping.key, props);
                         let value = OnyxUtils.tryGetCachedValue(key, mapping);
-                        if (!value && mapping.initialValue) {
-                            if (mapping.initialValue === null) {
-                                value = undefined;
-                            } else {
-                                value = mapping.initialValue;
-                            }
+                        const hasCacheForKey = cache.hasCacheForKey(key);
+
+                        if (!hasCacheForKey && !value && mapping.initialValue) {
+                            value = mapping.initialValue === null ? undefined : mapping.initialValue;
                         }
 
                         /**
@@ -79,7 +78,11 @@ export default function (mapOnyxToState, shouldDelayUpdates = false) {
                          * In reality, Onyx.merge() will only update the subscriber after all merges have been batched and the previous value is retrieved via a get() (returns a promise).
                          * So, we won't use the cache optimization here as it will lead us to arbitrarily defer various actions in the application code.
                          */
-                        if (mapping.initWithStoredValues !== false && ((value !== undefined && !OnyxUtils.hasPendingMergeForKey(key)) || mapping.allowStaleData)) {
+                        const hasPendingMergeForKey = OnyxUtils.hasPendingMergeForKey(key);
+                        const hasValueInCache = hasCacheForKey || value !== undefined;
+                        const shouldSetState = mapping.initWithStoredValues !== false && ((hasValueInCache && !hasPendingMergeForKey) || !!mapping.allowStaleData);
+
+                        if (shouldSetState) {
                             // eslint-disable-next-line no-param-reassign
                             resultObj[propertyName] = value;
                         }

--- a/lib/withOnyx.js
+++ b/lib/withOnyx.js
@@ -329,7 +329,6 @@ export default function (mapOnyxToState, shouldDelayUpdates = false) {
                 // that should not be passed to a wrapped component
                 const stateToPass = _.omit(this.state, 'loading');
 
-                console.log({stateToPass});
                 // Spreading props and state is necessary in an HOC where the data cannot be predicted
                 return (
                     <WrappedComponent

--- a/lib/withOnyx.js
+++ b/lib/withOnyx.js
@@ -64,7 +64,7 @@ export default function (mapOnyxToState, shouldDelayUpdates = false) {
                         const hasCacheForKey = cache.hasCacheForKey(key);
 
                         if (!hasCacheForKey && !value && mapping.initialValue) {
-                            value = mapping.initialValue === null ? undefined : mapping.initialValue;
+                            value = mapping.initialValue;
                         }
 
                         /**

--- a/tests/unit/onyxCacheTest.tsx
+++ b/tests/unit/onyxCacheTest.tsx
@@ -79,7 +79,7 @@ describe('Onyx', () => {
                 // Given empty cache
 
                 // When a value is retrieved
-                const result = cache.getValue('mockKey');
+                const result = cache.get('mockKey');
 
                 // Then it should be undefined
                 expect(result).not.toBeDefined();
@@ -92,8 +92,8 @@ describe('Onyx', () => {
 
                 // When a value is retrieved
                 // Then it should be the correct value
-                expect(cache.getValue('mockKey')).toEqual({items: ['mockValue', 'mockValue2']});
-                expect(cache.getValue('mockKey2')).toEqual('mockValue3');
+                expect(cache.get('mockKey')).toEqual({items: ['mockValue', 'mockValue2']});
+                expect(cache.get('mockKey2')).toEqual('mockValue3');
             });
         });
 
@@ -155,7 +155,7 @@ describe('Onyx', () => {
                 cache.set('mockKey', {value: 'mockValue'});
 
                 // Then data should be cached
-                const data = cache.getValue('mockKey');
+                const data = cache.get('mockKey');
                 expect(data).toEqual({value: 'mockValue'});
             });
 
@@ -178,7 +178,7 @@ describe('Onyx', () => {
                 cache.set('mockKey2', {value: []});
 
                 // Then the value should be overwritten
-                expect(cache.getValue('mockKey2')).toEqual({value: []});
+                expect(cache.get('mockKey2')).toEqual({value: []});
             });
         });
 
@@ -193,7 +193,7 @@ describe('Onyx', () => {
 
                 // Then a value should not be available in cache
                 expect(cache.hasCacheForKey('mockKey')).toBe(false);
-                expect(cache.getValue('mockKey')).not.toBeDefined();
+                expect(cache.get('mockKey')).not.toBeDefined();
                 expect(cache.getAllKeys().has('mockKey')).toBe(false);
             });
         });
@@ -209,8 +209,8 @@ describe('Onyx', () => {
                 });
 
                 // Then data should be created in cache
-                expect(cache.getValue('mockKey')).toEqual({value: 'mockValue'});
-                expect(cache.getValue('mockKey2')).toEqual({value: 'mockValue2'});
+                expect(cache.get('mockKey')).toEqual({value: 'mockValue'});
+                expect(cache.get('mockKey2')).toEqual({value: 'mockValue2'});
             });
 
             it('Should merge data to existing cache value', () => {
@@ -225,12 +225,12 @@ describe('Onyx', () => {
                 });
 
                 // Then the values should be merged together in cache
-                expect(cache.getValue('mockKey')).toEqual({
+                expect(cache.get('mockKey')).toEqual({
                     value: 'mockValue',
                     mockItems: [],
                 });
 
-                expect(cache.getValue('mockKey2')).toEqual({
+                expect(cache.get('mockKey2')).toEqual({
                     other: 'overwrittenMockValue',
                     items: [1, 2],
                     mock: 'mock',
@@ -247,7 +247,7 @@ describe('Onyx', () => {
                 });
 
                 // Then the values should be merged together in cache
-                expect(cache.getValue('mockKey')).toEqual({
+                expect(cache.get('mockKey')).toEqual({
                     value: 'mockValue',
                     mockItems: [],
                     otherValue: 'overwritten',
@@ -264,7 +264,7 @@ describe('Onyx', () => {
                 });
 
                 // Then the arrays should be replaced as expected
-                expect(cache.getValue('mockKey')).toEqual([{ID: 3}, {added: 'field'}, {}, {ID: 1000}]);
+                expect(cache.get('mockKey')).toEqual([{ID: 3}, {added: 'field'}, {}, {ID: 1000}]);
             });
 
             it('Should merge arrays inside objects correctly', () => {
@@ -277,7 +277,7 @@ describe('Onyx', () => {
                 });
 
                 // Then the first array is completely replaced by the second array
-                expect(cache.getValue('mockKey')).toEqual({ID: [2]});
+                expect(cache.get('mockKey')).toEqual({ID: [2]});
             });
 
             it('Should work with primitive values', () => {
@@ -288,31 +288,31 @@ describe('Onyx', () => {
                 cache.merge({mockKey: false});
 
                 // Then the object should be overwritten with a bool value
-                expect(cache.getValue('mockKey')).toEqual(false);
+                expect(cache.get('mockKey')).toEqual(false);
 
                 // When merge is called with number
                 cache.merge({mockKey: 0});
 
                 // Then the value should be overwritten
-                expect(cache.getValue('mockKey')).toEqual(0);
+                expect(cache.get('mockKey')).toEqual(0);
 
                 // When merge is called with string
                 cache.merge({mockKey: '123'});
 
                 // Then the value should be overwritten
-                expect(cache.getValue('mockKey')).toEqual('123');
+                expect(cache.get('mockKey')).toEqual('123');
 
                 // When merge is called with string again
                 cache.merge({mockKey: '123'});
 
                 // Then strings should not have been concatenated
-                expect(cache.getValue('mockKey')).toEqual('123');
+                expect(cache.get('mockKey')).toEqual('123');
 
                 // When merge is called with an object
                 cache.merge({mockKey: {value: 'myMockObject'}});
 
                 // Then the old primitive value should be overwritten with the object
-                expect(cache.getValue('mockKey')).toEqual({value: 'myMockObject'});
+                expect(cache.get('mockKey')).toEqual({value: 'myMockObject'});
             });
 
             it('Should ignore `undefined` values', () => {
@@ -323,12 +323,12 @@ describe('Onyx', () => {
                 cache.merge({mockKey: {ID: undefined}});
 
                 // Then the key should still be in cache and the value unchanged
-                expect(cache.getValue('mockKey')).toEqual({ID: 5});
+                expect(cache.get('mockKey')).toEqual({ID: 5});
 
                 cache.merge({mockKey: undefined});
 
                 // Then the key should still be in cache and the value unchanged
-                expect(cache.getValue('mockKey')).toEqual({ID: 5});
+                expect(cache.get('mockKey')).toEqual({ID: 5});
             });
 
             it('Should update storageKeys when new keys are created', () => {
@@ -363,8 +363,8 @@ describe('Onyx', () => {
 
                 cache.merge({mockKey: null});
 
-                expect(cache.getValue('mockKey')).toEqual(undefined);
-                expect(cache.getValue('mockNullKey')).toEqual(undefined);
+                expect(cache.get('mockKey')).toEqual(undefined);
+                expect(cache.get('mockNullKey')).toEqual(undefined);
             });
         });
 

--- a/tests/unit/onyxCacheTest.tsx
+++ b/tests/unit/onyxCacheTest.tsx
@@ -357,16 +357,14 @@ describe('Onyx', () => {
                 expect(() => cache.merge({})).not.toThrow();
             });
 
-            it('Should merge `null` values', () => {
-                // `null` values can override existing values and should also
-                // be preserved during merges.
+            it('Should remove `null` values when merging', () => {
                 cache.set('mockKey', {ID: 5});
                 cache.set('mockNullKey', null);
 
                 cache.merge({mockKey: null});
 
-                expect(cache.getValue('mockKey')).toEqual(null);
-                expect(cache.getValue('mockNullKey')).toEqual(null);
+                expect(cache.getValue('mockKey')).toEqual(undefined);
+                expect(cache.getValue('mockNullKey')).toEqual(undefined);
             });
         });
 

--- a/tests/unit/onyxClearNativeStorageTest.ts
+++ b/tests/unit/onyxClearNativeStorageTest.ts
@@ -54,7 +54,7 @@ describe('Set data while storage is clearing', () => {
         return waitForPromisesToResolve().then(() => {
             // Then the value in Onyx, the cache, and Storage is the default key state
             expect(onyxValue).toBe(DEFAULT_VALUE);
-            const cachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
+            const cachedValue = cache.get(ONYX_KEYS.DEFAULT_KEY);
             expect(cachedValue).toBe(DEFAULT_VALUE);
             return StorageMock.getItem(ONYX_KEYS.DEFAULT_KEY).then((storedValue) => expect(parseInt(storedValue as string, 10)).toBe(DEFAULT_VALUE));
         });
@@ -70,7 +70,7 @@ describe('Set data while storage is clearing', () => {
         return waitForPromisesToResolve().then(() => {
             // Then the value in Onyx, the cache, and Storage is the default key state
             expect(onyxValue).toBe(DEFAULT_VALUE);
-            const cachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
+            const cachedValue = cache.get(ONYX_KEYS.DEFAULT_KEY);
             expect(cachedValue).toBe(DEFAULT_VALUE);
             return StorageMock.getItem(ONYX_KEYS.DEFAULT_KEY).then((storedValue) => expect(parseInt(storedValue as string, 10)).toBe(DEFAULT_VALUE));
         });
@@ -94,7 +94,7 @@ describe('Set data while storage is clearing', () => {
         return waitForPromisesToResolve().then(() => {
             // Then the value of the preserved key is also still set in both the cache and storage
             expect(regularKeyOnyxValue).toBe(SET_VALUE);
-            expect(cache.getValue(ONYX_KEYS.REGULAR_KEY)).toBe(SET_VALUE);
+            expect(cache.get(ONYX_KEYS.REGULAR_KEY)).toBe(SET_VALUE);
             return StorageMock.getItem(ONYX_KEYS.REGULAR_KEY).then((storedValue) => expect(parseInt(storedValue as string, 10)).toBe(SET_VALUE));
         });
     });
@@ -111,7 +111,7 @@ describe('Set data while storage is clearing', () => {
         return waitForPromisesToResolve().then(() => {
             // Then the value in Onyx, the cache, and Storage is the set value
             expect(onyxValue).toBe(SET_VALUE);
-            const cachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
+            const cachedValue = cache.get(ONYX_KEYS.DEFAULT_KEY);
             expect(cachedValue).toBe(SET_VALUE);
             return StorageMock.getItem(ONYX_KEYS.DEFAULT_KEY).then((storedValue) => expect(parseInt(storedValue as string, 10)).toBe(SET_VALUE));
         });

--- a/tests/unit/onyxClearWebStorageTest.ts
+++ b/tests/unit/onyxClearWebStorageTest.ts
@@ -56,7 +56,7 @@ describe('Set data while storage is clearing', () => {
         return waitForPromisesToResolve().then(() => {
             // Then the value in Onyx, the cache, and Storage is the default key state
             expect(onyxValue).toBe(DEFAULT_VALUE);
-            const cachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
+            const cachedValue = cache.get(ONYX_KEYS.DEFAULT_KEY);
             expect(cachedValue).toBe(DEFAULT_VALUE);
             const storedValue = StorageMock.getItem(ONYX_KEYS.DEFAULT_KEY);
             return expect(storedValue).resolves.toBe(DEFAULT_VALUE);
@@ -73,7 +73,7 @@ describe('Set data while storage is clearing', () => {
         return waitForPromisesToResolve().then(() => {
             // Then the value in Onyx, the cache, and Storage is the default key state
             expect(onyxValue).toBe(DEFAULT_VALUE);
-            const cachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
+            const cachedValue = cache.get(ONYX_KEYS.DEFAULT_KEY);
             expect(cachedValue).toBe(DEFAULT_VALUE);
             const storedValue = StorageMock.getItem(ONYX_KEYS.DEFAULT_KEY);
             return expect(storedValue).resolves.toBe(DEFAULT_VALUE);
@@ -98,7 +98,7 @@ describe('Set data while storage is clearing', () => {
         return waitForPromisesToResolve().then(() => {
             // Then the value of the preserved key is also still set in both the cache and storage
             expect(regularKeyOnyxValue).toBe(SET_VALUE);
-            const regularKeyCachedValue = cache.getValue(ONYX_KEYS.REGULAR_KEY);
+            const regularKeyCachedValue = cache.get(ONYX_KEYS.REGULAR_KEY);
             expect(regularKeyCachedValue).toBe(SET_VALUE);
             const regularKeyStoredValue = StorageMock.getItem(ONYX_KEYS.REGULAR_KEY);
             return expect(regularKeyStoredValue).resolves.toBe(SET_VALUE);
@@ -117,7 +117,7 @@ describe('Set data while storage is clearing', () => {
         return waitForPromisesToResolve().then(() => {
             // Then the value in Onyx, the cache, and Storage is the set value
             expect(onyxValue).toBe(SET_VALUE);
-            const cachedValue = cache.getValue(ONYX_KEYS.DEFAULT_KEY);
+            const cachedValue = cache.get(ONYX_KEYS.DEFAULT_KEY);
             expect(cachedValue).toBe(SET_VALUE);
             const storedValue = StorageMock.getItem(ONYX_KEYS.DEFAULT_KEY);
             return expect(storedValue).resolves.toBe(SET_VALUE);

--- a/tests/unit/onyxClearWebStorageTest.ts
+++ b/tests/unit/onyxClearWebStorageTest.ts
@@ -158,7 +158,7 @@ describe('Set data while storage is clearing', () => {
                     expect(collectionCallback).toHaveBeenCalledTimes(3);
 
                     // And it should be called with the expected parameters each time
-                    expect(collectionCallback).toHaveBeenNthCalledWith(1, null, undefined);
+                    expect(collectionCallback).toHaveBeenNthCalledWith(1, undefined, undefined);
                     expect(collectionCallback).toHaveBeenNthCalledWith(2, {
                         test_1: 1,
                         test_2: 2,

--- a/tests/unit/onyxMultiMergeWebStorageTest.ts
+++ b/tests/unit/onyxMultiMergeWebStorageTest.ts
@@ -45,9 +45,9 @@ describe('Onyx.mergeCollection() and WebStorage', () => {
         expect(StorageMock.getMockStore().test_3).toEqual(initialTestObject);
 
         // And an empty cache values for the collection keys
-        expect(OnyxCache.getValue('test_1')).not.toBeDefined();
-        expect(OnyxCache.getValue('test_2')).not.toBeDefined();
-        expect(OnyxCache.getValue('test_3')).not.toBeDefined();
+        expect(OnyxCache.get('test_1')).not.toBeDefined();
+        expect(OnyxCache.get('test_2')).not.toBeDefined();
+        expect(OnyxCache.get('test_3')).not.toBeDefined();
 
         // When we merge additional data
         const additionalDataOne = {b: 'b', c: 'c', e: [1, 2]};
@@ -75,9 +75,9 @@ describe('Onyx.mergeCollection() and WebStorage', () => {
             };
 
             // Then our new data should merge with the existing data in the cache
-            expect(OnyxCache.getValue('test_1')).toEqual(finalObject);
-            expect(OnyxCache.getValue('test_2')).toEqual(finalObject);
-            expect(OnyxCache.getValue('test_3')).toEqual(finalObject);
+            expect(OnyxCache.get('test_1')).toEqual(finalObject);
+            expect(OnyxCache.get('test_2')).toEqual(finalObject);
+            expect(OnyxCache.get('test_3')).toEqual(finalObject);
 
             // And the storage should reflect the same state
             expect(StorageMock.getMockStore().test_1).toEqual(finalObject);
@@ -93,9 +93,9 @@ describe('Onyx.mergeCollection() and WebStorage', () => {
         expect(StorageMock.getMockStore().test_3).toBeFalsy();
 
         // And an empty cache values for the collection keys
-        expect(OnyxCache.getValue('test_1')).toBeFalsy();
-        expect(OnyxCache.getValue('test_2')).toBeFalsy();
-        expect(OnyxCache.getValue('test_3')).toBeFalsy();
+        expect(OnyxCache.get('test_1')).toBeFalsy();
+        expect(OnyxCache.get('test_2')).toBeFalsy();
+        expect(OnyxCache.get('test_3')).toBeFalsy();
 
         // When we merge additional data and wait for the change
         const data = {a: 'a', b: 'b'};
@@ -108,9 +108,9 @@ describe('Onyx.mergeCollection() and WebStorage', () => {
         return waitForPromisesToResolve()
             .then(() => {
                 // Then the cache and storage should match
-                expect(OnyxCache.getValue('test_1')).toEqual(data);
-                expect(OnyxCache.getValue('test_2')).toEqual(data);
-                expect(OnyxCache.getValue('test_3')).toEqual(data);
+                expect(OnyxCache.get('test_1')).toEqual(data);
+                expect(OnyxCache.get('test_2')).toEqual(data);
+                expect(OnyxCache.get('test_3')).toEqual(data);
                 expect(StorageMock.getMockStore().test_1).toEqual(data);
                 expect(StorageMock.getMockStore().test_2).toEqual(data);
                 expect(StorageMock.getMockStore().test_3).toEqual(data);
@@ -137,9 +137,9 @@ describe('Onyx.mergeCollection() and WebStorage', () => {
                 };
 
                 // Then our new data should merge with the existing data in the cache
-                expect(OnyxCache.getValue('test_1')).toEqual(finalObject);
-                expect(OnyxCache.getValue('test_2')).toEqual(finalObject);
-                expect(OnyxCache.getValue('test_3')).toEqual(finalObject);
+                expect(OnyxCache.get('test_1')).toEqual(finalObject);
+                expect(OnyxCache.get('test_2')).toEqual(finalObject);
+                expect(OnyxCache.get('test_3')).toEqual(finalObject);
 
                 // And the storage should reflect the same state
                 expect(StorageMock.getMockStore().test_1).toEqual(finalObject);
@@ -178,7 +178,7 @@ describe('Onyx.mergeCollection() and WebStorage', () => {
                 f: 'f',
             };
 
-            expect(OnyxCache.getValue('test_1')).toEqual(finalObject);
+            expect(OnyxCache.get('test_1')).toEqual(finalObject);
             expect(StorageMock.getMockStore().test_1).toEqual(finalObject);
         });
     });

--- a/tests/unit/onyxTest.ts
+++ b/tests/unit/onyxTest.ts
@@ -816,7 +816,7 @@ describe('Onyx', () => {
                     expect(mockCallback).toHaveBeenCalledTimes(2);
 
                     // AND the value for the first call should be null since the collection was not initialized at that point
-                    expect(mockCallback).toHaveBeenNthCalledWith(1, null, undefined);
+                    expect(mockCallback).toHaveBeenNthCalledWith(1, undefined, undefined);
 
                     // AND the value for the second call should be collectionUpdate since the collection was updated
                     expect(mockCallback).toHaveBeenNthCalledWith(2, collectionUpdate);
@@ -845,7 +845,7 @@ describe('Onyx', () => {
                     expect(mockCallback).toHaveBeenCalledTimes(2);
 
                     // AND the value for the first call should be null since the collection was not initialized at that point
-                    expect(mockCallback).toHaveBeenNthCalledWith(1, null, undefined);
+                    expect(mockCallback).toHaveBeenNthCalledWith(1, undefined, undefined);
 
                     // AND the value for the second call should be collectionUpdate since the collection was updated
                     expect(mockCallback).toHaveBeenNthCalledWith(2, collectionUpdate.testPolicy_1, 'testPolicy_1');
@@ -987,11 +987,11 @@ describe('Onyx', () => {
                 {onyxMethod: Onyx.METHOD.MERGE_COLLECTION, key: ONYX_KEYS.COLLECTION.TEST_UPDATE, value: {[itemKey]: {a: 'a'}}},
             ]).then(() => {
                 expect(collectionCallback).toHaveBeenCalledTimes(2);
-                expect(collectionCallback).toHaveBeenNthCalledWith(1, null, undefined);
+                expect(collectionCallback).toHaveBeenNthCalledWith(1, undefined, undefined);
                 expect(collectionCallback).toHaveBeenNthCalledWith(2, {[itemKey]: {a: 'a'}});
 
                 expect(testCallback).toHaveBeenCalledTimes(2);
-                expect(testCallback).toHaveBeenNthCalledWith(1, null, undefined);
+                expect(testCallback).toHaveBeenNthCalledWith(1, undefined, undefined);
                 expect(testCallback).toHaveBeenNthCalledWith(2, 'taco', ONYX_KEYS.TEST_KEY);
 
                 expect(otherTestCallback).toHaveBeenCalledTimes(2);


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

@mountiny @neil-marcellini 

### Details
<!-- Explanation of the change or anything fishy that is going on -->

Removes `null` values from OnyxCache (reads) and therefore removes unnecessary calls to `removeNestedNullValues` on read.

This PR adds a `nullishStorageKeys` Set to `OnyxCache` where a key can be added in order for the key to represent `null`/"not set" in cache. This change let's us keep existing performance and loading state improvements that @janicduplessis implemented in https://github.com/Expensify/react-native-onyx/pull/401.

This PR also adds some general code quality improvements around using the cache and handling reads and writes to Onyx.

Recently `IDBKeyvalProvider` hasn't been identical in it's behavior to `SQLiteStorageProvider`. Therefore, i added some extra logic to `setItem`, `multiSet` and `multiMerge`, to check for null values and handle those in the storage layer.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/react-native-onyx/issues/553
https://github.com/Expensify/App/issues/42654

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Manual Tests
<!---
Each set of changes should be tested against the Expensify/App repo on all platforms to verify it does not break our staging App.
--->

### Author Checklist

- [x] I linked the correct issue in the `### Related Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
