### PR TITLE
Update docs to promote useOnyx usage over withOnyx

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,32 +202,6 @@ Some components need to subscribe to multiple Onyx keys at once and sometimes, o
 Example: To get the policy of a report, the `policy` key depends on the `report` key.
 
 ```javascript
-import React from 'react';
-import {useOnyx} from 'react-native-onyx';
-const ONYXKEYS = {
-    REPORT: 'report_1234',
-    POLICY: 'policy_'
-};
-
-const App = () => {
-    const [report] = useOnyx(ONYXKEYS.REPORT);
-    const [policy] = useOnyx(`${ONYXKEYS.POLICY}${report.policyID}`);
-    
-    return (
-        <View>
-            {/* Render with policy data */}
-        </View>
-    );
-};
-
-export default App;
-```
-
-Background info:
-- The `key` value can be a function that returns the key that Onyx subscribes to
-- The first argument to the `key` function is the `props` from the component
-
-```javascript
 const App = ({reportID}) => {
     const [report] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`);
     const [policy] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY}${report.policyID}`);

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Awesome persistent storage solution wrapped in a Pub/Sub library.
 - Onyx allows other code to subscribe to changes in data, and then publishes change events whenever data is changed
 - Anything needing to read Onyx data needs to:
     1. Know what key the data is stored in (for web, you can find this by looking in the JS console > Application > local storage)
-    2. Subscribe to changes of the data for a particular key or set of keys. React functional components use the `useOnyx()` hook (recommended), class components use `withOnyx()` HOC (deprecated, not-recommended) and non-React libs use `Onyx.connect()`.
+    2. Subscribe to changes of the data for a particular key or set of keys. React function components use the `useOnyx()` hook (recommended), both class and function components can use `withOnyx()` HOC (deprecated, not-recommended) and non-React libs use `Onyx.connect()`.
     3. Get initialized with the current value of that key from persistent storage (Onyx does this by calling `setState()` or triggering the `callback` with the values currently on disk as part of the connection process)
 - Subscribing to Onyx keys is done using a constant defined in `ONYXKEYS`. Each Onyx key represents either a collection of items or a specific entry in storage. For example, since all reports are stored as individual keys like `report_1234`, if code needs to know about all the reports (e.g. display a list of them in the nav menu), then it would subscribe to the key `ONYXKEYS.COLLECTION.REPORT`.
 

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ export default App;
 5. The `useOnyx` hook reads the data and updates the state of the component:
    - `report={{reportID: 1234, policyID: 1, ...rest of the object...}}`
    - `policy={undefined}` (since there is no policy with ID `undefined`)
-6. As there is still an `undefined` key, the `useOnyx` hook again evaluates the key `policies_1` after fetching the updated `report` object which has `policyID: 1`.
+6. The `useOnyx` hook again evaluates the key `policies_1` after fetching the updated `report` object which has `policyID: 1`.
 7. The `useOnyx` hook reads the data and updates the state with:
    - `policy={{policyID: 1, ...rest of the object...}}`
 8. Now, all mappings have values that are defined (not undefined), and the component is rendered with all necessary data.

--- a/README.md
+++ b/README.md
@@ -407,9 +407,9 @@ Onyx.init({
 ```
 
 ```js
-const ReportActionsView = ({isActiveReport}) => {
+const ReportActionsView = ({reportID, isActiveReport}) => {
     const [reportActions] = useOnyx(
-        ({reportID}) => `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportID}_`,
+        `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportID}_`,
         {canEvict: () => !isActiveReport}
     );
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,9 @@ if (reportsResult.status === 'loading' || sessionResult.status === 'loading') {
 // rest of the component's code.
 ```
 
-> **Deprecated Note**: Please note, `withOnyx()` Higher Order Component (HOC) is now considered deprecated. Use `useOnyx()` hook instead.
+> [!warning]
+> ## Deprecated Note
+> Please note that the `withOnyx()` Higher Order Component (HOC) is now considered deprecated. Use `useOnyx()` hook instead.
 
 ```javascript
 import React from 'react';

--- a/README.md
+++ b/README.md
@@ -135,11 +135,18 @@ const App = () => {
 export default App;
 ```
 
