### PR TITLE
useOnyx dependencies list

### DIFF
--- a/lib/useOnyx.ts
+++ b/lib/useOnyx.ts
@@ -147,7 +147,7 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
     // Indicates if the hook is connecting to a Onyx key.
     const isConnectingRef = useRef(false);
 
-    // Stores the `onStoreChange` function, which can be used to trigger a `getSnapshot` update when desired.
+    // Stores the `onStoreChange()` function, which can be used to trigger a `getSnapshot()` update when desired.
     const onStoreChangeFnRef = useRef<(() => void) | null>(null);
 
     // Indicates if we should get the newest cached value from Onyx during `getSnapshot()` execution.
@@ -183,7 +183,7 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
 
     useEffect(() => {
         // This effect will only run if the `dependencies` array changes. If it changes it will force the hook
-        // to trigger a `getSnapshot` update by calling the stored `onStoreChange` function reference, thus
+        // to trigger a `getSnapshot()` update by calling the stored `onStoreChange()` function reference, thus
         // re-running the hook and returning the latest value to the consumer.
         if (connectionRef.current === null || isConnectingRef.current || !onStoreChangeFnRef.current) {
             return;
@@ -288,6 +288,7 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
                 key,
                 callback: () => {
                     isConnectingRef.current = false;
+                    onStoreChangeFnRef.current = onStoreChange;
 
                     // Signals that the first connection was made, so some logics in `getSnapshot()`
                     // won't be executed anymore.
@@ -312,9 +313,9 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
                 }
 
                 connectionManager.disconnect(connectionRef.current);
-                onStoreChangeFnRef.current = null;
-                isConnectingRef.current = false;
                 isFirstConnectionRef.current = false;
+                isConnectingRef.current = false;
+                onStoreChangeFnRef.current = null;
             };
         },
         [key, options?.initWithStoredValues, options?.reuseConnection, checkEvictableKey],

--- a/lib/useOnyx.ts
+++ b/lib/useOnyx.ts
@@ -1,5 +1,6 @@
 import {deepEqual, shallowEqual} from 'fast-equals';
 import {useCallback, useEffect, useRef, useSyncExternalStore} from 'react';
+import type {DependencyList} from 'react';
 import OnyxCache, {TASK} from './OnyxCache';
 import type {Connection} from './OnyxConnectionManager';
 import connectionManager from './OnyxConnectionManager';
@@ -104,12 +105,18 @@ function getCachedValue<TKey extends OnyxKey, TValue>(key: TKey, selector?: UseO
 function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
     key: TKey,
     options?: BaseUseOnyxOptions & UseOnyxInitialValueOption<TReturnValue> & Required<UseOnyxSelectorOption<TKey, TReturnValue>>,
+    dependencies?: DependencyList,
 ): UseOnyxResult<TReturnValue>;
 function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
     key: TKey,
     options?: BaseUseOnyxOptions & UseOnyxInitialValueOption<NoInfer<TReturnValue>>,
+    dependencies?: DependencyList,
 ): UseOnyxResult<TReturnValue>;
-function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(key: TKey, options?: UseOnyxOptions<TKey, TReturnValue>): UseOnyxResult<TReturnValue> {
+function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
+    key: TKey,
+    options?: UseOnyxOptions<TKey, TReturnValue>,
+    dependencies: DependencyList = [],
+): UseOnyxResult<TReturnValue> {
     const connectionRef = useRef<Connection | null>(null);
     const previousKey = usePrevious(key);
 
@@ -136,6 +143,10 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(key: TKey
     // Indicates if it's the first Onyx connection of this hook or not, as we don't want certain use cases
     // in `getSnapshot()` to be satisfied several times.
     const isFirstConnectionRef = useRef(true);
+
+    const isConnectingRef = useRef(false);
+
+    const onStoreChangeFnRef = useRef<(() => void) | null>(null);
 
     // Indicates if we should get the newest cached value from Onyx during `getSnapshot()` execution.
     const shouldGetCachedValueRef = useRef(true);
@@ -167,6 +178,14 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(key: TKey
             `'${previousKey}' key can't be changed to '${key}'. useOnyx() only supports dynamic keys if they are both collection member keys from the same collection e.g. from 'collection_id1' to 'collection_id2'.`,
         );
     }, [previousKey, key]);
