### PR TITLE
perf: improve native apps startup

### DIFF
--- a/lib/Onyx.ts
+++ b/lib/Onyx.ts
@@ -156,7 +156,7 @@ function connect<TKey extends OnyxKey>(connectOptions: ConnectOptions<TKey>): nu
 
                     // We did not opt into using waitForCollectionCallback mode so the callback is called for every matching key.
                     OnyxUtils.multiGet(matchingKeys).then((values) => {
-                        values.forEach(([key, val]) => {
+                        values.forEach((val, key) => {
                             OnyxUtils.sendDataToConnection(mapping, val as OnyxValue<TKey>, key as TKey, true);
                         });
                     });

--- a/lib/Onyx.ts
+++ b/lib/Onyx.ts
@@ -155,10 +155,11 @@ function connect<TKey extends OnyxKey>(connectOptions: ConnectOptions<TKey>): nu
                     }
 
                     // We did not opt into using waitForCollectionCallback mode so the callback is called for every matching key.
-                    // eslint-disable-next-line @typescript-eslint/prefer-for-of
-                    for (let i = 0; i < matchingKeys.length; i++) {
-                        OnyxUtils.get(matchingKeys[i]).then((val) => OnyxUtils.sendDataToConnection(mapping, val as OnyxValue<TKey>, matchingKeys[i] as TKey, true));
-                    }
+                    Storage.multiGet(matchingKeys).then((values) => {
+                        values.forEach(([key, val]) => {
+                            OnyxUtils.sendDataToConnection(mapping, val as OnyxValue<TKey>, key as TKey, true);
+                        });
+                    });
                     return;
                 }
 

--- a/lib/Onyx.ts
+++ b/lib/Onyx.ts
@@ -155,7 +155,7 @@ function connect<TKey extends OnyxKey>(connectOptions: ConnectOptions<TKey>): nu
                     }
 
                     // We did not opt into using waitForCollectionCallback mode so the callback is called for every matching key.