-While `Onyx.connect()` gives you more control on how your component reacts as data is fetched from disk, `useOnyx()` will delay the rendering of the wrapped component until all keys/entities have been fetched and passed to the component, this can be convenient for simple cases. This however, can really delay your application if many entities are connected to the same component, you can pass an `initialValue` to each key to allow Onyx to eagerly render your component with this value.
+The `useOnyx()` hook won't delay the rendering of the component using it while the key/entity is being fetched and passed to the component. However, you can simulate this behavior by checking if the `status` of the hook's result metadata is `loading`. When `status` is `loading` it means that the Onyx data is being loaded into cache and thus is not immediately available, while `loaded` means that the data is already loaded and available to be consumed.
 
-```javascript
-const [session] = useOnyx('session', {initialValue: {}});
-```
+\```javascript
+const [reports, reportsResult] = useOnyx(ONYXKEYS.COLLECTION.REPORT);
+const [session, sessionResult] = useOnyx(ONYXKEYS.SESSION);
+
+if (reportsResult.status === 'loading' || sessionResult.status === 'loading') {
+    return <Placeholder />; // or `null` if you don't want to render anything.
+}
+
+// rest of the component's code.
+\```
 
 > **Deprecated Note**: Please note, `withOnyx()` Higher Order Component (HOC) is now considered deprecated. Use `useOnyx()` hook instead.
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ export default App;
 
 The `useOnyx()` hook won't delay the rendering of the component using it while the key/entity is being fetched and passed to the component. However, you can simulate this behavior by checking if the `status` of the hook's result metadata is `loading`. When `status` is `loading` it means that the Onyx data is being loaded into cache and thus is not immediately available, while `loaded` means that the data is already loaded and available to be consumed.
 
-\```javascript
+```javascript
 const [reports, reportsResult] = useOnyx(ONYXKEYS.COLLECTION.REPORT);
 const [session, sessionResult] = useOnyx(ONYXKEYS.SESSION);
 
@@ -146,7 +146,7 @@ if (reportsResult.status === 'loading' || sessionResult.status === 'loading') {
 }
 
 // rest of the component's code.
-\```
+```
 
 > **Deprecated Note**: Please note, `withOnyx()` Higher Order Component (HOC) is now considered deprecated. Use `useOnyx()` hook instead.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Awesome persistent storage solution wrapped in a Pub/Sub library.
 - Onyx allows other code to subscribe to changes in data, and then publishes change events whenever data is changed
 - Anything needing to read Onyx data needs to:
     1. Know what key the data is stored in (for web, you can find this by looking in the JS console > Application > local storage)
-    2. Subscribe to changes of the data for a particular key or set of keys. React components use `withOnyx()` and non-React libs use `Onyx.connect()`.
+    2. Subscribe to changes of the data for a particular key or set of keys. React functional components use the `useOnyx()` hook (recommended), class components use `withOnyx()` HOC (deprecated, not-recommended) and non-React libs use `Onyx.connect()`.
     3. Get initialized with the current value of that key from persistent storage (Onyx does this by calling `setState()` or triggering the `callback` with the values currently on disk as part of the connection process)
 - Subscribing to Onyx keys is done using a constant defined in `ONYXKEYS`. Each Onyx key represents either a collection of items or a specific entry in storage. For example, since all reports are stored as individual keys like `report_1234`, if code needs to know about all the reports (e.g. display a list of them in the nav menu), then it would subscribe to the key `ONYXKEYS.COLLECTION.REPORT`.
 
@@ -116,7 +116,32 @@ To teardown the subscription call `Onyx.disconnect()` with the `connectionID` re
 Onyx.disconnect(connectionID);
 ```
 
-We can also access values inside React components via the `withOnyx()` [higher order component](https://reactjs.org/docs/higher-order-components.html). When the data changes the component will re-render.
+We can also access values inside React functional components via the `useOnyx()` [hook](https://react.dev/reference/react/hooks) (recommended) or class components via the `withOnyx()` [higher order component](https://reactjs.org/docs/higher-order-components.html) (deprecated, not-recommended). When the data changes the component will re-render.
+
+```javascript
+import React from 'react';
+import {useOnyx} from 'react-native-onyx';
+
+const App = () => {
+    const [session] = useOnyx('session');
+    
+    return (
+        <View>
+            {session.token ? <Text>Logged in</Text> : <Text>Logged out</Text>}
+        </View>
+    );
+};
+
+export default App;
+```
+
+While `Onyx.connect()` gives you more control on how your component reacts as data is fetched from disk, `useOnyx()` will delay the rendering of the wrapped component until all keys/entities have been fetched and passed to the component, this can be convenient for simple cases. This however, can really delay your application if many entities are connected to the same component, you can pass an `initialValue` to each key to allow Onyx to eagerly render your component with this value.
+
+```javascript
+const [session] = useOnyx('session', {initialValue: {}});
+```
+
+> **Deprecated Note**: Please note, `withOnyx()` Higher Order Component (HOC) is now considered deprecated. Use `useOnyx()` hook instead.
 
 ```javascript
 import React from 'react';
