### PR TITLE
Fix `getCollectionKey()` and `splitCollectionMemberKey()` logic to consider more possibilities of keys / collection keys

### DIFF
--- a/API-INTERNAL.md
+++ b/API-INTERNAL.md
@@ -68,8 +68,9 @@ or if the provided key is a collection member key (in case our configured key is
 <p>For example:</p>
 <ul>
 <li><code>getCollectionKey(&quot;report_123&quot;)</code> would return &quot;report_&quot;</li>
-<li><code>getCollectionKey(&quot;report&quot;)</code> would return &quot;report&quot;</li>
 <li><code>getCollectionKey(&quot;report_&quot;)</code> would return &quot;report_&quot;</li>
+<li><code>getCollectionKey(&quot;report_-1_something&quot;)</code> would return &quot;report_&quot;</li>
+<li><code>getCollectionKey(&quot;sharedNVP_user_-1_something&quot;)</code> would return &quot;sharedNVP_user_&quot;</li>
 </ul>
 </dd>
 <dt><a href="#tryGetCachedValue">tryGetCachedValue()</a></dt>
@@ -297,11 +298,12 @@ It extracts the non-numeric collection identifier of a given key.
 
 For example:
 - `getCollectionKey("report_123")` would return "report_"
-- `getCollectionKey("report")` would return "report"
 - `getCollectionKey("report_")` would return "report_"
+- `getCollectionKey("report_-1_something")` would return "report_"
+- `getCollectionKey("sharedNVP_user_-1_something")` would return "sharedNVP_user_"
 
 **Kind**: global function  
-**Returns**: <code>string</code> - The pure key without any numeric  
+**Returns**: <code>string</code> - The plain collection key.  
 
 | Param | Type | Description |
 | --- | --- | --- |

--- a/lib/Onyx.ts
+++ b/lib/Onyx.ts
@@ -479,8 +479,15 @@ function clear(keysToPreserve: OnyxKey[] = []): Promise<void> {
                     if (newValue !== oldValue) {
                         cache.set(key, newValue);
 
-                        const collectionKey = OnyxUtils.getCollectionKey(key);
-                        if (OnyxUtils.isCollectionKey(collectionKey)) {
+                        let collectionKey: string | undefined;
+                        try {
+                            collectionKey = OnyxUtils.getCollectionKey(key);
+                        } catch (e) {
+                            // If getCollectionKey() throws an error it means the key is not a collection key.
+                            collectionKey = undefined;
+                        }
+
+                        if (collectionKey) {
                             if (!keyValuesToResetAsCollection[collectionKey]) {
                                 keyValuesToResetAsCollection[collectionKey] = {};
                             }

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -421,15 +421,39 @@ function isCollectionMemberKey<TCollectionKey extends CollectionKeyBase>(collect
  * @returns A tuple where the first element is the collection part and the second element is the ID part.
  */
 function splitCollectionMemberKey<TKey extends CollectionKey, CollectionKeyType = TKey extends `${infer Prefix}_${string}` ? `${Prefix}_` : never>(key: TKey): [CollectionKeyType, string] {
-    const underscoreIndex = key.lastIndexOf('_');
+    // let collectionKey: string;
+    // let memberKey: string;
 
-    if (underscoreIndex === -1) {
-        throw new Error(`Invalid ${key} key provided, only collection keys are allowed.`);
+    // const firstUnderscoreIndex = key.indexOf('_');
+    // collectionKey = key.substring(0, firstUnderscoreIndex + 1);
+    // if (isCollectionKey(collectionKey)) {
+    //     memberKey = key.substring(firstUnderscoreIndex + 1);
+    //     return [collectionKey as CollectionKeyType, memberKey];
+    // }
+
+    // const lastUnderscoreIndex = key.lastIndexOf('_');
+    // collectionKey = key.substring(0, lastUnderscoreIndex + 1);
+    // if (isCollectionKey(collectionKey)) {
+    //     memberKey = key.substring(lastUnderscoreIndex + 1);
+    //     return [collectionKey as CollectionKeyType, memberKey];
+    // }
+
+    // throw new Error(`Invalid '${key}' key provided, only collection keys are allowed.`);
+
+    ////////
+
+    const collectionKeys = OnyxUtils.getCollectionKeys();
+
+    for (const collectionKey of collectionKeys) {
+        console.log(collectionKey);
+        // Check if the string starts with the current key
+        if (key.startsWith(collectionKey)) {
+            // Return the key and the rest of the string after the key
+            return [collectionKey as CollectionKeyType, key.slice(collectionKey.length)];
+        }
     }
 
-    const collectionKey = key.substring(0, underscoreIndex + 1) as CollectionKeyType;
-    const memberKey = key.substring(underscoreIndex + 1);
-    return [collectionKey, memberKey];
+    throw new Error(`Invalid '${key}' key provided, only collection keys are allowed.`);
 }
 
 /**

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -421,36 +421,21 @@ function isCollectionMemberKey<TCollectionKey extends CollectionKeyBase>(collect
  * @returns A tuple where the first element is the collection part and the second element is the ID part.
  */
 function splitCollectionMemberKey<TKey extends CollectionKey, CollectionKeyType = TKey extends `${infer Prefix}_${string}` ? `${Prefix}_` : never>(key: TKey): [CollectionKeyType, string] {
-    // let collectionKey: string;
-    // let memberKey: string;
+    // Start by finding the position of the last underscore in the string
+    let lastUnderscoreIndex = key.lastIndexOf('_');
 
-    // const firstUnderscoreIndex = key.indexOf('_');
-    // collectionKey = key.substring(0, firstUnderscoreIndex + 1);
-    // if (isCollectionKey(collectionKey)) {
-    //     memberKey = key.substring(firstUnderscoreIndex + 1);
-    //     return [collectionKey as CollectionKeyType, memberKey];
-    // }
+    // Iterate backwards to find the longest key that ends with '_'
+    while (lastUnderscoreIndex > 0) {
+        const possibleKey = key.slice(0, lastUnderscoreIndex + 1);
 
-    // const lastUnderscoreIndex = key.lastIndexOf('_');
-    // collectionKey = key.substring(0, lastUnderscoreIndex + 1);
-    // if (isCollectionKey(collectionKey)) {
-    //     memberKey = key.substring(lastUnderscoreIndex + 1);
-    //     return [collectionKey as CollectionKeyType, memberKey];
-    // }
-
-    // throw new Error(`Invalid '${key}' key provided, only collection keys are allowed.`);
-
-    ////////
-
-    const collectionKeys = OnyxUtils.getCollectionKeys();
-
-    for (const collectionKey of collectionKeys) {
-        console.log(collectionKey);
-        // Check if the string starts with the current key
-        if (key.startsWith(collectionKey)) {
-            // Return the key and the rest of the string after the key
-            return [collectionKey as CollectionKeyType, key.slice(collectionKey.length)];
+        // Check if the substring is a key in the Set
+        if (isCollectionKey(possibleKey)) {
+            // Return the matching key and the rest of the string
+            return [possibleKey as CollectionKeyType, key.slice(lastUnderscoreIndex + 1)];
         }
+
+        // Move to the next underscore to check smaller possible keys
+        lastUnderscoreIndex = key.lastIndexOf('_', lastUnderscoreIndex - 1);
     }
 
     throw new Error(`Invalid '${key}' key provided, only collection keys are allowed.`);

--- a/tests/unit/onyxUtilsTest.ts
+++ b/tests/unit/onyxUtilsTest.ts
@@ -17,50 +17,62 @@ Onyx.init({
 beforeEach(() => Onyx.clear());
 
 describe('OnyxUtils', () => {
-    describe('splitCollectionMemberKey should return correct values', () => {
-        const dataResult: Record<string, [string, string]> = {
-            test_: ['test_', ''],
-            test_level_: ['test_level_', ''],
-            test_level_1: ['test_level_', '1'],
-            test_level_2: ['test_level_', '2'],
-            test_level_last_3: ['test_level_last_', '3'],
-            test___FAKE__: ['test_', '__FAKE__'],
-            'test_-1_something': ['test_', '-1_something'],
-            'test_level_-1_something': ['test_level_', '-1_something'],
-        };
+    describe('splitCollectionMemberKey', () => {
+        describe('should return correct values', () => {
+            const dataResult: Record<string, [string, string]> = {
+                test_: ['test_', ''],
+                test_level_: ['test_level_', ''],
+                test_level_1: ['test_level_', '1'],
+                test_level_2: ['test_level_', '2'],
+                test_level_last_3: ['test_level_last_', '3'],
+                test___FAKE__: ['test_', '__FAKE__'],
+                'test_-1_something': ['test_', '-1_something'],
+                'test_level_-1_something': ['test_level_', '-1_something'],
+            };
 
-        it.each(Object.keys(dataResult))('%s', (key) => {
-            const [collectionKey, id] = OnyxUtils.splitCollectionMemberKey(key);
-            expect(collectionKey).toEqual(dataResult[key][0]);
-            expect(id).toEqual(dataResult[key][1]);
+            it.each(Object.keys(dataResult))('%s', (key) => {
+                const [collectionKey, id] = OnyxUtils.splitCollectionMemberKey(key);
+                expect(collectionKey).toEqual(dataResult[key][0]);
+                expect(id).toEqual(dataResult[key][1]);
+            });
+        });
+
+        it('should throw error if key does not contain underscore', () => {
+            expect(() => {
+                OnyxUtils.splitCollectionMemberKey(ONYXKEYS.TEST_KEY);
+            }).toThrowError("Invalid 'test' key provided, only collection keys are allowed.");
+            expect(() => {
+                OnyxUtils.splitCollectionMemberKey('');
+            }).toThrowError("Invalid '' key provided, only collection keys are allowed.");
         });
     });
 
-    it('splitCollectionMemberKey should throw error if key does not contain underscore', () => {
-        expect(() => {
-            OnyxUtils.splitCollectionMemberKey(ONYXKEYS.TEST_KEY);
-        }).toThrowError("Invalid 'test' key provided, only collection keys are allowed.");
-        expect(() => {
-            OnyxUtils.splitCollectionMemberKey('');
-        }).toThrowError("Invalid '' key provided, only collection keys are allowed.");
-    });
+    describe('getCollectionKey', () => {
+        describe('should return correct values', () => {
+            const dataResult: Record<string, string> = {
+                test_: 'test_',
+                test_level_: 'test_level_',
+                test_level_1: 'test_level_',
+                test_level_2: 'test_level_',
+                test_level_last_3: 'test_level_last_',
+                test___FAKE__: 'test_',
+                'test_-1_something': 'test_',
+                'test_level_-1_something': 'test_level_',
+            };
 
-    describe('getCollectionKey should return correct values', () => {
-        const dataResult: Record<string, string> = {
-            test: 'test',
-            test_: 'test_',
-            test_level_: 'test_level_',
-            test_level_1: 'test_level_',
-            test_level_2: 'test_level_',
-            test_level_last_3: 'test_level_last_',
-            test___FAKE__: 'test_',
-            'test_-1_something': 'test_',
-            'test_level_-1_something': 'test_level_',
-        };
+            it.each(Object.keys(dataResult))('%s', (key) => {
+                const collectionKey = OnyxUtils.getCollectionKey(key);
+                expect(collectionKey).toEqual(dataResult[key]);
+            });
+        });
 
-        it.each(Object.keys(dataResult))('%s', (key) => {
-            const collectionKey = OnyxUtils.getCollectionKey(key);
-            expect(collectionKey).toEqual(dataResult[key]);
+        it('should throw error if key does not contain underscore', () => {
+            expect(() => {
+                OnyxUtils.getCollectionKey(ONYXKEYS.TEST_KEY);
+            }).toThrowError("Invalid 'test' key provided, only collection keys are allowed.");
+            expect(() => {
+                OnyxUtils.getCollectionKey('');
+            }).toThrowError("Invalid '' key provided, only collection keys are allowed.");
         });
     });
 });

--- a/tests/unit/onyxUtilsTest.ts
+++ b/tests/unit/onyxUtilsTest.ts
@@ -38,14 +38,14 @@ describe('OnyxUtils', () => {
 
     it('splitCollectionMemberKey should throw error if key does not contain underscore', () => {
         expect(() => {
-            OnyxUtils.splitCollectionMemberKey('test');
+            OnyxUtils.splitCollectionMemberKey(ONYXKEYS.TEST_KEY);
         }).toThrowError("Invalid 'test' key provided, only collection keys are allowed.");
         expect(() => {
             OnyxUtils.splitCollectionMemberKey('');
         }).toThrowError("Invalid '' key provided, only collection keys are allowed.");
     });
 
-    it('getCollectionKey should return correct values', () => {
+    describe('getCollectionKey should return correct values', () => {
         const dataResult: Record<string, string> = {
             test: 'test',
             test_: 'test_',
@@ -53,9 +53,11 @@ describe('OnyxUtils', () => {
             test_level_1: 'test_level_',
             test_level_2: 'test_level_',
             test_level_last_3: 'test_level_last_',
+            'test_-1_something': 'test_',
+            'test_level_-1_something': 'test_level_',
         };
 
-        Object.keys(dataResult).forEach((key) => {
+        it.each(Object.keys(dataResult))('%s', (key) => {
             const collectionKey = OnyxUtils.getCollectionKey(key);
             expect(collectionKey).toEqual(dataResult[key]);
         });

--- a/tests/unit/onyxUtilsTest.ts
+++ b/tests/unit/onyxUtilsTest.ts
@@ -53,6 +53,7 @@ describe('OnyxUtils', () => {
             test_level_1: 'test_level_',
             test_level_2: 'test_level_',
             test_level_last_3: 'test_level_last_',
+            test___FAKE__: 'test_',
             'test_-1_something': 'test_',
             'test_level_-1_something': 'test_level_',
         };

--- a/tests/unit/onyxUtilsTest.ts
+++ b/tests/unit/onyxUtilsTest.ts
@@ -17,7 +17,7 @@ Onyx.init({
 beforeEach(() => Onyx.clear());
 
 describe('OnyxUtils', () => {
-    it('splitCollectionMemberKey should return correct values', () => {
+    describe('splitCollectionMemberKey should return correct values', () => {
         const dataResult: Record<string, [string, string]> = {
             test_: ['test_', ''],
             test_level_: ['test_level_', ''],
@@ -29,7 +29,7 @@ describe('OnyxUtils', () => {
             'test_level_-1_something': ['test_level_', '-1_something'],
         };
 
-        Object.keys(dataResult).forEach((key) => {
+        test.each(Object.keys(dataResult))('%s', (key) => {
             const [collectionKey, id] = OnyxUtils.splitCollectionMemberKey(key);
             expect(collectionKey).toEqual(dataResult[key][0]);
             expect(id).toEqual(dataResult[key][1]);

--- a/tests/unit/onyxUtilsTest.ts
+++ b/tests/unit/onyxUtilsTest.ts
@@ -1,4 +1,20 @@
+import Onyx from '../../lib';
 import OnyxUtils from '../../lib/OnyxUtils';
+
+const ONYXKEYS = {
+    TEST_KEY: 'test',
+    COLLECTION: {
+        TEST_KEY: 'test_',
+        TEST_LEVEL_KEY: 'test_level_',
+        TEST_LEVEL_LAST_KEY: 'test_level_',
+    },
+};
+
+Onyx.init({
+    keys: ONYXKEYS,
+});
+
+beforeEach(() => Onyx.clear());
 
 describe('OnyxUtils', () => {
     it('splitCollectionMemberKey should return correct values', () => {
@@ -8,6 +24,9 @@ describe('OnyxUtils', () => {
             test_level_1: ['test_level_', '1'],
             test_level_2: ['test_level_', '2'],
             test_level_last_3: ['test_level_last_', '3'],
+            test___FAKE__: ['test_', '__FAKE__'],
+            'test_-1_something': ['test_', '-1_something'],
+            'test_level_-1_something': ['test_level_', '-1_something'],
         };
 
         Object.keys(dataResult).forEach((key) => {
@@ -20,10 +39,10 @@ describe('OnyxUtils', () => {
     it('splitCollectionMemberKey should throw error if key does not contain underscore', () => {
         expect(() => {
             OnyxUtils.splitCollectionMemberKey('test');
-        }).toThrowError('Invalid test key provided, only collection keys are allowed.');
+        }).toThrowError("Invalid 'test' key provided, only collection keys are allowed.");
         expect(() => {
             OnyxUtils.splitCollectionMemberKey('');
-        }).toThrowError('Invalid  key provided, only collection keys are allowed.');
+        }).toThrowError("Invalid '' key provided, only collection keys are allowed.");
     });
 
     it('getCollectionKey should return correct values', () => {

--- a/tests/unit/onyxUtilsTest.ts
+++ b/tests/unit/onyxUtilsTest.ts
@@ -6,7 +6,7 @@ const ONYXKEYS = {
     COLLECTION: {
         TEST_KEY: 'test_',
         TEST_LEVEL_KEY: 'test_level_',
-        TEST_LEVEL_LAST_KEY: 'test_level_',
+        TEST_LEVEL_LAST_KEY: 'test_level_last_',
     },
 };
 

--- a/tests/unit/onyxUtilsTest.ts
+++ b/tests/unit/onyxUtilsTest.ts
@@ -29,7 +29,7 @@ describe('OnyxUtils', () => {
             'test_level_-1_something': ['test_level_', '-1_something'],
         };
 
-        test.each(Object.keys(dataResult))('%s', (key) => {
+        it.each(Object.keys(dataResult))('%s', (key) => {
             const [collectionKey, id] = OnyxUtils.splitCollectionMemberKey(key);
             expect(collectionKey).toEqual(dataResult[key][0]);
             expect(id).toEqual(dataResult[key][1]);

--- a/tests/unit/useOnyxTest.ts
+++ b/tests/unit/useOnyxTest.ts
@@ -12,14 +12,13 @@ const ONYXKEYS = {
     COLLECTION: {
         TEST_KEY: 'test_',
         TEST_KEY_2: 'test2_',
+        EVICTABLE_TEST_KEY: 'evictable_test_',
     },
-    EVICTABLE_TEST_KEY: 'evictable_test',
-    EVICTABLE_TEST_KEY2: 'evictable_test2',
 };
 
 Onyx.init({
     keys: ONYXKEYS,
-    safeEvictionKeys: [ONYXKEYS.EVICTABLE_TEST_KEY, ONYXKEYS.EVICTABLE_TEST_KEY2],
+    safeEvictionKeys: [ONYXKEYS.COLLECTION.EVICTABLE_TEST_KEY],
 });
 
 beforeEach(() => Onyx.clear());
@@ -577,50 +576,57 @@ describe('useOnyx', () => {
         });
 
         it('should add the connection to the blocklist when setting "canEvict" to false', async () => {
-            await StorageMock.setItem(ONYXKEYS.EVICTABLE_TEST_KEY, 'test');
+            Onyx.mergeCollection(ONYXKEYS.COLLECTION.EVICTABLE_TEST_KEY, {
+                [`${ONYXKEYS.COLLECTION.EVICTABLE_TEST_KEY}entry1`]: {id: 'entry1_id', name: 'entry1_name'},
+            } as GenericCollection);
 
-            renderHook(() => useOnyx(ONYXKEYS.EVICTABLE_TEST_KEY, {canEvict: false}));
+            renderHook(() => useOnyx(`${ONYXKEYS.COLLECTION.EVICTABLE_TEST_KEY}entry1`, {canEvict: false}));
 
             await act(async () => waitForPromisesToResolve());
 
             const evictionBlocklist = OnyxUtils.getEvictionBlocklist();
-            expect(evictionBlocklist[ONYXKEYS.EVICTABLE_TEST_KEY]).toHaveLength(1);
+            expect(evictionBlocklist[`${ONYXKEYS.COLLECTION.EVICTABLE_TEST_KEY}entry1`]).toHaveLength(1);
         });
 
         it('should handle removal/adding the connection to the blocklist properly when changing the evictable key to another', async () => {
-            await StorageMock.setItem(ONYXKEYS.EVICTABLE_TEST_KEY, 'test');
+            Onyx.mergeCollection(ONYXKEYS.COLLECTION.EVICTABLE_TEST_KEY, {
+                [`${ONYXKEYS.COLLECTION.EVICTABLE_TEST_KEY}entry1`]: {id: 'entry1_id', name: 'entry1_name'},
+                [`${ONYXKEYS.COLLECTION.EVICTABLE_TEST_KEY}entry2`]: {id: 'entry2_id', name: 'entry2_name'},
+            } as GenericCollection);
 
-            const {rerender} = renderHook((key: string) => useOnyx(key, {canEvict: false}), {initialProps: ONYXKEYS.EVICTABLE_TEST_KEY as string});
+            const {rerender} = renderHook((key: string) => useOnyx(key, {canEvict: false}), {initialProps: `${ONYXKEYS.COLLECTION.EVICTABLE_TEST_KEY}entry1` as string});
 
             await act(async () => waitForPromisesToResolve());
 
             const evictionBlocklist = OnyxUtils.getEvictionBlocklist();
-            expect(evictionBlocklist[ONYXKEYS.EVICTABLE_TEST_KEY]).toHaveLength(1);
-            expect(evictionBlocklist[ONYXKEYS.EVICTABLE_TEST_KEY2]).toBeUndefined();
+            expect(evictionBlocklist[`${ONYXKEYS.COLLECTION.EVICTABLE_TEST_KEY}entry1`]).toHaveLength(1);
+            expect(evictionBlocklist[`${ONYXKEYS.COLLECTION.EVICTABLE_TEST_KEY}entry2`]).toBeUndefined();
 
             await act(async () => {
-                rerender(ONYXKEYS.EVICTABLE_TEST_KEY2);
+                rerender(`${ONYXKEYS.COLLECTION.EVICTABLE_TEST_KEY}entry2`);
             });
 
-            expect(evictionBlocklist[ONYXKEYS.EVICTABLE_TEST_KEY]).toBeUndefined();
-            expect(evictionBlocklist[ONYXKEYS.EVICTABLE_TEST_KEY2]).toHaveLength(1);
+            expect(evictionBlocklist[`${ONYXKEYS.COLLECTION.EVICTABLE_TEST_KEY}entry1`]).toBeUndefined();
+            expect(evictionBlocklist[`${ONYXKEYS.COLLECTION.EVICTABLE_TEST_KEY}entry2`]).toHaveLength(1);
         });
 
         it('should remove the connection from the blocklist when setting "canEvict" to true', async () => {
-            await StorageMock.setItem(ONYXKEYS.EVICTABLE_TEST_KEY, 'test');
+            Onyx.mergeCollection(ONYXKEYS.COLLECTION.EVICTABLE_TEST_KEY, {
+                [`${ONYXKEYS.COLLECTION.EVICTABLE_TEST_KEY}entry1`]: {id: 'entry1_id', name: 'entry1_name'},
+            } as GenericCollection);
 
-            const {rerender} = renderHook((canEvict: boolean) => useOnyx(ONYXKEYS.EVICTABLE_TEST_KEY, {canEvict}), {initialProps: false as boolean});
+            const {rerender} = renderHook((canEvict: boolean) => useOnyx(`${ONYXKEYS.COLLECTION.EVICTABLE_TEST_KEY}entry1`, {canEvict}), {initialProps: false as boolean});
 
             await act(async () => waitForPromisesToResolve());
 
             const evictionBlocklist = OnyxUtils.getEvictionBlocklist();
-            expect(evictionBlocklist[ONYXKEYS.EVICTABLE_TEST_KEY]).toHaveLength(1);
+            expect(evictionBlocklist[`${ONYXKEYS.COLLECTION.EVICTABLE_TEST_KEY}entry1`]).toHaveLength(1);
 
             await act(async () => {
                 rerender(true);
             });
 
-            expect(evictionBlocklist[ONYXKEYS.EVICTABLE_TEST_KEY]).toBeUndefined();
+            expect(evictionBlocklist[`${ONYXKEYS.COLLECTION.EVICTABLE_TEST_KEY}entry1`]).toBeUndefined();
         });
     });
 });


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details

This PR:

1. Fixes both `getCollectionKey()` and `splitCollectionMemberKey()` logic to consider some keys / collection keys edge cases with underscore that weren't being considered before e.g. `report__FAKE` and `cards_-1_Expensify Card`, thus fixing https://github.com/Expensify/App/issues/48777 and https://github.com/Expensify/App/issues/49147.
2. Fixes `canEvict` tests in `useOnyxTest.ts` as they were actually wrong and were only working because of the faulty logic this PR is fixing.

### Related Issues

https://github.com/Expensify/App/issues/48777

https://github.com/Expensify/App/issues/49147

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Manual Tests
<!---
Each set of changes should be tested against the Expensify/App repo on all platforms to verify it does not break our staging App.
--->

### Author Checklist

- [x] I linked the correct issue in the `### Related Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
