### PR TITLE
Prevent "canBeMissing" alert if Onyx.clear() is in progress

### DIFF
--- a/lib/useOnyx.ts
+++ b/lib/useOnyx.ts
@@ -287,8 +287,9 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
             resultRef.current = [previousValueRef.current ?? undefined, {status: newStatus}];
 
             // If `canBeMissing` is set to `false` and the Onyx value of that key is not defined,
-            // we log an alert so it can be acknowledged by the consumer.
-            if (options?.canBeMissing === false && newStatus === 'loaded' && !isOnyxValueDefined) {
+            // we log an alert so it can be acknowledged by the consumer. Additionally, we won't log alerts
+            // if there's a `Onyx.clear()` task in progress.
+            if (options?.canBeMissing === false && newStatus === 'loaded' && !isOnyxValueDefined && !OnyxCache.hasPendingTask(TASK.CLEAR)) {
                 Logger.logAlert(`useOnyx returned no data for key with canBeMissing set to false.`, {key, showAlert: true});
             }
         }

--- a/tests/unit/useOnyxTest.ts
+++ b/tests/unit/useOnyxTest.ts
@@ -773,7 +773,7 @@ describe('useOnyx', () => {
 
             expect(result1.current[0]).toBeUndefined();
             expect(result1.current[1].status).toEqual('loaded');
-            expect(logAlertFn).not.toBeCalledWith(alertMessage);
+            expect(logAlertFn).not.toBeCalled();
 
             await act(async () => Onyx.set(ONYXKEYS.TEST_KEY, 'test'));
 
@@ -782,7 +782,7 @@ describe('useOnyx', () => {
             await act(async () => Onyx.set(ONYXKEYS.TEST_KEY, null));
 
             expect(result1.current[0]).toBeUndefined();
-            expect(logAlertFn).not.toBeCalledWith(alertMessage);
+            expect(logAlertFn).not.toBeCalled();
         });
 
         it('should not log an alert if Onyx doesn\'t return data, "canBeMissing" property is false but "initWithStoredValues" is also false', async () => {
@@ -791,7 +791,7 @@ describe('useOnyx', () => {
             expect(result1.current[0]).toBeUndefined();
             expect(result1.current[1].status).toEqual('loaded');
 
-            expect(logAlertFn).not.toBeCalledWith(alertMessage);
+            expect(logAlertFn).not.toBeCalled();
         });
 
         it('should log an alert if Onyx doesn\'t return data in loaded state and "canBeMissing" property is false', async () => {
@@ -799,7 +799,7 @@ describe('useOnyx', () => {
 
             expect(result1.current[0]).toBeUndefined();
             expect(result1.current[1].status).toEqual('loading');
-            expect(logAlertFn).not.toBeCalledWith(alertMessage);
+            expect(logAlertFn).not.toBeCalled();
 
             await act(async () => waitForPromisesToResolve());
 
@@ -830,7 +830,7 @@ describe('useOnyx', () => {
 
             expect(result1.current[0]).toBeUndefined();
             expect(result1.current[1].status).toEqual('loading');
-            expect(logAlertFn).not.toBeCalledWith(alertMessage);
+            expect(logAlertFn).not.toBeCalled();
 
             await act(async () => waitForPromisesToResolve());
 
@@ -876,6 +876,31 @@ describe('useOnyx', () => {
             expect(result1.current[0]).toBe('undefined_changed');
             expect(logAlertFn).toHaveBeenCalledTimes(2);
             expect(logAlertFn).toHaveBeenNthCalledWith(2, alertMessage, {key: ONYXKEYS.TEST_KEY, showAlert: true});
+        });
+
+        it('should not log an alert if "canBeMissing" property is false but there is a Onyx.clear() task in progress', async () => {
+            const {result: result1} = renderHook(() => useOnyx(ONYXKEYS.TEST_KEY, {canBeMissing: false}));
+
+            expect(result1.current[0]).toBeUndefined();
+            expect(result1.current[1].status).toEqual('loading');
+            expect(logAlertFn).not.toBeCalled();
+
+            await act(async () => waitForPromisesToResolve());
+
+            expect(result1.current[0]).toBeUndefined();
+            expect(result1.current[1].status).toEqual('loaded');
+            expect(logAlertFn).toHaveBeenCalledTimes(1);
+            expect(logAlertFn).toHaveBeenNthCalledWith(1, alertMessage, {key: ONYXKEYS.TEST_KEY, showAlert: true});
+
+            await act(async () => Onyx.set(ONYXKEYS.TEST_KEY, 'test'));
+
+            expect(result1.current[0]).toBe('test');
+
+            logAlertFn.mockReset();
+            await act(async () => Onyx.clear());
+
+            expect(result1.current[0]).toBeUndefined();
+            expect(logAlertFn).not.toBeCalled();
         });
     });
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details

This PR fixes the useOnyx() `canBeMissing` logic previously introduced [here](https://github.com/Expensify/react-native-onyx/pull/623) to stop logging alerts if there's a Onyx.clear() task in progress. This fix will prevent unnecessary and wrong logging when signing out in NewDot.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/App/issues/58499

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

Unit tests were added to cover this fix.

### Manual Tests
<!---
Each set of changes should be tested against the Expensify/App repo on all platforms to verify it does not break our staging App.
--->

1. Checkout this branch and link it to your E/App repo (using [this PR](https://github.com/Expensify/App/pull/59191) branch) by following [these instructions](https://github.com/Expensify/react-native-onyx/blob/main/README.md#development).
2. Change one of the `useOnyx()`s of [InitialSettingsPage.tsx](https://github.com/Expensify/App/blob/main/src/pages/settings/InitialSettingsPage.tsx) for example that already have a Onyx value.
   ```diff
   diff --git a/src/pages/settings/InitialSettingsPage.tsx b/src/pages/settings/InitialSettingsPage.tsx
   index f13438566f3..729634fd92f 100755
   --- a/src/pages/settings/InitialSettingsPage.tsx
   +++ b/src/pages/settings/InitialSettingsPage.tsx
   @@ -86,7 +86,7 @@ function InitialSettingsPage({currentUserPersonalDetails}: InitialSettingsPagePr
        const [bankAccountList] = useOnyx(ONYXKEYS.BANK_ACCOUNT_LIST);
        const [fundList] = useOnyx(ONYXKEYS.FUND_LIST);
        const [walletTerms] = useOnyx(ONYXKEYS.WALLET_TERMS);
   -    const [loginList] = useOnyx(ONYXKEYS.LOGIN_LIST);
   +    const [loginList] = useOnyx(ONYXKEYS.LOGIN_LIST, {canBeMissing: false});
        const [policies] = useOnyx(ONYXKEYS.COLLECTION.POLICY);
        const [privatePersonalDetails] = useOnyx(ONYXKEYS.PRIVATE_PERSONAL_DETAILS);
        const [tryNewDot] = useOnyx(ONYXKEYS.NVP_TRYNEWDOT);
   
   ```
3. Create a new account and sign in.
4. Go to Settings and sign out the user.
5. Assert no alerts are displayed.

### Author Checklist

- [x] I linked the correct issue in the `### Related Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