@@ -164,27 +189,68 @@ export default withOnyx({
 }, true)(App);
 ```
 
-### Dependent Onyx Keys and withOnyx()
+### Dependent Onyx Keys and useOnyx()
 Some components need to subscribe to multiple Onyx keys at once and sometimes, one key might rely on the data from another key. This is similar to a JOIN in SQL.
 
 Example: To get the policy of a report, the `policy` key depends on the `report` key.
 
 ```javascript
-export default withOnyx({
-    report: {
-        key: ({reportID) => `${ONYXKEYS.COLLECTION.REPORT}${reportID}`,
-    },
-    policy: {
-        key: ({report}) => `${ONYXKEYS.COLLECTION.POLICY}${report.policyID}`,
-    },
-})(App);
+import React from 'react';
+import {useOnyx} from 'react-native-onyx';
+const ONYXKEYS = {
+    REPORT: 'report_1234',
+    POLICY: 'policy_'
+};
+
+const App = () => {
+    const [report] = useOnyx(ONYXKEYS.REPORT);
+    const [policy] = useOnyx(`${ONYXKEYS.POLICY}${report.policyID}`);
+    
+    return (
+        <View>
+            {/* Render with policy data */}
+        </View>
+    );
+};
+
+export default App;
 ```
 
 Background info:
 - The `key` value can be a function that returns the key that Onyx subscribes to
 - The first argument to the `key` function is the `props` from the component
 
-**Detailed explanation of how this is handled and rendered:**
+```javascript
+const App = ({reportID}) => {
+    const [report] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`);
+    const [policy] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY}${report.policyID}`);
+
+    return (
+        <View>
+            {/* Render with policy data */}
+        </View>
+    );
+};
+
+export default App;
+```
+
+**Detailed explanation of how this is handled and rendered with `useOnyx()`:**
+
+1. The component mounts with a `reportID={1234}` prop.
+2. The `useOnyx` hook evaluates the mapping and subscribes to the key `reports_1234` using the `reportID` prop.
+3. The `useOnyx` hook fetches the data for the key `reports_1234` from Onyx and sets the state with the initial value (if provided).
+4. Since `policyID` is not defined yet, it defaults to `undefined`. The `useOnyx` hook subscribes to the key `policies_undefined`.
+5. The `useOnyx` hook reads the data and updates the state of the component:
+   - `report={{reportID: 1234, policyID: 1, ...rest of the object...}}`   - `policy={undefined}` (since there is no policy with ID `undefined`)
+6. As there is still an `undefined` key, the `useOnyx` hook again evaluates the key `policies_1` after fetching the updated `report` object which has `policyID: 1`.
+7. The `useOnyx` hook reads the data and updates the state with:
+   - `policy={{policyID: 1, ...rest of the object...}}`
+8. Now, all mappings have values that are defined (not undefined), and the component is rendered with all necessary data.
+  
+* It is VERY important to NOT use empty string default values like `report.policyID || ''`. This results in the key returned to `useOnyx` as `policies_`, which subscribes to the ENTIRE POLICY COLLECTION and is most assuredly not what you were intending. You can use a default of `0` (as long as you are reasonably sure that there is never a policyID=0). This allows Onyx to return `undefined` as the value of the policy key, which is handled by `useOnyx` appropriately.
+
+**Detailed explanation of how this is handled and rendered with `withOnyx` HOC:**
 1. The component mounts with a `reportID={1234}` prop
 2. `withOnyx` evaluates the mapping
 3. `withOnyx` connects to the key `reports_1234` because of the prop passed to the component
@@ -239,15 +305,23 @@ Onyx.mergeCollection(ONYXKEYS.COLLECTION.REPORT, {
 There are several ways to subscribe to these keys:
 
 ```javascript
