### PR TITLE
fix: `Onyx.clear` handle collections and regular keys with an underscore

### DIFF
--- a/lib/Onyx.ts
+++ b/lib/Onyx.ts
@@ -554,22 +554,27 @@ function mergeCollection<TKey extends CollectionKeyBase, TMap>(collectionKey: TK
  * @param keysToPreserve is a list of ONYXKEYS that should not be cleared with the rest of the data
  */
 function clear(keysToPreserve: OnyxKey[] = []): Promise<void> {
+    const defaultKeyStates = OnyxUtils.getDefaultKeyStates();
+    const initialKeys = Object.keys(defaultKeyStates);
+
     return OnyxUtils.getAllKeys()
-        .then((keys) => {
+        .then((cachedKeys) => {
             cache.clearNullishStorageKeys();
 
             const keysToBeClearedFromStorage: OnyxKey[] = [];
             const keyValuesToResetAsCollection: Record<OnyxKey, OnyxCollection<KeyValueMapping[OnyxKey]>> = {};
             const keyValuesToResetIndividually: KeyValueMapping = {};
 
+            const allKeys = new Set([...cachedKeys, ...initialKeys]);
+
             // The only keys that should not be cleared are:
             // 1. Anything specifically passed in keysToPreserve (because some keys like language preferences, offline
             //      status, or activeClients need to remain in Onyx even when signed out)
             // 2. Any keys with a default state (because they need to remain in Onyx as their default, and setting them
             //      to null would cause unknown behavior)
-            keys.forEach((key) => {
+            //   2.1 However, if a default key was explicitly set to null, we need to reset it to the default value
+            allKeys.forEach((key) => {
                 const isKeyToPreserve = keysToPreserve.includes(key);
-                const defaultKeyStates = OnyxUtils.getDefaultKeyStates();
                 const isDefaultKey = key in defaultKeyStates;
 
                 // If the key is being removed or reset to default:
@@ -611,7 +616,6 @@ function clear(keysToPreserve: OnyxKey[] = []): Promise<void> {
                 updatePromises.push(OnyxUtils.scheduleNotifyCollectionSubscribers(key, value));
             });
 
-            const defaultKeyStates = OnyxUtils.getDefaultKeyStates();
             const defaultKeyValuePairs = Object.entries(
                 Object.keys(defaultKeyStates)
                     .filter((key) => !keysToPreserve.includes(key))

--- a/lib/Onyx.ts
+++ b/lib/Onyx.ts
@@ -586,12 +586,14 @@ function clear(keysToPreserve: OnyxKey[] = []): Promise<void> {
                     const newValue = defaultKeyStates[key] ?? null;
                     if (newValue !== oldValue) {
                         cache.set(key, newValue);
-                        const collectionKey = key.substring(0, key.indexOf('_') + 1);
-                        if (collectionKey) {
+
+                        const potentialCollectionKey = OnyxUtils.getCollectionKey(key);
+                        if (OnyxUtils.isCollectionKey(potentialCollectionKey)) {
+                            const [collectionKey, memberKey] = OnyxUtils.splitCollectionMemberKey(key);
                             if (!keyValuesToResetAsCollection[collectionKey]) {
                                 keyValuesToResetAsCollection[collectionKey] = {};
                             }
-                            keyValuesToResetAsCollection[collectionKey]![key] = newValue ?? undefined;
+                            keyValuesToResetAsCollection[collectionKey]![memberKey] = newValue ?? undefined;
                         } else {
                             keyValuesToResetIndividually[key] = newValue ?? undefined;
                         }
@@ -612,6 +614,7 @@ function clear(keysToPreserve: OnyxKey[] = []): Promise<void> {
             Object.entries(keyValuesToResetIndividually).forEach(([key, value]) => {
                 updatePromises.push(OnyxUtils.scheduleSubscriberUpdate(key, value, cache.get(key, false)));
             });
+            console.log(keyValuesToResetAsCollection);
             Object.entries(keyValuesToResetAsCollection).forEach(([key, value]) => {
                 updatePromises.push(OnyxUtils.scheduleNotifyCollectionSubscribers(key, value));
             });

--- a/lib/Onyx.ts
+++ b/lib/Onyx.ts
@@ -587,13 +587,12 @@ function clear(keysToPreserve: OnyxKey[] = []): Promise<void> {
                     if (newValue !== oldValue) {
                         cache.set(key, newValue);
 
-                        const potentialCollectionKey = OnyxUtils.getCollectionKey(key);
-                        if (OnyxUtils.isCollectionKey(potentialCollectionKey)) {
-                            const [collectionKey, memberKey] = OnyxUtils.splitCollectionMemberKey(key);
+                        const collectionKey = OnyxUtils.getCollectionKey(key);
+                        if (OnyxUtils.isCollectionKey(collectionKey)) {
                             if (!keyValuesToResetAsCollection[collectionKey]) {
                                 keyValuesToResetAsCollection[collectionKey] = {};
                             }
-                            keyValuesToResetAsCollection[collectionKey]![memberKey] = newValue ?? undefined;
+                            keyValuesToResetAsCollection[collectionKey]![key] = newValue ?? undefined;
                         } else {
                             keyValuesToResetIndividually[key] = newValue ?? undefined;
                         }

--- a/lib/Onyx.ts
+++ b/lib/Onyx.ts
@@ -614,7 +614,6 @@ function clear(keysToPreserve: OnyxKey[] = []): Promise<void> {
             Object.entries(keyValuesToResetIndividually).forEach(([key, value]) => {
                 updatePromises.push(OnyxUtils.scheduleSubscriberUpdate(key, value, cache.get(key, false)));
             });
-            console.log(keyValuesToResetAsCollection);
             Object.entries(keyValuesToResetAsCollection).forEach(([key, value]) => {
                 updatePromises.push(OnyxUtils.scheduleNotifyCollectionSubscribers(key, value));
             });

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -403,14 +403,16 @@ function isCollectionMemberKey<TCollectionKey extends CollectionKeyBase>(collect
  * @param key - The collection member key to split.
  * @returns A tuple where the first element is the collection part and the second element is the ID part.
  */
-function splitCollectionMemberKey<TKey extends CollectionKey>(key: TKey): [TKey extends `${infer Prefix}_${string}` ? `${Prefix}_` : never, string] {
+function splitCollectionMemberKey<TKey extends CollectionKey, CollectionKeyType = TKey extends `${infer Prefix}_${string}` ? `${Prefix}_` : never>(key: TKey): [CollectionKeyType, string] {
     const underscoreIndex = key.lastIndexOf('_');
 
     if (underscoreIndex === -1) {
         throw new Error(`Invalid ${key} key provided, only collection keys are allowed.`);
     }
 
-    return [key.substring(0, underscoreIndex + 1) as TKey extends `${infer Prefix}_${string}` ? `${Prefix}_` : never, key.substring(underscoreIndex + 1)];
+    const collectionKey = key.substring(0, underscoreIndex + 1) as CollectionKeyType;
+    const memberKey = key.substring(underscoreIndex + 1);
+    return [collectionKey, memberKey];
 }
 
 /**

--- a/tests/unit/onyxTest.ts
+++ b/tests/unit/onyxTest.ts
@@ -9,6 +9,8 @@ import type GenericCollection from '../utils/GenericCollection';
 const ONYX_KEYS = {
     TEST_KEY: 'test',
     OTHER_TEST: 'otherTest',
+    // Special case: this key is not a collection key, but it has an underscore in its name
+    KEY_WITH_UNDERSCORE: 'nvp_test',
     COLLECTION: {
         TEST_KEY: 'test_',
         TEST_CONNECT_COLLECTION: 'testConnectCollection_',
@@ -25,6 +27,7 @@ Onyx.init({
     keys: ONYX_KEYS,
     initialKeyStates: {
         [ONYX_KEYS.OTHER_TEST]: 42,
+        [ONYX_KEYS.KEY_WITH_UNDERSCORE]: 'default',
     },
 });
 
@@ -196,6 +199,35 @@ describe('Onyx', () => {
                 expect(mockCallback).toHaveBeenCalledTimes(0);
 
                 return Onyx.disconnect(otherTestConnectionID);
+            });
+    });
+
+    it('should notify key subscribers that use a underscore in their name', () => {
+        const mockCallback = jest.fn();
+        connectionID = Onyx.connect({
+            key: ONYX_KEYS.KEY_WITH_UNDERSCORE,
+            callback: mockCallback,
+        });
+
+        return waitForPromisesToResolve()
+            .then(() => mockCallback.mockReset())
+            .then(() => Onyx.set(ONYX_KEYS.KEY_WITH_UNDERSCORE, 'test'))
+            .then(() => {
+                expect(mockCallback).toHaveBeenCalledTimes(1);
+                expect(mockCallback).toHaveBeenLastCalledWith('test', ONYX_KEYS.KEY_WITH_UNDERSCORE);
+                mockCallback.mockReset();
+                return Onyx.clear();
+            })
+            .then(() => {
+                expect(mockCallback).toHaveBeenCalledTimes(1);
+                expect(mockCallback).toHaveBeenCalledWith('default', ONYX_KEYS.KEY_WITH_UNDERSCORE);
+            })
+            .then(() => Onyx.set(ONYX_KEYS.KEY_WITH_UNDERSCORE, 'default'))
+            .then(() => mockCallback.mockReset())
+            .then(() => Onyx.set(ONYX_KEYS.KEY_WITH_UNDERSCORE, 'test'))
+            .then(() => {
+                expect(mockCallback).toHaveBeenCalledTimes(1);
+                expect(mockCallback).toHaveBeenCalledWith('test', ONYX_KEYS.KEY_WITH_UNDERSCORE);
             });
     });
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

**Warning: This PR is based on this PR, which should be merged before this one:**

- https://github.com/Expensify/react-native-onyx/pull/573

(otherwise some tests of this PR would fail)

-----

The clear method wasn't working correctly for keys that have an underscore in their name, but are none-collection keys (e.g. `nvp_isFirstTimeNewExpensifyUser`).

With this PR and the aforementioned all expensify tests are passing (right now, [when bumping to latest they are broken](https://github.com/Expensify/App/pull/46297#issuecomment-2252785350) due to this [PR](https://github.com/Expensify/react-native-onyx/pull/570))

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/react-native-onyx/issues/569

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

Added a test that will run a bunch of modifications to a key which is using an underscore for its name. The succession of changes would fail without these changes.

### Manual Tests
<!---
Each set of changes should be tested against the Expensify/App repo on all platforms to verify it does not break our staging App.
--->

n/a, confirmed that the expensify test suite is passing

### Author Checklist

- [x] I linked the correct issue in the `### Related Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos

Note: Only tested and web and assumed other platforms to work (as this only concerned the .clear method which is called during logout)

<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->



https://github.com/user-attachments/assets/f857a4f5-15a8-4a01-bfd2-6dc98fc8a96d


</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
