### PR TITLE
Pin GitHub Actions to immutable commit SHAs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,8 @@ jobs:
             - uses: actions/checkout@v4
 
             - name: Setup Node
-              uses: actions/setup-node@v4
+              # v4
+              uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
               with:
                   node-version-file: ".nvmrc"
                   cache: npm

--- a/.github/workflows/reassurePerfTests.yml
+++ b/.github/workflows/reassurePerfTests.yml
@@ -11,12 +11,14 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              # v4
+              uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
               with:
                   fetch-depth: 0
 
             - name: Setup Node
-              uses: actions/setup-node@v4
+              # v4
+              uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
               with:
                   node-version-file: '.nvmrc'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,8 @@ jobs:
                       ${{ runner.os }}-node-
 
             - name: Setup Node
-              uses: actions/setup-node@v4
+              # v4
+              uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
               with:
                   node-version-file: ".nvmrc"
 

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -11,7 +11,8 @@ jobs:
             - uses: actions/checkout@v4
 
             - name: Setup Node
-              uses: actions/setup-node@v4
+              # v4
+              uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
               with:
                   node-version-file: ".nvmrc"
                   cache: npm


### PR DESCRIPTION
Coming from https://expensify.slack.com/archives/CC7NECV4L/p1743022578963949, this pull request updates all mutable action references to use immutable commit hashes instead. This is a security measure to protect from supply chain attacks.