### PR TITLE
Fix useOnyx equality check

### DIFF
--- a/lib/useOnyx.ts
+++ b/lib/useOnyx.ts
@@ -159,12 +159,11 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(key: TKey
             newFetchStatus = 'loaded';
         }
 
-        // We do a deep equality check if we are subscribed to a collection key and `selector` is defined,
-        // since each `OnyxUtils.tryGetCachedValue()` call will generate a plain new collection object with new records as well,
-        // all of them created using the `selector` function.
+        // We do a deep equality check if `selector` is defined, since each `OnyxUtils.tryGetCachedValue()` call will
+        // generate a plain new primitive/object/array that was created using the `selector` function.
         // For the other cases we will only deal with object reference checks, so just a shallow equality check is enough.
         let areValuesEqual: boolean;
-        if (OnyxUtils.isCollectionKey(key) && selectorRef.current) {
+        if (selectorRef.current) {
             areValuesEqual = deepEqual(previousValueRef.current ?? undefined, newValueRef.current);
         } else {
             areValuesEqual = shallowEqual(previousValueRef.current ?? undefined, newValueRef.current);

--- a/lib/useOnyx.ts
+++ b/lib/useOnyx.ts
@@ -159,11 +159,12 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(key: TKey
             newFetchStatus = 'loaded';
         }
 
-        // We do a deep equality check if `selector` is defined, since each `OnyxUtils.tryGetCachedValue()` call will
-        // generate a plain new primitive/object/array that was created using the `selector` function.
+        // We do a deep equality check if we are subscribed to a collection key OR `selector` is defined,
+        // since each `OnyxUtils.tryGetCachedValue()` call will generate a plain new collection object when using a collection key,
+        // or a new primitive/object/array that was created using the `selector` function.
         // For the other cases we will only deal with object reference checks, so just a shallow equality check is enough.
         let areValuesEqual: boolean;
-        if (selectorRef.current) {
+        if (OnyxUtils.isCollectionKey(key) || selectorRef.current) {
             areValuesEqual = deepEqual(previousValueRef.current ?? undefined, newValueRef.current);
         } else {
             areValuesEqual = shallowEqual(previousValueRef.current ?? undefined, newValueRef.current);

--- a/lib/useOnyx.ts
+++ b/lib/useOnyx.ts
@@ -159,12 +159,11 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(key: TKey
             newFetchStatus = 'loaded';
         }
 
-        // We do a deep equality check if we are subscribed to a collection key OR `selector` is defined,
-        // since each `OnyxUtils.tryGetCachedValue()` call will generate a plain new collection object when using a collection key,
-        // or a new primitive/object/array that was created using the `selector` function.
+        // We do a deep equality check if `selector` is defined, since each `OnyxUtils.tryGetCachedValue()` call will
+        // generate a plain new primitive/object/array that was created using the `selector` function.
         // For the other cases we will only deal with object reference checks, so just a shallow equality check is enough.
         let areValuesEqual: boolean;
-        if (OnyxUtils.isCollectionKey(key) || selectorRef.current) {
+        if (selectorRef.current) {
             areValuesEqual = deepEqual(previousValueRef.current ?? undefined, newValueRef.current);
         } else {
             areValuesEqual = shallowEqual(previousValueRef.current ?? undefined, newValueRef.current);

--- a/tests/unit/useOnyxTest.ts
+++ b/tests/unit/useOnyxTest.ts
@@ -198,21 +198,42 @@ describe('useOnyx', () => {
         it('should not change selected data if a property outside that data was changed', async () => {
             Onyx.set(ONYXKEYS.TEST_KEY, {id: 'test_id', name: 'test_name'});
 
-            const {result} = renderHook(() =>
+            // primitive
+            const {result: primitiveResult} = renderHook(() =>
+                useOnyx(ONYXKEYS.TEST_KEY, {
+                    // @ts-expect-error bypass
+                    selector: (entry: OnyxEntry<{id: string; name: string}>) => entry?.id,
+                }),
+            );
+
+            // object
+            const {result: objectResult} = renderHook(() =>
                 useOnyx(ONYXKEYS.TEST_KEY, {
                     // @ts-expect-error bypass
                     selector: (entry: OnyxEntry<{id: string; name: string}>) => ({id: entry?.id}),
                 }),
             );
 
+            // array
+            const {result: arrayResult} = renderHook(() =>
+                useOnyx(ONYXKEYS.TEST_KEY, {
+                    // @ts-expect-error bypass
+                    selector: (entry: OnyxEntry<{id: string; name: string}>) => [{id: entry?.id}],
+                }),
+            );
+
             await act(async () => waitForPromisesToResolve());
 
-            const oldResult = result.current;
+            const oldPrimitiveResult = primitiveResult.current;
+            const oldObjectResult = objectResult.current;
+            const oldArrayResult = arrayResult.current;
 
             await act(async () => Onyx.merge(ONYXKEYS.TEST_KEY, {name: 'test_name_changed'}));
 
             // must be the same reference
-            expect(oldResult).toBe(result.current);
+            expect(oldPrimitiveResult).toBe(primitiveResult.current);
+            expect(oldObjectResult).toBe(objectResult.current);
+            expect(oldArrayResult).toBe(arrayResult.current);
         });
 
         it('should not change selected collection data if a property outside that data was changed', async () => {

--- a/tests/unit/useOnyxTest.ts
+++ b/tests/unit/useOnyxTest.ts
@@ -3,6 +3,7 @@ import type {OnyxEntry} from '../../lib';
 import Onyx, {useOnyx} from '../../lib';
 import waitForPromisesToResolve from '../utils/waitForPromisesToResolve';
 import StorageMock from '../../lib/storage';
+import type GenericCollection from '../utils/GenericCollection';
 
 const ONYXKEYS = {
     TEST_KEY: 'test',
@@ -163,12 +164,11 @@ describe('useOnyx', () => {
         });
 
         it('should return selected data from a collection key', async () => {
-            // @ts-expect-error bypass
             Onyx.mergeCollection(ONYXKEYS.COLLECTION.TEST_KEY, {
                 [`${ONYXKEYS.COLLECTION.TEST_KEY}entry1`]: {id: 'entry1_id', name: 'entry1_name'},
                 [`${ONYXKEYS.COLLECTION.TEST_KEY}entry2`]: {id: 'entry2_id', name: 'entry2_name'},
                 [`${ONYXKEYS.COLLECTION.TEST_KEY}entry3`]: {id: 'entry3_id', name: 'entry3_name'},
-            });
+            } as GenericCollection);
 
             const {result} = renderHook(() =>
                 useOnyx(ONYXKEYS.COLLECTION.TEST_KEY, {
@@ -237,12 +237,11 @@ describe('useOnyx', () => {
         });
 
         it('should not change selected collection data if a property outside that data was changed', async () => {
-            // @ts-expect-error bypass
             Onyx.mergeCollection(ONYXKEYS.COLLECTION.TEST_KEY, {
                 [`${ONYXKEYS.COLLECTION.TEST_KEY}entry1`]: {id: 'entry1_id', name: 'entry1_name'},
                 [`${ONYXKEYS.COLLECTION.TEST_KEY}entry2`]: {id: 'entry2_id', name: 'entry2_name'},
                 [`${ONYXKEYS.COLLECTION.TEST_KEY}entry3`]: {id: 'entry3_id', name: 'entry3_name'},
-            });
+            } as GenericCollection);
 
             const {result} = renderHook(() =>
                 useOnyx(ONYXKEYS.COLLECTION.TEST_KEY, {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details

This PR fixes an incorrect equality check `useOnyx` does when returning selected data as array of objects, that was causing an infinite loop in E/App.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/App/pull/44724

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Manual Tests
<!---
Each set of changes should be tested against the Expensify/App repo on all platforms to verify it does not break our staging App.
--->

### Author Checklist

- [x] I linked the correct issue in the `### Related Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>


https://github.com/Expensify/react-native-onyx/assets/20051562/58224667-dde2-4a72-b0ab-d331cb1715a9






</details>

<details>
<summary>Android: mWeb Chrome</summary>





https://github.com/Expensify/react-native-onyx/assets/20051562/31881323-7ffc-4a5c-8f46-526b1fff7d49



</details>

<details>
<summary>iOS: Native</summary>

https://github.com/Expensify/react-native-onyx/assets/20051562/19d3f4eb-bb2a-457e-a116-ad988b17a85a

</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/Expensify/react-native-onyx/assets/20051562/4a4a5d3b-9fb5-400c-81e3-b576b529e569

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>


https://github.com/Expensify/react-native-onyx/assets/20051562/8831c068-ff2e-4dcd-b28b-1a88fd639283


https://github.com/Expensify/react-native-onyx/assets/20051562/6d376501-383d-42ef-bd38-2f131ee90764



</details>

<details>
<summary>MacOS: Desktop</summary>


https://github.com/Expensify/react-native-onyx/assets/20051562/eb8ef5ed-5891-4d8a-b8ca-6ee12108d3cc



</details>
