### PR TITLE
Feat: Call useOnyx selector for entire collection

### DIFF
--- a/lib/useOnyx.ts
+++ b/lib/useOnyx.ts
@@ -220,7 +220,7 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(key: TKey
             newFetchStatus = 'loaded';
         }
 
-        // We do a deep equality check if `selector` is defined, since each `OnyxUtils.tryGetCachedValue()` call will
+        // We do a deep equality check if `selector` is defined, since each `tryGetCachedValue()` call will
         // generate a plain new primitive/object/array that was created using the `selector` function.
         // For the other cases we will only deal with object reference checks, so just a shallow equality check is enough.
         let areValuesEqual: boolean;

--- a/lib/useOnyx.ts
+++ b/lib/useOnyx.ts
@@ -109,7 +109,7 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(key: TKey
 
     // Stores the previous cached value as it's necessary to compare with the new value in `getSnapshot()`.
     // We initialize it to `null` to simulate that we don't have any value from cache yet.
-    const previousValueRef = useRef<TReturnValue | OnyxValue<TKey> | undefined | null>(null);
+    const previousValueRef = useRef<CachedValue<TKey, TReturnValue> | undefined | null>(null);
 
     // Stores the newest cached value in order to compare with the previous one and optimize `getSnapshot()` execution.
     const newValueRef = useRef<CachedValue<TKey, TReturnValue> | undefined | null>(null);

--- a/lib/useOnyx.ts
+++ b/lib/useOnyx.ts
@@ -74,7 +74,7 @@ function getCachedValue<TKey extends OnyxKey>(key: TKey): OnyxValue<TKey> | unde
 
     const values: Record<string, unknown> = {};
     allCacheKeys.forEach((cacheKey) => {
-        if (cacheKey.startsWith(key)) {
+        if (!cacheKey.startsWith(key)) {
             return;
         }
 

--- a/lib/useOnyx.ts
+++ b/lib/useOnyx.ts
@@ -59,6 +59,10 @@ type UseOnyxResult<TKey extends OnyxKey, TValue> = [CachedValue<TKey, TValue>, R
 
 type UseOnyxSelector<TKey extends OnyxKey, SelectorValue> = (data?: OnyxValue<TKey>) => SelectorValue;
 
+/**
+ * Gets the cached value from the Onyx cache. If the key is a collection key, it will return all the values in the collection.
+ * It is a fork of `tryGetCachedValue` from `OnyxUtils` caused by different selector logic in `useOnyx`. It should be unified in the future, when `withOnyx` is removed.
+ */
 function getCachedValue<TKey extends OnyxKey>(key: TKey): OnyxValue<TKey> | undefined {
     if (!OnyxUtils.isCollectionKey(key)) {
         return OnyxCache.get(key) as OnyxValue<TKey> | undefined;
@@ -84,6 +88,9 @@ function getCachedValue<TKey extends OnyxKey>(key: TKey): OnyxValue<TKey> | unde
     return values as OnyxValue<TKey>;
 }
 
+/**
+ * Gets the value from cache and maps it with selector.
+ */
 function getSelectedValue<TKey extends OnyxKey, TValue = OnyxValue<TKey> | undefined>(key: TKey, selector?: UseOnyxSelector<TKey, TValue>) {
     const value = getCachedValue(key);
 

--- a/lib/useOnyx.ts
+++ b/lib/useOnyx.ts
@@ -61,7 +61,7 @@ type UseOnyxSelector<TKey extends OnyxKey, SelectorValue> = (data?: OnyxValue<TK
 
 function getCachedValue<TKey extends OnyxKey>(key: TKey): OnyxValue<TKey> | undefined {
     if (!OnyxUtils.isCollectionKey(key)) {
-        return OnyxCache.get(key);
+        return OnyxCache.get(key) as OnyxValue<TKey> | undefined;
     }
 
     const allCacheKeys = OnyxCache.getAllKeys();
@@ -190,7 +190,7 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(key: TKey
             // If `newValueRef.current` is `null` or any other value it means that the cache does have a value for that key.
             // This difference between `undefined` and other values is crucial and it's used to address the following
             // conditions and use cases.
-            newValueRef.current = getSelectedValue<TKey, TReturnValue>(key, selectorRef.current);
+            newValueRef.current = getSelectedValue(key, selectorRef.current) as CachedValue<TKey, TReturnValue>;
 
             // We set this flag to `false` again since we don't want to get the newest cached value every time `getSnapshot()` is executed,
             // and only when `Onyx.connect()` callback is fired.

--- a/lib/useOnyx.ts
+++ b/lib/useOnyx.ts
@@ -119,7 +119,7 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(key: TKey
 
     // Stores the previously result returned by the hook, containing the data from cache and the fetch status.
     // We initialize it to `undefined` and `loading` fetch status to simulate the initial result when the hook is loading from the cache.
-    // However, if `initWithStoredValues` is `true` we set the fetch status to `loaded` since we want to signal that data is ready.
+    // However, if `initWithStoredValues` is `false` we set the fetch status to `loaded` since we want to signal that data is ready.
     const resultRef = useRef<UseOnyxResult<TReturnValue>>([
         undefined,
         {
@@ -180,6 +180,11 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(key: TKey
     }, [key, options?.canEvict]);
 
     const getSnapshot = useCallback(() => {
+        // We return the initial result right away during the first connection if `initWithStoredValues` is set to `false`.
+        if (isFirstConnectionRef.current && options?.initWithStoredValues === false) {
+            return resultRef.current;
+        }
+
         // We get the value from cache while the first connection to Onyx is being made,
         // so we can return any cached value right away. After the connection is made, we only
         // update `newValueRef` when `Onyx.connect()` callback is fired.
@@ -237,7 +242,7 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(key: TKey
         }
 
         return resultRef.current;
-    }, [key, selectorRef, options?.allowStaleData, options?.initialValue]);
+    }, [options?.initWithStoredValues, options?.allowStaleData, options?.initialValue, key, selectorRef]);
 
     const subscribe = useCallback(
         (onStoreChange: () => void) => {

--- a/lib/useOnyx.ts
+++ b/lib/useOnyx.ts
@@ -94,6 +94,14 @@ function getSelectedValue<TKey extends OnyxKey, TValue>(key: TKey, selector?: Us
     return selectedValue;
 }
 
+function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
+    key: TKey,
+    options?: BaseUseOnyxOptions & UseOnyxInitialValueOption<TReturnValue> & Required<UseOnyxSelectorOption<TKey, TReturnValue>>,
+): UseOnyxResult<TReturnValue>;
+function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
+    key: TKey,
+    options?: BaseUseOnyxOptions & UseOnyxInitialValueOption<NoInfer<TReturnValue>>,
+): UseOnyxResult<TReturnValue>;
 function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(key: TKey, options?: UseOnyxOptions<TKey, TReturnValue>) {
     const connectionRef = useRef<Connection | null>(null);
     const previousKey = usePrevious(key);

--- a/lib/useOnyx.ts
+++ b/lib/useOnyx.ts
@@ -5,7 +5,7 @@ import OnyxCache from './OnyxCache';
 import type {Connection} from './OnyxConnectionManager';
 import connectionManager from './OnyxConnectionManager';
 import OnyxUtils from './OnyxUtils';
-import type {CollectionKeyBase, KeyValueMapping, OnyxCollection, OnyxEntry, OnyxKey, OnyxValue} from './types';
+import type {CollectionKeyBase, OnyxCollection, OnyxEntry, OnyxKey, OnyxValue} from './types';
 import useLiveRef from './useLiveRef';
 import usePrevious from './usePrevious';
 
@@ -61,7 +61,7 @@ type UseOnyxSelector<TKey extends OnyxKey, SelectorValue> = (data?: OnyxValue<TK
 
 function getCachedValue<TKey extends OnyxKey>(key: TKey): OnyxValue<TKey> | undefined {
     if (!OnyxUtils.isCollectionKey(key)) {
-        return OnyxCache.get(key) as OnyxValue<TKey>;
+        return OnyxCache.get(key);
     }
 
     const allCacheKeys = OnyxCache.getAllKeys();
@@ -72,9 +72,9 @@ function getCachedValue<TKey extends OnyxKey>(key: TKey): OnyxValue<TKey> | unde
         return;
     }
 
-    const values: OnyxCollection<KeyValueMapping[TKey]> = {};
+    const values: Record<string, unknown> = {};
     allCacheKeys.forEach((cacheKey) => {
-        if (!cacheKey.startsWith(key)) {
+        if (cacheKey.startsWith(key)) {
             return;
         }
 

--- a/lib/useOnyx.ts
+++ b/lib/useOnyx.ts
@@ -111,7 +111,7 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(key: TKey
     // Stores the previously result returned by the hook, containing the data from cache and the fetch status.
     // We initialize it to `undefined` and `loading` fetch status to simulate the initial result when the hook is loading from the cache.
     // However, if `initWithStoredValues` is `false` we set the fetch status to `loaded` since we want to signal that data is ready.
-    const resultRef = useRef<UseOnyxResult<TReturnValue | undefined>>([
+    const resultRef = useRef<UseOnyxResult<TReturnValue | undefined | null>>([
         undefined,
         {
             status: options?.initWithStoredValues === false ? 'loaded' : 'loading',

--- a/tests/unit/useOnyxTest.ts
+++ b/tests/unit/useOnyxTest.ts
@@ -1,5 +1,5 @@
 import {act, renderHook} from '@testing-library/react-native';
-import type {OnyxEntry} from '../../lib';
+import type {OnyxCollection, OnyxEntry} from '../../lib';
 import Onyx, {useOnyx} from '../../lib';
 import OnyxUtils from '../../lib/OnyxUtils';
 import StorageMock from '../../lib/storage';
@@ -176,7 +176,11 @@ describe('useOnyx', () => {
             const {result} = renderHook(() =>
                 useOnyx(ONYXKEYS.COLLECTION.TEST_KEY, {
                     // @ts-expect-error bypass
-                    selector: (entry: OnyxEntry<{id: string; name: string}>) => entry?.id,
+                    selector: (entries: OnyxCollection<{id: string; name: string}>) =>
+                        Object.entries(entries ?? {}).reduce<NonNullable<OnyxCollection<string>>>((acc, [key, value]) => {
+                            acc[key] = value?.id;
+                            return acc;
+                        }, {}),
                 }),
             );
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

This PR makes `useOnyx` call its `selector` once for entire collection object instead of calling selector per item.

❗ As `withOnyx` is deprecated the change to its selector functionality was not implemented. In order to achieve this, separation between `withOnyx` and `useOnyx` selectors were introduced.

Implementation steps:
1. Modify tests to work with new functionality
2. Refactor typings to match new functionality
3. Fix implementation to make both test runner and type checker happy :)

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/App/issues/49644

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Manual Tests
<!---
Each set of changes should be tested against the Expensify/App repo on all platforms to verify it does not break our staging App.
--->

### Author Checklist

- [ ] I linked the correct issue in the `### Related Issues` section above
- [ ] I wrote clear testing steps that cover the changes made in this PR
    - [ ] I added steps for local testing in the `Tests` section
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android / native
    - [ ] Android / Chrome
    - [ ] iOS / native
    - [ ] iOS / Safari
    - [ ] MacOS / Chrome / Safari
    - [ ] MacOS / Desktop
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [ ] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [ ] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [ ] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [ ] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [ ] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [ ] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [ ] I verified that if a function's arguments changed that all usages have also been updated correctly
- [ ] If a new component is created I verified that:
    - [ ] A similar component doesn't exist in the codebase
    - [ ] All props are defined accurately and each prop has a `/** comment above it */`
    - [ ] The file is named correctly
    - [ ] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [ ] The only data being stored in the state is data necessary for rendering and nothing else
    - [ ] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [ ] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [ ] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [ ] All JSX used for rendering exists in the render method
    - [ ] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [ ] If any new file was added I verified that:
    - [ ] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [ ] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