+
+    // eslint-disable-next-line rulesdir/prefer-early-return
+    useEffect(() => {
+        if (connectionRef.current !== null && !isConnectingRef.current && onStoreChangeFnRef.current) {
+            shouldGetCachedValueRef.current = true;
+            onStoreChangeFnRef.current();
+        }
+    }, [...dependencies]);
 
     // Mimics withOnyx's checkEvictableKeys() behavior.
     const checkEvictableKey = useCallback(() => {
@@ -255,9 +274,14 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(key: TKey
 
     const subscribe = useCallback(
         (onStoreChange: () => void) => {
+            isConnectingRef.current = true;
+            onStoreChangeFnRef.current = onStoreChange;
+
             connectionRef.current = connectionManager.connect<CollectionKeyBase>({
                 key,
                 callback: () => {
+                    isConnectingRef.current = false;
+
                     // Signals that the first connection was made, so some logics in `getSnapshot()`
                     // won't be executed anymore.
                     isFirstConnectionRef.current = false;
@@ -281,6 +305,8 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(key: TKey
                 }
 
                 connectionManager.disconnect(connectionRef.current);
+                onStoreChangeFnRef.current = null;
+                isConnectingRef.current = false;
                 isFirstConnectionRef.current = false;
             };
         },

--- a/tests/unit/useOnyxTest.ts
+++ b/tests/unit/useOnyxTest.ts
@@ -611,7 +611,7 @@ describe('useOnyx', () => {
     });
 
     describe('dependencies', () => {
-        it('should 1', async () => {
+        it('should return the updated selected value when a external value passed to the dependencies list changes', async () => {
             Onyx.mergeCollection(ONYXKEYS.COLLECTION.TEST_KEY, {
                 [`${ONYXKEYS.COLLECTION.TEST_KEY}entry1`]: {id: 'entry1_id', name: 'entry1_name'},
                 [`${ONYXKEYS.COLLECTION.TEST_KEY}entry2`]: {id: 'entry2_id', name: 'entry2_name'},

--- a/tests/unit/useOnyxTest.ts
+++ b/tests/unit/useOnyxTest.ts
@@ -610,6 +610,55 @@ describe('useOnyx', () => {
         });
     });
 
+    describe('dependencies', () => {
+        it('should 1', async () => {
+            Onyx.mergeCollection(ONYXKEYS.COLLECTION.TEST_KEY, {
+                [`${ONYXKEYS.COLLECTION.TEST_KEY}entry1`]: {id: 'entry1_id', name: 'entry1_name'},
+                [`${ONYXKEYS.COLLECTION.TEST_KEY}entry2`]: {id: 'entry2_id', name: 'entry2_name'},
+                [`${ONYXKEYS.COLLECTION.TEST_KEY}entry3`]: {id: 'entry3_id', name: 'entry3_name'},
+            } as GenericCollection);
+
+            let externalValue = 'ex1';
+
+            const {result, rerender} = renderHook(() =>
+                useOnyx(
+                    ONYXKEYS.COLLECTION.TEST_KEY,
+                    {
+                        // @ts-expect-error bypass
+                        selector: (entries: OnyxCollection<{id: string; name: string}>) =>
+                            Object.entries(entries ?? {}).reduce<NonNullable<OnyxCollection<string>>>((acc, [key, value]) => {
+                                acc[key] = `${value?.id}_${externalValue}`;
+                                return acc;
+                            }, {}),
+                    },
+                    [externalValue],
+                ),
+            );
+
+            await act(async () => waitForPromisesToResolve());
+
+            expect(result.current[0]).toEqual({
+                [`${ONYXKEYS.COLLECTION.TEST_KEY}entry1`]: 'entry1_id_ex1',
+                [`${ONYXKEYS.COLLECTION.TEST_KEY}entry2`]: 'entry2_id_ex1',
+                [`${ONYXKEYS.COLLECTION.TEST_KEY}entry3`]: 'entry3_id_ex1',
+            });
+            expect(result.current[1].status).toEqual('loaded');
+
+            externalValue = 'ex2';
+
+            await act(async () => {
+                rerender(undefined);
+            });
+
+            expect(result.current[0]).toEqual({
+                [`${ONYXKEYS.COLLECTION.TEST_KEY}entry1`]: 'entry1_id_ex2',
+                [`${ONYXKEYS.COLLECTION.TEST_KEY}entry2`]: 'entry2_id_ex2',
+                [`${ONYXKEYS.COLLECTION.TEST_KEY}entry3`]: 'entry3_id_ex2',
+            });
+            expect(result.current[1].status).toEqual('loaded');
+        });
+    });
+
     // This test suite must be the last one to avoid problems when running the other tests here.
     describe('canEvict', () => {
         const error = (key: string) => `canEvict can't be used on key '${key}'. This key must explicitly be flagged as safe for removal by adding it to Onyx.init({safeEvictionKeys: []}).`;


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

This PR implements a dependencies array to `useOnyx`. Similarly to the dependencies array of React hooks e.g. `useMemo`/`useCallback`, any changes to the variables inside the dependencies array will make the hook trigger an update to return the latest value to the consumer.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/App/issues/52597

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

Unit tests were implemented to cover this change.

### Manual Tests
<!---
Each set of changes should be tested against the Expensify/App repo on all platforms to verify it does not break our staging App.
--->

Since it's a feature that won't be used yet, I only added simple tests proving that E/App works.

### Author Checklist

- [x] I linked the correct issue in the `### Related Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/38cb1167-3b1f-4e2b-9918-42d32d3cf4e4




</details>

<details>
<summary>Android: mWeb Chrome</summary>


https://github.com/user-attachments/assets/75409cba-6dc1-4743-adf5-75158b0c972f



</details>

<details>
<summary>iOS: Native</summary>


https://github.com/user-attachments/assets/ba919907-cb9c-463d-964d-c4f1b9c01601



</details>

<details>
<summary>iOS: mWeb Safari</summary>


https://github.com/user-attachments/assets/f26120e8-6c62-4f97-971e-abfffb8b62dd



</details>

<details>
<summary>MacOS: Chrome / Safari</summary>


https://github.com/user-attachments/assets/c3c09f67-9f7f-401d-bc5e-803a61036f13


https://github.com/user-attachments/assets/357bbcbc-68a7-4294-809f-aa7017beb619



</details>

<details>
<summary>MacOS: Desktop</summary>


https://github.com/user-attachments/assets/f93c19f3-18c6-4f47-868c-32f5cd2a8498



</details>
