### PR TITLE
perf: avoid re-calculating collection key length and use key.startsWith

### DIFF
--- a/lib/Onyx.ts
+++ b/lib/Onyx.ts
@@ -645,6 +645,7 @@ function updateSnapshots(data: OnyxUpdate[]) {
     const promises: Array<() => Promise<void>> = [];
 
     const snapshotCollection = OnyxUtils.getCachedCollection(snapshotCollectionKey);
+    const snapshotCollectionKeyLength = snapshotCollectionKey.length;
 
     Object.entries(snapshotCollection).forEach(([snapshotKey, snapshotValue]) => {
         // Snapshots may not be present in cache. We don't know how to update them so we skip.
@@ -656,7 +657,7 @@ function updateSnapshots(data: OnyxUpdate[]) {
 
         data.forEach(({key, value}) => {
             // snapshots are normal keys so we want to skip update if they are written to Onyx
-            if (OnyxUtils.isCollectionMemberKey(snapshotCollectionKey, key)) {
+            if (OnyxUtils.isCollectionMemberKey(snapshotCollectionKey, key, snapshotCollectionKeyLength)) {
                 return;
             }
 

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -384,7 +384,7 @@ function isCollectionKey(key: OnyxKey): key is CollectionKeyBase {
 }
 
 function isCollectionMemberKey<TCollectionKey extends CollectionKeyBase>(collectionKey: TCollectionKey, key: string): key is `${TCollectionKey}${string}` {
-    return Str.startsWith(key, collectionKey) && key.length > collectionKey.length;
+    return key.startsWith(collectionKey) && key.length > collectionKey.length;
 }
 
 /**

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -395,7 +395,7 @@ function isCollectionKey(key: OnyxKey): key is CollectionKeyBase {
 }
 
 function isCollectionMemberKey<TCollectionKey extends CollectionKeyBase>(collectionKey: TCollectionKey, key: string, collectionKeyLength: number): key is `${TCollectionKey}${string}` {
-    return Str.startsWith(key, collectionKey) && key.length > collectionKeyLength;
+    return key.startsWith(collectionKey) && key.length > collectionKeyLength;
 }
 
 /**

--- a/lib/useOnyx.ts
+++ b/lib/useOnyx.ts
@@ -109,7 +109,11 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(key: TKey
             const previousCollectionKey = OnyxUtils.splitCollectionMemberKey(previousKey)[0];
             const collectionKey = OnyxUtils.splitCollectionMemberKey(key)[0];
 
-            if (OnyxUtils.isCollectionMemberKey(previousCollectionKey, previousKey) && OnyxUtils.isCollectionMemberKey(collectionKey, key) && previousCollectionKey === collectionKey) {
+            if (
+                OnyxUtils.isCollectionMemberKey(previousCollectionKey, previousKey, previousCollectionKey.length) &&
+                OnyxUtils.isCollectionMemberKey(collectionKey, key, collectionKey.length) &&
+                previousCollectionKey === collectionKey
+            ) {
                 return;
             }
         } catch (e) {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

This PR is part of performance improvements based on https://github.com/Expensify/App/issues/45528. Based on the provided trace, we see that the `isCollectionMemberKey` takes around ~270ms as a whole. For a function, which is called repeatedly in a loop, this seems too much.

We couldn't reproduce the same behaviour as of the provided trace because we have accounts with less data, so we decided to benchmark the current implementation of `isCollectionMemberKey` and the improved implementation. In the latter, we propose to pass the `collectionKey.length` as a constant, which means do not re-calculate this in a loop. Which can happen when `isCollectionMemberKey` is called in a loop.

Let's take a look below at the results:

![Screenshot 2024-08-05 at 7 33 38 PM](https://github.com/user-attachments/assets/f3bb7c8c-a903-4cff-b99d-7cb8c27016e2)


The improved case outperforms the baseline by being able to perform _**4k more operations per second**_. The two cases are just the same with just one exception and that is in the improved one, we are not accessing the `collectionKey.length` each time.

The next improvement we propose is to avoid using `Str.startsWith` as it has additional checks using `typeof` operators. We can instead use `key.startsWith(collectionKey)` which is able to perform better on large data. See the benchmarks of above improvement combined against the baseline:

![Screenshot 2024-08-06 at 1 08 50 PM](https://github.com/user-attachments/assets/41996429-e282-45f5-91d9-24924f6567dc)

With both improvements combined, we get _**8k more operations per second**_ as compared to the baseline.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/App/issues/45528

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Manual Tests
<!---
Each set of changes should be tested against the Expensify/App repo on all platforms to verify it does not break our staging App.
--->

### Author Checklist

- [x] I linked the correct issue in the `### Related Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [X] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/74b09c52-36a4-45f8-abdf-58892f454185


</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/ab6298b4-af0f-43f0-97a3-1ba313666d65


</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/e431b7f1-a111-4b87-9872-8d6df09326b3


</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/68749bb1-8aca-45b3-adc2-7750beea63b4


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/70109d56-66da-4e2f-a997-bce249245bf1


</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/59bfbbbf-974d-45fa-acde-4d8930087cd9


</details>