-withOnyx({
-    allReports: {key: ONYXKEYS.COLLECTION.REPORT},
-})(MyComponent);
+const MyComponent = () => {
+    const [allReports] = useOnyx(ONYXKEYS.COLLECTION.REPORT);
+
+    return (
+        <View>
+            {/* Render with allReports data */}
+        </View>
+    );
+};
+
+export default MyComponent;
 ```
 
 This will add a prop to the component called `allReports` which is an object of collection member key/values. Changes to the individual member keys will modify the entire object and new props will be passed with each individual key update. The prop doesn't update on the initial rendering of the component until the entire collection has been read out of Onyx.
 
 ```js
-Onyx.connect({key: ONYXKEYS.COLLECTION.REPORT}, callback: (memberValue, memberKey) => {...}});
+Onyx.connect({key: ONYXKEYS.COLLECTION.REPORT}, callback: (memberValue, memberKey) => {...});
 ```
 
 This will fire the callback once per member key depending on how many collection member keys are currently stored. Changes to those keys after the initial callbacks fire will occur when each individual key is updated.
@@ -256,11 +330,11 @@ This will fire the callback once per member key depending on how many collection
 Onyx.connect({
     key: ONYXKEYS.COLLECTION.REPORT,
     waitForCollectionCallback: true,
-    callback: (allReports) => {...}},
+    callback: (allReports) => {...},
 });
 ```
 
-This final option forces `Onyx.connect()` to behave more like `withOnyx()` and only update the callback once with the entire collection initially and later with an updated version of the collection when individual keys update.
+This final option forces `Onyx.connect()` to behave more like `useOnyx()` and only update the callback once with the entire collection initially and later with an updated version of the collection when individual keys update.
 
 ### Performance Considerations When Using Collections
 
