### PR TITLE
add setCollection method

### DIFF
--- a/API.md
+++ b/API.md
@@ -50,6 +50,10 @@ value will be saved to storage after the default value.</p>
 <dt><a href="#update">update(data)</a> ⇒</dt>
 <dd><p>Insert API responses and lifecycle data into Onyx</p>
 </dd>
+<dt><a href="#setCollection">setCollection(collectionKey, collection)</a></dt>
+<dd><p>Sets a collection by replacing all existing collection members with new values.
+Any existing collection members not included in the new data will be removed.</p>
+</dd>
 </dl>
 
 <a name="init"></a>
@@ -209,3 +213,23 @@ Insert API responses and lifecycle data into Onyx
 | --- | --- |
 | data | An array of objects with update expressions |
 
+<a name="setCollection"></a>
+
+## setCollection(collectionKey, collection)
+Sets a collection by replacing all existing collection members with new values.
+Any existing collection members not included in the new data will be removed.
+
+**Kind**: global function  
+
+| Param | Description |
+| --- | --- |
+| collectionKey | e.g. `ONYXKEYS.COLLECTION.REPORT` |
+| collection | Object collection keyed by individual collection member keys and values |
+
+**Example**  
+```js
+Onyx.setCollection(ONYXKEYS.COLLECTION.REPORT, {
+    [`${ONYXKEYS.COLLECTION.REPORT}1`]: report1,
+    [`${ONYXKEYS.COLLECTION.REPORT}2`]: report2,
+});
+```

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -38,6 +38,7 @@ const METHOD = {
     SET: 'set',
     MERGE: 'merge',
     MERGE_COLLECTION: 'mergecollection',
+    SET_COLLECTION: 'setcollection',
     MULTI_SET: 'multiset',
     CLEAR: 'clear',
 } as const;

--- a/tests/unit/onyxTest.ts
+++ b/tests/unit/onyxTest.ts
@@ -1725,5 +1725,86 @@ describe('Onyx', () => {
                     });
             });
         });
+
+        describe('setCollection', () => {
+            it('should replace all existing collection members with new values and remove old ones', async () => {
+                let result: OnyxCollection<unknown>;
+                const routeA = `${ONYX_KEYS.COLLECTION.ROUTES}A`;
+                const routeB = `${ONYX_KEYS.COLLECTION.ROUTES}B`;
+                const routeC = `${ONYX_KEYS.COLLECTION.ROUTES}C`;
+
+                connection = Onyx.connect({
+                    key: ONYX_KEYS.COLLECTION.ROUTES,
+                    initWithStoredValues: false,
+                    callback: (value) => (result = value),
+                    waitForCollectionCallback: true,
+                });
+
+                // Set initial collection state
+                await Onyx.mergeCollection(ONYX_KEYS.COLLECTION.ROUTES, {
+                    [routeA]: {name: 'Route A'},
+                    [routeB]: {name: 'Route B'},
+                    [routeC]: {name: 'Route C'},
+                } as GenericCollection);
+
+                // Replace with new collection data
+                await Onyx.setCollection(ONYX_KEYS.COLLECTION.ROUTES, {
+                    [routeA]: {name: 'New Route A'},
+                    [routeB]: {name: 'New Route B'},
+                } as GenericCollection);
+
+                expect(result).toEqual({
+                    [routeA]: {name: 'New Route A'},
+                    [routeB]: {name: 'New Route B'},
+                });
+            });
+
+            it('should not update if collection is empty', async () => {
+                let result: OnyxCollection<unknown>;
+                const routeA = `${ONYX_KEYS.COLLECTION.ROUTES}A`;
+
+                connection = Onyx.connect({
+                    key: ONYX_KEYS.COLLECTION.ROUTES,
+                    initWithStoredValues: false,
+                    callback: (value) => (result = value),
+                    waitForCollectionCallback: true,
+                });
+
+                await Onyx.mergeCollection(ONYX_KEYS.COLLECTION.ROUTES, {
+                    [routeA]: {name: 'Route A'},
+                } as GenericCollection);
+
+                await Onyx.setCollection(ONYX_KEYS.COLLECTION.ROUTES, {} as GenericCollection);
+
+                expect(result).toEqual({
+                    [routeA]: {name: 'Route A'},
+                });
+            });
+
+            it('should reject collection items with invalid keys', async () => {
+                let result: OnyxCollection<unknown>;
+                const routeA = `${ONYX_KEYS.COLLECTION.ROUTES}A`;
+                const invalidRoute = 'invalid_route';
+
+                connection = Onyx.connect({
+                    key: ONYX_KEYS.COLLECTION.ROUTES,
+                    initWithStoredValues: false,
+                    callback: (value) => (result = value),
+                    waitForCollectionCallback: true,
+                });
+
+                await Onyx.mergeCollection(ONYX_KEYS.COLLECTION.ROUTES, {
+                    [routeA]: {name: 'Route A'},
+                } as GenericCollection);
+
+                await Onyx.setCollection(ONYX_KEYS.COLLECTION.ROUTES, {
+                    [invalidRoute]: {name: 'Invalid Route'},
+                } as GenericCollection);
+
+                expect(result).toEqual({
+                    [routeA]: {name: 'Route A'},
+                });
+            });
+        });
     });
 });

