### PR TITLE
useOnyx `canBeMissing` option

### DIFF
--- a/API-INTERNAL.md
+++ b/API-INTERNAL.md
@@ -43,6 +43,11 @@ The resulting collection will only contain items that are returned by the select
 <dt><a href="#get">get()</a></dt>
 <dd><p>Get some data from the store</p>
 </dd>
+<dt><a href="#tupleGet">tupleGet()</a></dt>
+<dd><p>This helper exists to map an array of Onyx keys such as <code>[&#39;report_&#39;, &#39;conciergeReportID&#39;]</code>
+to the values for those keys (correctly typed) such as <code>[OnyxCollection&lt;Report&gt;, OnyxEntry&lt;string&gt;]</code></p>
+<p>Note: just using .map, you&#39;d end up with <code>Array&lt;OnyxCollection&lt;Report&gt;|OnyxEntry&lt;string&gt;&gt;</code>, which is not what we want. This preserves the order of the keys provided.</p>
+</dd>
 <dt><a href="#storeKeyBySubscriptions">storeKeyBySubscriptions(subscriptionID, key)</a></dt>
 <dd><p>Stores a subscription ID associated with a given key.</p>
 </dd>
@@ -240,6 +245,15 @@ The resulting collection will only contain items that are returned by the select
 
 ## get()
 Get some data from the store
+
+**Kind**: global function  
+<a name="tupleGet"></a>
+
+## tupleGet()
+This helper exists to map an array of Onyx keys such as `['report_', 'conciergeReportID']`
+to the values for those keys (correctly typed) such as `[OnyxCollection<Report>, OnyxEntry<string>]`
+
+Note: just using .map, you'd end up with `Array<OnyxCollection<Report>|OnyxEntry<string>>`, which is not what we want. This preserves the order of the keys provided.
 
 **Kind**: global function  
 <a name="storeKeyBySubscriptions"></a>

--- a/API-INTERNAL.md
+++ b/API-INTERNAL.md
@@ -46,7 +46,7 @@ The resulting collection will only contain items that are returned by the select
 <dt><a href="#tupleGet">tupleGet()</a></dt>
 <dd><p>This helper exists to map an array of Onyx keys such as <code>[&#39;report_&#39;, &#39;conciergeReportID&#39;]</code>
 to the values for those keys (correctly typed) such as <code>[OnyxCollection&lt;Report&gt;, OnyxEntry&lt;string&gt;]</code></p>
-<p>Note: just using .map, you&#39;d end up with <code>Array&lt;OnyxCollection&lt;Report&gt;|OnyxEntry&lt;string&gt;&gt;</code>, which is not what we want. This preserves the order of the keys provided.</p>
+<p>Note: just using <code>.map</code>, you&#39;d end up with <code>Array&lt;OnyxCollection&lt;Report&gt;|OnyxEntry&lt;string&gt;&gt;</code>, which is not what we want. This preserves the order of the keys provided.</p>
 </dd>
 <dt><a href="#storeKeyBySubscriptions">storeKeyBySubscriptions(subscriptionID, key)</a></dt>
 <dd><p>Stores a subscription ID associated with a given key.</p>
@@ -253,7 +253,7 @@ Get some data from the store
 This helper exists to map an array of Onyx keys such as `['report_', 'conciergeReportID']`
 to the values for those keys (correctly typed) such as `[OnyxCollection<Report>, OnyxEntry<string>]`
 
-Note: just using .map, you'd end up with `Array<OnyxCollection<Report>|OnyxEntry<string>>`, which is not what we want. This preserves the order of the keys provided.
+Note: just using `.map`, you'd end up with `Array<OnyxCollection<Report>|OnyxEntry<string>>`, which is not what we want. This preserves the order of the keys provided.
 
 **Kind**: global function  
 <a name="storeKeyBySubscriptions"></a>

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ It's also beneficial to use a [selector](https://github.com/Expensify/react-nati
 
 ### useOnyx()'s `canBeMissing` option
 
-You can pass the `canBeMissing` configuration flag to `useOnyx` if you want the hook to log an alert when data is missing from Onyx store. Regarding usage in `Expensify/App` repo, if the component calling this is the one loading the data by calling an action, then you should set this to `true`. If the component calling this does not load the data then you should set it to `false`, which means that if the data is not there, it will log an alert, as it means we are using data that no one loaded and that's most probably a bug.
+You must pass the `canBeMissing` configuration flag to `useOnyx` if you want the hook to log an alert when data is missing from Onyx store. Regarding usage in `Expensify/App` repo, if the component calling this is the one loading the data by calling an action, then you should set this to `true`. If the component calling this does not load the data then you should set it to `false`, which means that if the data is not there, it will log an alert, as it means we are using data that no one loaded and that's most probably a bug.
 
 ```javascript
 const Component = ({reportID}) => {

--- a/README.md
+++ b/README.md
@@ -256,6 +256,21 @@ DO NOT use more than one `withOnyx` component at a time. It adds overhead and pr
 
 It's also beneficial to use a [selector](https://github.com/Expensify/react-native-onyx/blob/main/API.md#connectmapping--number) with the mapping in case you need to grab a single item in a collection (like a single report action).
 
+### useOnyx()'s `canBeMissing` option
+
+You can pass the `canBeMissing` configuration flag to `useOnyx` if you want the hook to log an alert when data is missing from Onyx store. Regarding usage in `Expensify/App` repo, if the component calling this is the one loading the data by calling an action, then you should set this to `true`. If the component calling this does not load the data then you should set it to `false`, which means that if the data is not there, it will log an alert, as it means we are using data that no one loaded and that's most probably a bug.
+
+```javascript
+const Component = ({reportID}) => {
+    // This hook will log an alert (via `Logger.logAlert()`) if `report` is `undefined`.
+    const [report] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`, {canBeMissing: false});
+    
+    // rest of the component's code.
+};
+
+export default Component;
+```
+
 ## Collections
 
 Collections allow keys with similar value types to be subscribed together by subscribing to the collection key. To define one, it must be included in the `ONYXKEYS.COLLECTION` object and it must be suffixed with an underscore. Member keys should use a unique identifier or index after the collection key prefix (e.g. `report_42`).

--- a/lib/Logger.ts
+++ b/lib/Logger.ts
@@ -1,6 +1,7 @@
 type LogData = {
     message: string;
     level: 'alert' | 'info' | 'hmmm';
+    extraData?: Record<string, unknown>;
 };
 type LoggerCallback = (data: LogData) => void;
 
@@ -17,22 +18,22 @@ function registerLogger(callback: LoggerCallback) {
 /**
  * Send an alert message to the logger
  */
-function logAlert(message: string) {
-    logger({message: `[Onyx] ${message}`, level: 'alert'});
+function logAlert(message: string, extraData?: Record<string, unknown>) {
+    logger({message: `[Onyx] ${message}`, level: 'alert', extraData});
 }
 
 /**
  * Send an info message to the logger
  */
-function logInfo(message: string) {
-    logger({message: `[Onyx] ${message}`, level: 'info'});
+function logInfo(message: string, extraData?: Record<string, unknown>) {
+    logger({message: `[Onyx] ${message}`, level: 'info', extraData});
 }
 
 /**
  * Send an hmmm message to the logger
  */
-function logHmmm(message: string) {
-    logger({message: `[Onyx] ${message}`, level: 'hmmm'});
+function logHmmm(message: string, extraData?: Record<string, unknown>) {
+    logger({message: `[Onyx] ${message}`, level: 'hmmm', extraData});
 }
 
 export {registerLogger, logInfo, logAlert, logHmmm};

--- a/lib/Logger.ts
+++ b/lib/Logger.ts
@@ -1,7 +1,9 @@
+type Parameters = string | Record<string, unknown> | Array<Record<string, unknown>> | Error;
+
 type LogData = {
     message: string;
     level: 'alert' | 'info' | 'hmmm';
-    extraData?: Record<string, unknown>;
+    parameters?: Parameters;
 };
 type LoggerCallback = (data: LogData) => void;
 
@@ -18,22 +20,22 @@ function registerLogger(callback: LoggerCallback) {
 /**
  * Send an alert message to the logger
  */
-function logAlert(message: string, extraData?: Record<string, unknown>) {
-    logger({message: `[Onyx] ${message}`, level: 'alert', extraData});
+function logAlert(message: string, parameters?: Parameters) {
+    logger({message: `[Onyx] ${message}`, level: 'alert', parameters});
 }
 
 /**
  * Send an info message to the logger
  */
-function logInfo(message: string, extraData?: Record<string, unknown>) {
-    logger({message: `[Onyx] ${message}`, level: 'info', extraData});
+function logInfo(message: string, parameters?: Parameters) {
+    logger({message: `[Onyx] ${message}`, level: 'info', parameters});
 }
 
 /**
  * Send an hmmm message to the logger
  */
-function logHmmm(message: string, extraData?: Record<string, unknown>) {
-    logger({message: `[Onyx] ${message}`, level: 'hmmm', extraData});
+function logHmmm(message: string, parameters?: Parameters) {
+    logger({message: `[Onyx] ${message}`, level: 'hmmm', parameters});
 }
 
 export {registerLogger, logInfo, logAlert, logHmmm};

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -390,7 +390,7 @@ function multiGet<TKey extends OnyxKey>(keys: CollectionKeyBase[]): Promise<Map<
  * This helper exists to map an array of Onyx keys such as `['report_', 'conciergeReportID']`
  * to the values for those keys (correctly typed) such as `[OnyxCollection<Report>, OnyxEntry<string>]`
  *
- * Note: just using .map, you'd end up with `Array<OnyxCollection<Report>|OnyxEntry<string>>`, which is not what we want. This preserves the order of the keys provided.
+ * Note: just using `.map`, you'd end up with `Array<OnyxCollection<Report>|OnyxEntry<string>>`, which is not what we want. This preserves the order of the keys provided.
  */
 function tupleGet<Keys extends readonly OnyxKey[]>(keys: Keys): Promise<{[Index in keyof Keys]: OnyxValue<Keys[Index]>}> {
     return Promise.all(keys.map((key) => OnyxUtils.get(key))) as Promise<{[Index in keyof Keys]: OnyxValue<Keys[Index]>}>;

--- a/lib/useOnyx.ts
+++ b/lib/useOnyx.ts
@@ -289,7 +289,7 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
             // If `canBeMissing` is set to `false` and the Onyx value of that key is not defined,
             // we log an alert so it can be acknowledged by the consumer.
             if (options?.canBeMissing === false && newStatus === 'loaded' && !isOnyxValueDefined) {
-                Logger.logAlert(`useOnyx returned no data for key '${key}' while canBeMissing was set to false.`, {showAlert: true});
+                Logger.logAlert(`useOnyx returned no data for key with canBeMissing set to false.`, {key, showAlert: true});
             }
         }
 

--- a/lib/useOnyx.ts
+++ b/lib/useOnyx.ts
@@ -104,17 +104,6 @@ function tryGetCachedValue<TKey extends OnyxKey>(key: TKey): OnyxValue<OnyxKey> 
     return values;
 }
 
-/**
- * Gets the value from cache and maps it with selector. It changes `null` to `undefined` for `useOnyx` compatibility.
- */
-function getCachedValue<TKey extends OnyxKey, TValue>(key: TKey, selector?: UseOnyxSelector<TKey, TValue>) {
-    const value = tryGetCachedValue(key) as OnyxValue<TKey>;
-
-    const selectedValue = selector ? selector(value) : (value as TValue);
-
-    return selectedValue ?? undefined;
-}
-
 function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
     key: TKey,
     options?: BaseUseOnyxOptions & UseOnyxInitialValueOption<TReturnValue> & Required<UseOnyxSelectorOption<TKey, TReturnValue>>,
@@ -225,6 +214,8 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
     }, [key, options?.canEvict]);
 
     const getSnapshot = useCallback(() => {
+        let isOnyxValueDefined = true;
+
         // We return the initial result right away during the first connection if `initWithStoredValues` is set to `false`.
         if (isFirstConnectionRef.current && options?.initWithStoredValues === false) {
             return resultRef.current;
@@ -234,11 +225,14 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
         // so we can return any cached value right away. After the connection is made, we only
         // update `newValueRef` when `Onyx.connect()` callback is fired.
         if (isFirstConnectionRef.current || shouldGetCachedValueRef.current) {
-            // If `newValueRef.current` is `undefined` it means that the cache doesn't have a value for that key yet.
-            // If `newValueRef.current` is `null` or any other value it means that the cache does have a value for that key.
-            // This difference between `undefined` and other values is crucial and it's used to address the following
-            // conditions and use cases.
-            newValueRef.current = getCachedValue(key, selectorRef.current);
+            // Gets the value from cache and maps it with selector. It changes `null` to `undefined` for `useOnyx` compatibility.
+            const value = tryGetCachedValue(key) as OnyxValue<TKey>;
+            const selectedValue = selectorRef.current ? selectorRef.current(value) : value;
+            newValueRef.current = (selectedValue ?? undefined) as TReturnValue | undefined;
+
+            // This flag is `false` when the original Onyx value (without selector) is not defined yet.
+            // It will be used later to check if we need to log an alert that the value is missing.
+            isOnyxValueDefined = value !== null && value !== undefined;
 
             // We set this flag to `false` again since we don't want to get the newest cached value every time `getSnapshot()` is executed,
             // and only when `Onyx.connect()` callback is fired.
@@ -261,7 +255,7 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
         // If data is not present in cache and `initialValue` is set during the first connection,
         // we set the new value to `initialValue` and fetch status to `loaded` since we already have some data to return to the consumer.
         if (isFirstConnectionRef.current && !hasCacheForKey && options?.initialValue !== undefined) {
-            newValueRef.current = (options?.initialValue ?? undefined) as TReturnValue;
+            newValueRef.current = options.initialValue;
             newFetchStatus = 'loaded';
         }
 
@@ -275,7 +269,7 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
             areValuesEqual = shallowEqual(previousValueRef.current ?? undefined, newValueRef.current);
         }
 
-        // We updated the cached value and the result in the following conditions:
+        // We update the cached value and the result in the following conditions:
         // We will update the cached value and the result in any of the following situations:
         // - The previously cached value is different from the new value.
         // - The previously cached value is `null` (not set from cache yet) and we have cache for this key
@@ -286,11 +280,12 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
             previousValueRef.current = newValueRef.current;
 
             // If the new value is `null` we default it to `undefined` to ensure the consumer gets a consistent result from the hook.
-            const newValue = previousValueRef.current ?? undefined;
             const newStatus = newFetchStatus ?? 'loaded';
             resultRef.current = [previousValueRef.current ?? undefined, {status: newStatus}];
 
-            if (options?.canBeMissing === false && newStatus === 'loaded' && newValue === undefined) {
+            // If `canBeMissing` is set to `false` and the Onyx value of that key is not defined,
+            // we log an alert so it can be acknowledged by the consumer.
+            if (options?.canBeMissing === false && newStatus === 'loaded' && !isOnyxValueDefined) {
                 Logger.logAlert(`useOnyx returned no data for key '${key}' while canBeMissing was set to false.`);
             }
         }

--- a/lib/useOnyx.ts
+++ b/lib/useOnyx.ts
@@ -286,7 +286,7 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
             // If `canBeMissing` is set to `false` and the Onyx value of that key is not defined,
             // we log an alert so it can be acknowledged by the consumer.
             if (options?.canBeMissing === false && newStatus === 'loaded' && !isOnyxValueDefined) {
-                Logger.logAlert(`useOnyx returned no data for key '${key}' while canBeMissing was set to false.`);
+                Logger.logAlert(`useOnyx returned no data for key '${key}' while canBeMissing was set to false.`, {showAlert: true});
             }
         }
 

--- a/lib/useOnyx.ts
+++ b/lib/useOnyx.ts
@@ -40,7 +40,10 @@ type BaseUseOnyxOptions = {
     allowDynamicKey?: boolean;
 
     /**
-     * If set to `false`, the hook will log an alert when Onyx doesn't return data for that key.
+     * If the component calling this is the one loading the data by calling an action, then you should set this to `true`.
+     *
+     * If the component calling this does not load the data then you should set it to `false`, which means that if the data
+     * is not there, it will log an alert, as it means we are using data that no one loaded and that's most probably a bug.
      */
     canBeMissing?: boolean;
 };

--- a/tests/unit/useOnyxTest.ts
+++ b/tests/unit/useOnyxTest.ts
@@ -752,7 +752,6 @@ describe('useOnyx', () => {
 
     describe('canBeMissing', () => {
         let logAlertFn = jest.fn();
-        const alertMessage = 'useOnyx returned no data for key with canBeMissing set to false.';
 
         beforeEach(() => {
             logAlertFn = jest.fn();

--- a/tests/unit/useOnyxTest.ts
+++ b/tests/unit/useOnyxTest.ts
@@ -752,7 +752,8 @@ describe('useOnyx', () => {
 
     describe('canBeMissing', () => {
         let logAlertFn = jest.fn();
-        const alert = (key: string) => `useOnyx returned no data for key '${key}' while canBeMissing was set to false.`;
+        // const alert = (key: string) => `useOnyx returned no data for key '${key}' while canBeMissing was set to false.`;
+        const alertMessage = 'useOnyx returned no data for key with canBeMissing set to false.';
 
         beforeEach(() => {
             logAlertFn = jest.fn();
@@ -773,7 +774,7 @@ describe('useOnyx', () => {
 
             expect(result1.current[0]).toBeUndefined();
             expect(result1.current[1].status).toEqual('loaded');
-            expect(logAlertFn).not.toBeCalledWith(alert(ONYXKEYS.TEST_KEY));
+            expect(logAlertFn).not.toBeCalledWith(alertMessage);
 
             await act(async () => Onyx.set(ONYXKEYS.TEST_KEY, 'test'));
 
@@ -782,7 +783,7 @@ describe('useOnyx', () => {
             await act(async () => Onyx.set(ONYXKEYS.TEST_KEY, null));
 
             expect(result1.current[0]).toBeUndefined();
-            expect(logAlertFn).not.toBeCalledWith(alert(ONYXKEYS.TEST_KEY));
+            expect(logAlertFn).not.toBeCalledWith(alertMessage);
         });
 
         it('should not log an alert if Onyx doesn\'t return data, "canBeMissing" property is false but "initWithStoredValues" is also false', async () => {
@@ -791,7 +792,7 @@ describe('useOnyx', () => {
             expect(result1.current[0]).toBeUndefined();
             expect(result1.current[1].status).toEqual('loaded');
 
-            expect(logAlertFn).not.toBeCalledWith(alert(ONYXKEYS.TEST_KEY));
+            expect(logAlertFn).not.toBeCalledWith(alertMessage);
         });
 
         it('should log an alert if Onyx doesn\'t return data in loaded state and "canBeMissing" property is false', async () => {
@@ -799,14 +800,14 @@ describe('useOnyx', () => {
 
             expect(result1.current[0]).toBeUndefined();
             expect(result1.current[1].status).toEqual('loading');
-            expect(logAlertFn).not.toBeCalledWith(alert(ONYXKEYS.TEST_KEY));
+            expect(logAlertFn).not.toBeCalledWith(alertMessage);
 
             await act(async () => waitForPromisesToResolve());
 
             expect(result1.current[0]).toBeUndefined();
             expect(result1.current[1].status).toEqual('loaded');
             expect(logAlertFn).toHaveBeenCalledTimes(1);
-            expect(logAlertFn).toHaveBeenNthCalledWith(1, alert(ONYXKEYS.TEST_KEY), {showAlert: true});
+            expect(logAlertFn).toHaveBeenNthCalledWith(1, alertMessage, {key: ONYXKEYS.TEST_KEY, showAlert: true});
 
             await act(async () => Onyx.set(ONYXKEYS.TEST_KEY, 'test'));
 
@@ -816,7 +817,7 @@ describe('useOnyx', () => {
 
             expect(result1.current[0]).toBeUndefined();
             expect(logAlertFn).toHaveBeenCalledTimes(2);
-            expect(logAlertFn).toHaveBeenNthCalledWith(2, alert(ONYXKEYS.TEST_KEY), {showAlert: true});
+            expect(logAlertFn).toHaveBeenNthCalledWith(2, alertMessage, {key: ONYXKEYS.TEST_KEY, showAlert: true});
         });
 
         it('should log an alert if Onyx doesn\'t return selected data in loaded state and "canBeMissing" property is false', async () => {
@@ -830,14 +831,14 @@ describe('useOnyx', () => {
 
             expect(result1.current[0]).toBeUndefined();
             expect(result1.current[1].status).toEqual('loading');
-            expect(logAlertFn).not.toBeCalledWith(alert(ONYXKEYS.TEST_KEY));
+            expect(logAlertFn).not.toBeCalledWith(alertMessage);
 
             await act(async () => waitForPromisesToResolve());
 
             expect(result1.current[0]).toBeUndefined();
             expect(result1.current[1].status).toEqual('loaded');
             expect(logAlertFn).toHaveBeenCalledTimes(1);
-            expect(logAlertFn).toHaveBeenNthCalledWith(1, alert(ONYXKEYS.TEST_KEY), {showAlert: true});
+            expect(logAlertFn).toHaveBeenNthCalledWith(1, alertMessage, {key: ONYXKEYS.TEST_KEY, showAlert: true});
 
             await act(async () => Onyx.set(ONYXKEYS.TEST_KEY, 'test'));
 
@@ -847,7 +848,7 @@ describe('useOnyx', () => {
 
             expect(result1.current[0]).toBeUndefined();
             expect(logAlertFn).toHaveBeenCalledTimes(2);
-            expect(logAlertFn).toHaveBeenNthCalledWith(2, alert(ONYXKEYS.TEST_KEY), {showAlert: true});
+            expect(logAlertFn).toHaveBeenNthCalledWith(2, alertMessage, {key: ONYXKEYS.TEST_KEY, showAlert: true});
         });
 
         it('should log an alert if Onyx doesn\'t return data but there is a selector that always return something and "canBeMissing" property is false', async () => {
@@ -865,7 +866,7 @@ describe('useOnyx', () => {
             expect(result1.current[0]).toBe('undefined_changed');
             expect(result1.current[1].status).toEqual('loaded');
             expect(logAlertFn).toHaveBeenCalledTimes(1);
-            expect(logAlertFn).toHaveBeenNthCalledWith(1, alert(ONYXKEYS.TEST_KEY), {showAlert: true});
+            expect(logAlertFn).toHaveBeenNthCalledWith(1, alertMessage, {key: ONYXKEYS.TEST_KEY, showAlert: true});
 
             await act(async () => Onyx.set(ONYXKEYS.TEST_KEY, 'test'));
 
@@ -875,7 +876,7 @@ describe('useOnyx', () => {
 
             expect(result1.current[0]).toBe('undefined_changed');
             expect(logAlertFn).toHaveBeenCalledTimes(2);
-            expect(logAlertFn).toHaveBeenNthCalledWith(2, alert(ONYXKEYS.TEST_KEY), {showAlert: true});
+            expect(logAlertFn).toHaveBeenNthCalledWith(2, alertMessage, {key: ONYXKEYS.TEST_KEY, showAlert: true});
         });
     });
 

--- a/tests/unit/useOnyxTest.ts
+++ b/tests/unit/useOnyxTest.ts
@@ -850,7 +850,7 @@ describe('useOnyx', () => {
             expect(logAlertFn).toHaveBeenNthCalledWith(2, alert(ONYXKEYS.TEST_KEY));
         });
 
-        it('should not log an alert if Onyx doesn\'t return data but there is a selector that always return something and "canBeMissing" property is false', async () => {
+        it('should log an alert if Onyx doesn\'t return data but there is a selector that always return something and "canBeMissing" property is false', async () => {
             const {result: result1} = renderHook(() =>
                 useOnyx(ONYXKEYS.TEST_KEY, {
                     // @ts-expect-error bypass
@@ -864,7 +864,8 @@ describe('useOnyx', () => {
 
             expect(result1.current[0]).toBe('undefined_changed');
             expect(result1.current[1].status).toEqual('loaded');
-            expect(logAlertFn).not.toBeCalledWith(alert(ONYXKEYS.TEST_KEY));
+            expect(logAlertFn).toHaveBeenCalledTimes(1);
+            expect(logAlertFn).toHaveBeenNthCalledWith(1, alert(ONYXKEYS.TEST_KEY));
 
             await act(async () => Onyx.set(ONYXKEYS.TEST_KEY, 'test'));
 
@@ -873,7 +874,8 @@ describe('useOnyx', () => {
             await act(async () => Onyx.set(ONYXKEYS.TEST_KEY, null));
 
             expect(result1.current[0]).toBe('undefined_changed');
-            expect(logAlertFn).not.toBeCalledWith(alert(ONYXKEYS.TEST_KEY));
+            expect(logAlertFn).toHaveBeenCalledTimes(2);
+            expect(logAlertFn).toHaveBeenNthCalledWith(2, alert(ONYXKEYS.TEST_KEY));
         });
     });
 

--- a/tests/unit/useOnyxTest.ts
+++ b/tests/unit/useOnyxTest.ts
@@ -806,7 +806,7 @@ describe('useOnyx', () => {
             expect(result1.current[0]).toBeUndefined();
             expect(result1.current[1].status).toEqual('loaded');
             expect(logAlertFn).toHaveBeenCalledTimes(1);
-            expect(logAlertFn).toHaveBeenNthCalledWith(1, alert(ONYXKEYS.TEST_KEY));
+            expect(logAlertFn).toHaveBeenNthCalledWith(1, alert(ONYXKEYS.TEST_KEY), {showAlert: true});
 
             await act(async () => Onyx.set(ONYXKEYS.TEST_KEY, 'test'));
 
@@ -816,7 +816,7 @@ describe('useOnyx', () => {
 
             expect(result1.current[0]).toBeUndefined();
             expect(logAlertFn).toHaveBeenCalledTimes(2);
-            expect(logAlertFn).toHaveBeenNthCalledWith(2, alert(ONYXKEYS.TEST_KEY));
+            expect(logAlertFn).toHaveBeenNthCalledWith(2, alert(ONYXKEYS.TEST_KEY), {showAlert: true});
         });
 
         it('should log an alert if Onyx doesn\'t return selected data in loaded state and "canBeMissing" property is false', async () => {
@@ -837,7 +837,7 @@ describe('useOnyx', () => {
             expect(result1.current[0]).toBeUndefined();
             expect(result1.current[1].status).toEqual('loaded');
             expect(logAlertFn).toHaveBeenCalledTimes(1);
-            expect(logAlertFn).toHaveBeenNthCalledWith(1, alert(ONYXKEYS.TEST_KEY));
+            expect(logAlertFn).toHaveBeenNthCalledWith(1, alert(ONYXKEYS.TEST_KEY), {showAlert: true});
 
             await act(async () => Onyx.set(ONYXKEYS.TEST_KEY, 'test'));
 
@@ -847,7 +847,7 @@ describe('useOnyx', () => {
 
             expect(result1.current[0]).toBeUndefined();
             expect(logAlertFn).toHaveBeenCalledTimes(2);
-            expect(logAlertFn).toHaveBeenNthCalledWith(2, alert(ONYXKEYS.TEST_KEY));
+            expect(logAlertFn).toHaveBeenNthCalledWith(2, alert(ONYXKEYS.TEST_KEY), {showAlert: true});
         });
 
         it('should log an alert if Onyx doesn\'t return data but there is a selector that always return something and "canBeMissing" property is false', async () => {
@@ -865,7 +865,7 @@ describe('useOnyx', () => {
             expect(result1.current[0]).toBe('undefined_changed');
             expect(result1.current[1].status).toEqual('loaded');
             expect(logAlertFn).toHaveBeenCalledTimes(1);
-            expect(logAlertFn).toHaveBeenNthCalledWith(1, alert(ONYXKEYS.TEST_KEY));
+            expect(logAlertFn).toHaveBeenNthCalledWith(1, alert(ONYXKEYS.TEST_KEY), {showAlert: true});
 
             await act(async () => Onyx.set(ONYXKEYS.TEST_KEY, 'test'));
 
@@ -875,7 +875,7 @@ describe('useOnyx', () => {
 
             expect(result1.current[0]).toBe('undefined_changed');
             expect(logAlertFn).toHaveBeenCalledTimes(2);
-            expect(logAlertFn).toHaveBeenNthCalledWith(2, alert(ONYXKEYS.TEST_KEY));
+            expect(logAlertFn).toHaveBeenNthCalledWith(2, alert(ONYXKEYS.TEST_KEY), {showAlert: true});
         });
     });
 

--- a/tests/unit/useOnyxTest.ts
+++ b/tests/unit/useOnyxTest.ts
@@ -752,7 +752,6 @@ describe('useOnyx', () => {
 
     describe('canBeMissing', () => {
         let logAlertFn = jest.fn();
-        // const alert = (key: string) => `useOnyx returned no data for key '${key}' while canBeMissing was set to false.`;
         const alertMessage = 'useOnyx returned no data for key with canBeMissing set to false.';
 
         beforeEach(() => {

--- a/tests/unit/useOnyxTest.ts
+++ b/tests/unit/useOnyxTest.ts
@@ -752,6 +752,7 @@ describe('useOnyx', () => {
 
     describe('canBeMissing', () => {
         let logAlertFn = jest.fn();
+        const alertMessage = 'useOnyx returned no data for key with canBeMissing set to false.';
 
         beforeEach(() => {
             logAlertFn = jest.fn();

--- a/tests/unit/useOnyxTest.ts
+++ b/tests/unit/useOnyxTest.ts
@@ -799,11 +799,13 @@ describe('useOnyx', () => {
 
             expect(result1.current[0]).toBeUndefined();
             expect(result1.current[1].status).toEqual('loading');
+            expect(logAlertFn).not.toBeCalledWith(alert(ONYXKEYS.TEST_KEY));
 
             await act(async () => waitForPromisesToResolve());
 
             expect(result1.current[0]).toBeUndefined();
             expect(result1.current[1].status).toEqual('loaded');
+            expect(logAlertFn).toHaveBeenCalledTimes(1);
             expect(logAlertFn).toHaveBeenNthCalledWith(1, alert(ONYXKEYS.TEST_KEY));
 
             await act(async () => Onyx.set(ONYXKEYS.TEST_KEY, 'test'));
@@ -813,6 +815,7 @@ describe('useOnyx', () => {
             await act(async () => Onyx.set(ONYXKEYS.TEST_KEY, null));
 
             expect(result1.current[0]).toBeUndefined();
+            expect(logAlertFn).toHaveBeenCalledTimes(2);
             expect(logAlertFn).toHaveBeenNthCalledWith(2, alert(ONYXKEYS.TEST_KEY));
         });
 
@@ -827,11 +830,13 @@ describe('useOnyx', () => {
 
             expect(result1.current[0]).toBeUndefined();
             expect(result1.current[1].status).toEqual('loading');
+            expect(logAlertFn).not.toBeCalledWith(alert(ONYXKEYS.TEST_KEY));
 
             await act(async () => waitForPromisesToResolve());
 
             expect(result1.current[0]).toBeUndefined();
             expect(result1.current[1].status).toEqual('loaded');
+            expect(logAlertFn).toHaveBeenCalledTimes(1);
             expect(logAlertFn).toHaveBeenNthCalledWith(1, alert(ONYXKEYS.TEST_KEY));
 
             await act(async () => Onyx.set(ONYXKEYS.TEST_KEY, 'test'));
@@ -841,6 +846,7 @@ describe('useOnyx', () => {
             await act(async () => Onyx.set(ONYXKEYS.TEST_KEY, null));
 
             expect(result1.current[0]).toBeUndefined();
+            expect(logAlertFn).toHaveBeenCalledTimes(2);
             expect(logAlertFn).toHaveBeenNthCalledWith(2, alert(ONYXKEYS.TEST_KEY));
         });
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details

This PR adds a new `canBeMissing` configuration flag to `useOnyx`. This flag, when explicitly set to `false`, will log an alert when Onyx doesn't return data for that key.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/App/issues/58499

### Automated Tests

Unit tests were added to cover this feature.

### Manual Tests
<!---
Each set of changes should be tested against the Expensify/App repo on all platforms to verify it does not break our staging App.
--->

1. Checkout this branch and link it to your E/App repo by following [these instructions](https://github.com/Expensify/react-native-onyx/blob/main/README.md#development).
2. Change one of the `useOnyx()`s of [FreeTrial.tsx](https://github.com/Expensify/App/blob/main/src/pages/settings/Subscription/FreeTrial.tsx) component to set the `canBeMissing` flag.
   ```diff
   diff --git a/src/pages/settings/Subscription/FreeTrial.tsx b/src/pages/settings/Subscription/FreeTrial.tsx
   index 1d82614d66f..b3872873c3f 100644
   --- a/src/pages/settings/Subscription/FreeTrial.tsx
   +++ b/src/pages/settings/Subscription/FreeTrial.tsx
   @@ -23,7 +23,7 @@ type FreeTrialProps = {
   function FreeTrial({badgeStyles, pressable = false, addSpacing = false, success = true, inARow = false}: FreeTrialProps) {
       const styles = useThemeStyles();
       const [policies] = useOnyx(ONYXKEYS.COLLECTION.POLICY);
   -    const [firstDayFreeTrial] = useOnyx(ONYXKEYS.NVP_FIRST_DAY_FREE_TRIAL);
   +    const [firstDayFreeTrial] = useOnyx(ONYXKEYS.NVP_FIRST_DAY_FREE_TRIAL, {canBeMissing: false});
       const [lastDayFreeTrial] = useOnyx(ONYXKEYS.NVP_LAST_DAY_FREE_TRIAL);
       const [privateSubscription] = useOnyx(ONYXKEYS.NVP_PRIVATE_SUBSCRIPTION);
   
   
   ```
3. Change [Expensify.tsx](https://github.com/Expensify/App/blob/main/src/Expensify.tsx) to display the alert.
   ```diff
   diff --git a/src/Expensify.tsx b/src/Expensify.tsx
   index 13542380888..b01542872b1 100644
   --- a/src/Expensify.tsx
   +++ b/src/Expensify.tsx
   @@ -4,6 +4,7 @@ import type {NativeEventSubscription} from 'react-native';
    import {AppState, Linking, Platform} from 'react-native';
    import type {OnyxEntry} from 'react-native-onyx';
    import Onyx, {useOnyx} from 'react-native-onyx';
   +import alert from './components/Alert';
    import ConfirmModal from './components/ConfirmModal';
    import DeeplinkWrapper from './components/DeeplinkWrapper';
    import EmojiPicker from './components/EmojiPicker/EmojiPicker';
   @@ -45,10 +46,14 @@ import type {Route} from './ROUTES';
    import SplashScreenStateContext from './SplashScreenStateContext';
    import type {ScreenShareRequest} from './types/onyx';
    
   -Onyx.registerLogger(({level, message}) => {
   +Onyx.registerLogger(({level, message, extraData}) => {
        if (level === 'alert') {
            Log.alert(message);
            console.error(message);
   +
   +        if (extraData?.showAlert) {
   +            alert(message);
   +        }
        } else if (level === 'hmmm') {
            Log.hmmm(message);
        } else {
   
   ```
4. Create a new account and sign in.
5. Switch between Settings and Inbox in order to trigger the alert.
6. Assert an alert is displayed both visually and in the console.

### Author Checklist

- [x] I linked the correct issue in the `### Related Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>


https://github.com/user-attachments/assets/724123bf-0b9b-473a-b340-0c1f23f2fc36



</details>

<details>
<summary>Android: mWeb Chrome</summary>

I'm having problems with my emulators when opening the Chrome app (they crash instantly), so I couldn't record videos for this platform.

</details>

<details>
<summary>iOS: Native</summary>


https://github.com/user-attachments/assets/f26df8d4-9325-49a7-89b7-f1f944c45559



</details>

<details>
<summary>iOS: mWeb Safari</summary>


https://github.com/user-attachments/assets/cbdd86f3-0cd9-4dec-99d6-bc29a74e3398



</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/164bb01f-8ba5-4944-89e8-f4e577b67819


https://github.com/user-attachments/assets/642755dd-736f-409c-8334-3e1998ab026c




</details>

<details>
<summary>MacOS: Desktop</summary>


https://github.com/user-attachments/assets/b4463cc2-51d6-48aa-9d4f-46d38287121c



</details>