-                    Storage.multiGet(matchingKeys).then((values) => {
+                    OnyxUtils.multiGet(matchingKeys).then((values) => {
                         values.forEach(([key, val]) => {
                             OnyxUtils.sendDataToConnection(mapping, val as OnyxValue<TKey>, key as TKey, true);
                         });

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -249,10 +249,13 @@ function get<TKey extends OnyxKey, TValue extends OnyxValue<TKey>>(key: TKey): P
 function multiGet<TKey extends OnyxKey>(keys: CollectionKeyBase[]): Promise<Map<OnyxKey, OnyxValue<TKey>>> {
     // Keys that are not in the cache
     const missingKeys: OnyxKey[] = [];
+
     // Tasks that are pending
     const pendingTasks: Array<Promise<OnyxValue<TKey>>> = [];
+
     // Keys for the tasks that are pending
     const pendingKeys: OnyxKey[] = [];
+
     // Data to be sent back to the invoker
     const dataMap = new Map<OnyxKey, OnyxValue<TKey>>();
 

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -298,7 +298,7 @@ function multiGet<TKey extends OnyxKey>(keys: CollectionKeyBase[]): Promise<Map<
 
                 return Storage.multiGet(missingKeys);
             })
-            // We are going to add the data from the missing keys to the data object and also merge it to the cache.
+            // Add the data from the missing keys to the data map and also merge it to the cache.
             .then((values) => {
                 if (!values || values.length === 0) {
                     return dataMap;

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -282,7 +282,7 @@ function multiGet<TKey extends OnyxKey>(keys: CollectionKeyBase[]): Promise<Map<
 
     return (
         Promise.all(pendingTasks)
-            // We are going to wait for all the pending tasks to resolve and then add the data to the data object.
+            // Wait for all the pending tasks to resolve and then add the data to the data map.
             .then((values) => {
                 values.forEach((value, index) => {
                     dataMap.set(pendingKeys[index], value);

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -29,7 +29,6 @@ import type {
 } from './types';
 import utils from './utils';
 import type {WithOnyxState} from './withOnyx/types';
-import type {KeyValuePairList} from './storage/providers/types';
 
 // Method constants
 const METHOD = {
@@ -247,7 +246,7 @@ function get<TKey extends OnyxKey, TValue extends OnyxValue<TKey>>(key: TKey): P
 }
 
 // multiGet the data first from the cache and then from the storage for the missing keys.
-function multiGet<TKey extends OnyxKey>(keys: CollectionKeyBase[]): Promise<KeyValuePairList> {
+function multiGet<TKey extends OnyxKey>(keys: CollectionKeyBase[]): Promise<Map<OnyxKey, OnyxValue<TKey>>> {
     // Keys that are not in the cache
     const missingKeys: OnyxKey[] = [];
     // Tasks that are pending
@@ -255,12 +254,20 @@ function multiGet<TKey extends OnyxKey>(keys: CollectionKeyBase[]): Promise<KeyV
     // Keys for the tasks that are pending
     const pendingKeys: OnyxKey[] = [];
     // Data to be sent back to the invoker
-    const data: KeyValuePairList = [];
+    const dataMap = new Map<OnyxKey, OnyxValue<TKey>>();
 
+    /**
+     * We are going to iterate over all the matching keys and check if we have the data in the cache.
+     * If we do then we add it to the data object. If we do not then we check if there is a pending task
+     * for the key. If there is then we add the promise to the pendingTasks array and the key to the pendingKeys
+     * array. If there is no pending task then we add the key to the missingKeys array.
+     *
+     * These missingKeys will be later to use to multiGet the data from the storage.
+     */
     keys.forEach((key) => {
         const cacheValue = cache.get(key) as OnyxValue<TKey>;
         if (cacheValue) {
-            data.push([key, cacheValue]);
+            dataMap.set(key, cacheValue);
             return;
         }
 
@@ -278,7 +285,7 @@ function multiGet<TKey extends OnyxKey>(keys: CollectionKeyBase[]): Promise<KeyV
             // We are going to wait for all the pending tasks to resolve and then add the data to the data object.
             .then((values) => {
                 values.forEach((value, index) => {
-                    data.push([pendingKeys[index], value]);
+                    dataMap.set(pendingKeys[index], value);
                 });
 
                 return Promise.resolve();
@@ -292,19 +299,19 @@ function multiGet<TKey extends OnyxKey>(keys: CollectionKeyBase[]): Promise<KeyV
                 return Storage.multiGet(missingKeys);
             })
             // We are going to add the data from the missing keys to the data object and also merge it to the cache.
-            .then((values): Promise<KeyValuePairList> => {
+            .then((values) => {
                 if (!values || values.length === 0) {
-                    return Promise.resolve(data);
+                    return dataMap;
                 }
 
                 // temp object is used to merge the missing data into the cache
                 const temp: OnyxCollection<KeyValueMapping[TKey]> = {};
                 values.forEach(([key, value]) => {
-                    data.push([key, value]);
+                    dataMap.set(key, value as OnyxValue<TKey>);
                     temp[key] = value as OnyxValue<TKey>;
                 });
                 cache.merge(temp);
-                return Promise.resolve(data);
+                return dataMap;
             })
     );
 }
@@ -907,75 +914,10 @@ function addKeyToRecentlyAccessedIfNeeded<TKey extends OnyxKey>(mapping: Mapping
  * Gets the data for a given an array of matching keys, combines them into an object, and sends the result back to the subscriber.
  */
 function getCollectionDataAndSendAsObject<TKey extends OnyxKey>(matchingKeys: CollectionKeyBase[], mapping: Mapping<TKey>): void {
-    // Keys that are not in the cache
-    const missingKeys: OnyxKey[] = [];
-    // Tasks that are pending
-    const pendingTasks: Array<Promise<OnyxValue<TKey>>> = [];
-    // Keys for the tasks that are pending
-    const pendingKeys: OnyxKey[] = [];
-
-    // We are going to combine all the data from the matching keys into a single object
-    const data: OnyxCollection<KeyValueMapping[TKey]> = {};
-
-    /**
-     * We are going to iterate over all the matching keys and check if we have the data in the cache.
-     * If we do then we add it to the data object. If we do not then we check if there is a pending task
-     * for the key. If there is then we add the promise to the pendingTasks array and the key to the pendingKeys
-     * array. If there is no pending task then we add the key to the missingKeys array.
-     *
-     * These missingKeys will be later to use to multiGet the data from the storage.
-     */
-    matchingKeys.forEach((key) => {
-        const cacheValue = cache.get(key) as OnyxValue<TKey>;
-        if (cacheValue) {
-            data[key] = cacheValue;
-            return;
-        }
-
-        const pendingKey = `get:${key}`;
-        if (cache.hasPendingTask(pendingKey)) {
-            pendingTasks.push(cache.getTaskPromise(pendingKey) as Promise<OnyxValue<TKey>>);
-            pendingKeys.push(key);
-        } else {
-            missingKeys.push(key);
-        }
+    multiGet(matchingKeys).then((dataMap) => {
+        const data = Object.fromEntries(dataMap.entries()) as OnyxValue<TKey>;
+        sendDataToConnection(mapping, data, undefined, true);
     });
-
-    Promise.all(pendingTasks)
-        // We are going to wait for all the pending tasks to resolve and then add the data to the data object.
-        .then((values) => {
-            values.forEach((value, index) => {
-                data[pendingKeys[index]] = value;
-            });
-
-            return Promise.resolve();
-        })
-        // We are going to get the missing keys using multiGet from the storage.
-        .then(() => {
-            if (missingKeys.length === 0) {
-                return Promise.resolve(undefined);
-            }
-            return Storage.multiGet(missingKeys);
-        })
-        // We are going to add the data from the missing keys to the data object and also merge it to the cache.
-        .then((values) => {
-            if (!values || values.length === 0) {
-                return Promise.resolve();
-            }
-
-            // temp object is used to merge the missing data into the cache
-            const temp: OnyxCollection<KeyValueMapping[TKey]> = {};
-            values.forEach(([key, value]) => {
-                data[key] = value as OnyxValue<TKey>;
-                temp[key] = value as OnyxValue<TKey>;
-            });
-            cache.merge(temp);
-            return Promise.resolve();
-        })
-        // We are going to send the data to the subscriber.
-        .finally(() => {
-            sendDataToConnection(mapping, data as OnyxValue<TKey>, undefined, true);
-        });
 }
 
 /**

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -258,7 +258,7 @@ function multiGet<TKey extends OnyxKey>(keys: CollectionKeyBase[]): Promise<Map<
 
     /**
      * We are going to iterate over all the matching keys and check if we have the data in the cache.
-     * If we do then we add it to the data object. If we do not then we check if there is a pending task
+     * If we do then we add it to the data object. If we do not have them, then we check if there is a pending task
      * for the key. If there is such task, then we add the promise to the pendingTasks array and the key to the pendingKeys
      * array. If there is no pending task then we add the key to the missingKeys array.
      *

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -259,7 +259,7 @@ function multiGet<TKey extends OnyxKey>(keys: CollectionKeyBase[]): Promise<Map<
     /**
      * We are going to iterate over all the matching keys and check if we have the data in the cache.
      * If we do then we add it to the data object. If we do not then we check if there is a pending task
-     * for the key. If there is then we add the promise to the pendingTasks array and the key to the pendingKeys
+     * for the key. If there is such task, then we add the promise to the pendingTasks array and the key to the pendingKeys
      * array. If there is no pending task then we add the key to the missingKeys array.
      *
      * These missingKeys will be later used to multiGet the data from the storage.

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -262,7 +262,7 @@ function multiGet<TKey extends OnyxKey>(keys: CollectionKeyBase[]): Promise<Map<
      * for the key. If there is then we add the promise to the pendingTasks array and the key to the pendingKeys
      * array. If there is no pending task then we add the key to the missingKeys array.
      *
-     * These missingKeys will be later to use to multiGet the data from the storage.
+     * These missingKeys will be later used to multiGet the data from the storage.
      */
     keys.forEach((key) => {
         const cacheValue = cache.get(key) as OnyxValue<TKey>;

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -290,7 +290,7 @@ function multiGet<TKey extends OnyxKey>(keys: CollectionKeyBase[]): Promise<Map<
 
                 return Promise.resolve();
             })
-            // We are going to get the missing keys using multiGet from the storage.
+            // Get the missing keys using multiGet from the storage.
             .then(() => {
                 if (missingKeys.length === 0) {
                     return Promise.resolve(undefined);

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -17,7 +17,7 @@ function isEmptyObject<T>(obj: T | EmptyValue): obj is EmptyValue {
  */
 function isMergeableObject(value: unknown): value is Record<string, unknown> {
     const isNonNullObject = value != null ? typeof value === 'object' : false;
-    return isNonNullObject && Object.prototype.toString.call(value) !== '[object RegExp]' && Object.prototype.toString.call(value) !== '[object Date]' && !Array.isArray(value);
+    return isNonNullObject && !(value instanceof RegExp) && !(value instanceof Date) && !Array.isArray(value);
 }
 
 /**
@@ -37,9 +37,8 @@ function mergeObject<TObject extends Record<string, unknown>>(target: TObject | 
     // If "shouldRemoveNestedNulls" is true, we want to remove null values from the merged object
     // and therefore we need to omit keys where either the source or target value is null.
     if (targetObject) {
-        const targetKeys = Object.keys(targetObject);
-        for (let i = 0; i < targetKeys.length; ++i) {
-            const key = targetKeys[i];
+        // eslint-disable-next-line no-restricted-syntax, guard-for-in
+        for (const key in targetObject) {
             const sourceValue = source?.[key];
             const targetValue = targetObject?.[key];
 
@@ -58,10 +57,9 @@ function mergeObject<TObject extends Record<string, unknown>>(target: TObject | 
     }
 
     // After copying over all keys from the target object, we want to merge the source object into the destination object.
-    const sourceKeys = Object.keys(source);
-    for (let i = 0; i < sourceKeys.length; ++i) {
-        const key = sourceKeys[i];
-        const sourceValue = source?.[key];
+    // eslint-disable-next-line no-restricted-syntax, guard-for-in
+    for (const key in source) {
+        const sourceValue = source?.[key] as Record<string, unknown>;
         const targetValue = targetObject?.[key];
 
         // If undefined is passed as the source value for a key, we want to generally ignore it.


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

The changes in the PR are part of improving the app startup which was profiled for the native Apps. The main change is explained below, the other changes are self explanatory.

<hr/> 
Prior to the following change, we had 2.4 seconds being consumed in the loop. We can improve this by doing a `multiGet` and then doing a loop over returned keys. This reduces the execution time to 250 ms, saving us 2 seconds.

![Screenshot 2024-06-20 at 6 12 54 PM](https://github.com/Expensify/react-native-onyx/assets/47336142/7fc41b0b-c054-4396-8c66-22868b8afc5b)

Before:
![Screenshot 2024-06-20 at 6 17 19 PM](https://github.com/Expensify/react-native-onyx/assets/47336142/18b0d914-98dc-49c4-85f0-57314add1e78)



After:
![Screenshot 2024-06-20 at 6 18 03 PM](https://github.com/Expensify/react-native-onyx/assets/47336142/b38a33dc-f429-458f-9f78-bce2ac1b853c)



<hr/> 

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/App/issues/43746

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Manual Tests
<!---
Each set of changes should be tested against the Expensify/App repo on all platforms to verify it does not break our staging App.
--->

### Author Checklist

- [X] I linked the correct issue in the `### Related Issues` section above
- [X] I wrote clear testing steps that cover the changes made in this PR
    - [X] I added steps for local testing in the `Tests` section
    - [X] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [X] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [X] I ran the tests on **all platforms** & verified they passed on:
    - [X] Android / native
    - [X] Android / Chrome
    - [X] iOS / native
    - [X] iOS / Safari
    - [X] MacOS / Chrome / Safari
    - [X] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [X] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [X] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [X] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [X] I verified that comments were added to code that is not self explanatory
    - [X] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [X] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [X] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [X] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [X] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [X] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [X] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [X] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [X] I verified that if a function's arguments changed that all usages have also been updated correctly
- [X] If a new component is created I verified that:
    - [X] A similar component doesn't exist in the codebase
    - [X] All props are defined accurately and each prop has a `/** comment above it */`
    - [X] The file is named correctly
    - [X] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [X] The only data being stored in the state is data necessary for rendering and nothing else
    - [X] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [X] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [X] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [X] All JSX used for rendering exists in the render method
    - [X] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [X] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [X] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/react-native-onyx/assets/47336142/a0e2ff33-eb62-45ad-8aed-fb2bddcb18ea


</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/react-native-onyx/assets/47336142/16ab1920-f82f-4b1e-8160-7594bddaa272


</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/react-native-onyx/assets/47336142/a215f721-a281-4937-8ba9-931404a353bd


</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/react-native-onyx/assets/47336142/7f24c6fa-ac8c-482e-842a-1c5f7d778ff9


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/react-native-onyx/assets/47336142/728ef8b3-86c1-404f-8945-276258902834


</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/react-native-onyx/assets/47336142/983b0783-5836-460b-8c26-e5716542f9b9


</details>