--- a/tests/unit/onyxTest.ts
+++ b/tests/unit/onyxTest.ts
@@ -1731,6 +1731,7 @@ describe('Onyx', () => {
                 let result: OnyxCollection<unknown>;
                 const routeA = `${ONYX_KEYS.COLLECTION.ROUTES}A`;
                 const routeB = `${ONYX_KEYS.COLLECTION.ROUTES}B`;
+                const routeB1 = `${ONYX_KEYS.COLLECTION.ROUTES}B1`;
                 const routeC = `${ONYX_KEYS.COLLECTION.ROUTES}C`;
 
                 connection = Onyx.connect({
@@ -1743,7 +1744,7 @@ describe('Onyx', () => {
                 // Set initial collection state
                 await Onyx.mergeCollection(ONYX_KEYS.COLLECTION.ROUTES, {
                     [routeA]: {name: 'Route A'},
-                    [routeB]: {name: 'Route B'},
+                    [routeB1]: {name: 'Route B1'},
                     [routeC]: {name: 'Route C'},
                 } as GenericCollection);
 
@@ -1751,15 +1752,17 @@ describe('Onyx', () => {
                 await Onyx.setCollection(ONYX_KEYS.COLLECTION.ROUTES, {
                     [routeA]: {name: 'New Route A'},
                     [routeB]: {name: 'New Route B'},
+                    [routeC]: {name: 'New Route C'},
                 } as GenericCollection);
 
                 expect(result).toEqual({
                     [routeA]: {name: 'New Route A'},
                     [routeB]: {name: 'New Route B'},
+                    [routeC]: {name: 'New Route C'},
                 });
             });
 
-            it('should not update if collection is empty', async () => {
+            it('should replace the collection with empty values', async () => {
                 let result: OnyxCollection<unknown>;
                 const routeA = `${ONYX_KEYS.COLLECTION.ROUTES}A`;
 
@@ -1776,9 +1779,7 @@ describe('Onyx', () => {
 
                 await Onyx.setCollection(ONYX_KEYS.COLLECTION.ROUTES, {} as GenericCollection);
 
-                expect(result).toEqual({
-                    [routeA]: {name: 'Route A'},
-                });
+                expect(result).toEqual({});
             });
 
             it('should reject collection items with invalid keys', async () => {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
In order to better align the Expensify client data with the server data there's a need to introduce a new `setCollection` method which will set the new collection data and remove the old one.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/App/issues/51864

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
Added test to cover all possible cases

### Manual Tests
<!---
Each set of changes should be tested against the Expensify/App repo on all platforms to verify it does not break our staging App.
--->

### Author Checklist

- [x] I linked the correct issue in the `### Related Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