@@ -270,12 +344,12 @@ Remember, `mergeCollection()` will notify a subscriber only *once* with the tota
 
 ```js
 // Bad
-_.each(reports, report => Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${report.reportID}`, report)); // -> A component using withOnyx() will have it's state updated with each iteration
+_.each(reports, report => Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${report.reportID}`, report)); // -> A component using useOnyx() will have it's state updated with each iteration
 
 // Good
 const values = {};
 _.each(reports, report => values[`${ONYXKEYS.COLLECTION.REPORT}${report.reportID}`] = report);
-Onyx.mergeCollection(ONYXKEYS.COLLECTION.REPORT, values); // -> A component using withOnyx() will only have it's state updated once
+Onyx.mergeCollection(ONYXKEYS.COLLECTION.REPORT, values); // -> A component using useOnyx() will only have its state updated once
 ```
 
 ## Clean up
@@ -325,12 +399,20 @@ Onyx.init({
 ```
 
 ```js
-export default withOnyx({
-    reportActions: {
-        key: ({reportID}) => `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportID}_`,
-        canEvict: props => !props.isActiveReport,
-    },
-})(ReportActionsView);
+const ReportActionsView = ({isActiveReport}) => {
+    const [reportActions] = useOnyx(
+        ({reportID}) => `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportID}_`,
+        {canEvict: () => !isActiveReport}
+    );
+
+    return (
+        <View>
+            {/* Render with reportActions data */}
+        </View>
+    );
+};
+
+export default ReportActionsView;
 ```
 
 # Benchmarks

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ To teardown the subscription call `Onyx.disconnect()` with the `connectionID` re
 Onyx.disconnect(connectionID);
 ```
 
-We can also access values inside React functional components via the `useOnyx()` [hook](https://react.dev/reference/react/hooks) (recommended) or class components via the `withOnyx()` [higher order component](https://reactjs.org/docs/higher-order-components.html) (deprecated, not-recommended). When the data changes the component will re-render.
+We can also access values inside React function components via the `useOnyx()` [hook](https://react.dev/reference/react/hooks) (recommended) or class and function components via the `withOnyx()` [higher order component](https://reactjs.org/docs/higher-order-components.html) (deprecated, not-recommended). When the data changes the component will re-render.
 
 ```javascript
 import React from 'react';

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ export default App;
 1. The component mounts with a `reportID={1234}` prop.
 2. The `useOnyx` hook evaluates the mapping and subscribes to the key `reports_1234` using the `reportID` prop.
 3. The `useOnyx` hook fetches the data for the key `reports_1234` from Onyx and sets the state with the initial value (if provided).
-4. Since `policyID` is not defined yet, it defaults to `undefined`. The `useOnyx` hook subscribes to the key `policies_undefined`.
+4. Since `report` is not defined yet, `report?.policyID` defaults to `undefined`. The `useOnyx` hook subscribes to the key `policies_undefined`.
 5. The `useOnyx` hook reads the data and updates the state of the component:
    - `report={{reportID: 1234, policyID: 1, ...rest of the object...}}`   - `policy={undefined}` (since there is no policy with ID `undefined`)
 6. As there is still an `undefined` key, the `useOnyx` hook again evaluates the key `policies_1` after fetching the updated `report` object which has `policyID: 1`.

--- a/README.md
+++ b/README.md
@@ -249,7 +249,8 @@ export default App;
 3. The `useOnyx` hook fetches the data for the key `reports_1234` from Onyx and sets the state with the initial value (if provided).
 4. Since `report` is not defined yet, `report?.policyID` defaults to `undefined`. The `useOnyx` hook subscribes to the key `policies_undefined`.
 5. The `useOnyx` hook reads the data and updates the state of the component:
-   - `report={{reportID: 1234, policyID: 1, ...rest of the object...}}`   - `policy={undefined}` (since there is no policy with ID `undefined`)
+   - `report={{reportID: 1234, policyID: 1, ...rest of the object...}}`
+   - `policy={undefined}` (since there is no policy with ID `undefined`)
 6. As there is still an `undefined` key, the `useOnyx` hook again evaluates the key `policies_1` after fetching the updated `report` object which has `policyID: 1`.
 7. The `useOnyx` hook reads the data and updates the state with:
    - `policy={{policyID: 1, ...rest of the object...}}`

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ export default withOnyx({
 })(App);
 ```
 
-While `Onyx.connect()` gives you more control on how your component reacts as data is fetched from disk, `withOnyx()` will delay the rendering of the wrapped component until all keys/entities have been fetched and passed to the component, this can be convenient for simple cases. This however, can really delay your application if many entities are connected to the same component, you can pass an `initialValue` to each key to allow Onyx to eagerly render your component with this value.
+Differently from `useOnyx()`, `withOnyx()` will delay the rendering of the wrapped component until all keys/entities have been fetched and passed to the component, this can be convenient for simple cases. This however, can really delay your application if many entities are connected to the same component, you can pass an `initialValue` to each key to allow Onyx to eagerly render your component with this value.
 
 ```javascript
 export default withOnyx({

--- a/README.md
+++ b/README.md
@@ -180,7 +180,9 @@ export default withOnyx({
 })(App);
 ```
 
-Additionally, if your component has many keys/entities when your component will mount but will receive many updates as data is fetched from DB and passed down to it, as every key that gets fetched will trigger a `setState` on the `withOnyx` HOC. This might cause re-renders on the initial mounting, preventing the component from mounting/rendering in reasonable time, making your app feel slow and even delaying animations. You can workaround this by passing an additional object with the `shouldDelayUpdates` property set to true. Onyx will then put all the updates in a queue until you decide when then should be applied, the component will receive a function `markReadyForHydration`. A good place to call this function is on the `onLayout` method, which gets triggered after your component has been rendered.
+Additionally, if your component has many keys/entities when your component will mount but will receive many updates as data is fetched from DB and passed down to it, as every key that gets fetched will trigger a `setState` on the `withOnyx` HOC. This might cause re-renders on the initial mounting, preventing the component from mounting/rendering in reasonable time, making your app feel slow and even delaying animations.
+
+You can workaround this by passing an additional object with the `shouldDelayUpdates` property set to true. Onyx will then put all the updates in a queue until you decide when then should be applied, the component will receive a function `markReadyForHydration`. A good place to call this function is on the `onLayout` method, which gets triggered after your component has been rendered.
 
 ```javascript
 const App = ({session, markReadyForHydration}) => (


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

Based on this [Slack 🧵](https://expensify.slack.com/archives/C01GTK53T8Q/p1716888600220139) discussion, this PR is updating the docs to promote the usage of the `useOnyx` hook over the `withOnyx` HOC which is deprecated and should not be used anymore, except if absolutely necessary for example if using React class components where hooks cannot be used.

cc @roryabraham @fabioh8010 

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Manual Tests
<!---
Each set of changes should be tested against the Expensify/App repo on all platforms to verify it does not break our staging App.
--->

### Author Checklist

- [x] I linked the correct issue in the `### Related Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
