### PR TITLE
fix: snapshot data is updated after the loading state

### DIFF
--- a/lib/Onyx.ts
+++ b/lib/Onyx.ts
@@ -730,8 +730,8 @@ function update(data: OnyxUpdate[]): Promise<void> {
     });
 
     return clearPromise
-        .then(() => Promise.all(promises.map((p) => p())))
         .then(() => updateSnapshots(data))
+        .then(() => Promise.all(promises.map((p) => p())))
         .then(() => undefined);
 }
 

--- a/lib/Onyx.ts
+++ b/lib/Onyx.ts
@@ -731,7 +731,10 @@ function update(data: OnyxUpdate[]): Promise<void> {
 
     const snapshotPromises = updateSnapshots(data);
 
-    return clearPromise.then(() => Promise.all([...snapshotPromises, ...promises].map((p) => p()))).then(() => undefined);
+    // We need to run the snapshot updates before the other updates so the snapshot data can be updated before the loading state in the snapshot
+    const finalPromises = snapshotPromises.concat(promises);
+
+    return clearPromise.then(() => Promise.all(finalPromises.map((p) => p()))).then(() => undefined);
 }
 
 type BaseCollection<TMap> = Record<string, TMap | null>;

--- a/lib/Onyx.ts
+++ b/lib/Onyx.ts
@@ -552,7 +552,7 @@ function clear(keysToPreserve: OnyxKey[] = []): Promise<void> {
 
 function updateSnapshots(data: OnyxUpdate[]) {
     const snapshotCollectionKey = OnyxUtils.getSnapshotKey();
-    if (!snapshotCollectionKey) return;
+    if (!snapshotCollectionKey) return [];
 
     const promises: Array<() => Promise<void>> = [];
 
@@ -601,7 +601,7 @@ function updateSnapshots(data: OnyxUpdate[]) {
         promises.push(() => merge(snapshotKey, {data: updatedData}));
     });
 
-    return Promise.all(promises.map((p) => p()));
+    return promises;
 }
 
 /**
@@ -729,10 +729,9 @@ function update(data: OnyxUpdate[]): Promise<void> {
         }
     });
 
-    return clearPromise
-        .then(() => updateSnapshots(data))
-        .then(() => Promise.all(promises.map((p) => p())))
-        .then(() => undefined);
+    const snapshotPromises = updateSnapshots(data);
+
+    return clearPromise.then(() => Promise.all([...snapshotPromises, ...promises].map((p) => p()))).then(() => undefined);
 }
 
 type BaseCollection<TMap> = Record<string, TMap | null>;

--- a/tests/unit/onyxTest.ts
+++ b/tests/unit/onyxTest.ts
@@ -1454,6 +1454,15 @@ describe('Onyx', () => {
             callback,
         });
 
+        function delay(ms: number) {
+            return new Promise((resolve) => {
+                setTimeout(resolve, ms);
+            });
+        }
+
+        // Delay for the first callback to be called
+        await delay(100);
+
         await Onyx.update([{key: cat, value: finalValue, onyxMethod: Onyx.METHOD.MERGE}]);
 
         expect(callback).toBeCalledTimes(2);

--- a/tests/unit/onyxTest.ts
+++ b/tests/unit/onyxTest.ts
@@ -1454,10 +1454,7 @@ describe('Onyx', () => {
             callback,
         });
 
-        // The snapshot is updated belong to other updates, so we need to set a delay to ensure the connection is done before the snapshot is updated
-        await new Promise((resolve) => {
-            setTimeout(resolve, 100);
-        });
+        await waitForPromisesToResolve();
 
         await Onyx.update([{key: cat, value: finalValue, onyxMethod: Onyx.METHOD.MERGE}]);
 

--- a/tests/unit/onyxTest.ts
+++ b/tests/unit/onyxTest.ts
@@ -1454,14 +1454,10 @@ describe('Onyx', () => {
             callback,
         });
 
-        function delay(ms: number) {
-            return new Promise((resolve) => {
-                setTimeout(resolve, ms);
-            });
-        }
-
-        // Delay for the first callback to be called
-        await delay(100);
+        // The snapshot is updated belong to other updates, so we need to set a delay to ensure the connection is done before the snapshot is updated
+        await new Promise((resolve) => {
+            setTimeout(resolve, 100);
+        });
 
         await Onyx.update([{key: cat, value: finalValue, onyxMethod: Onyx.METHOD.MERGE}]);
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/App/issues/53265

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Manual Tests
<!---
Each set of changes should be tested against the Expensify/App repo on all platforms to verify it does not break our staging App.
--->

Precondition: Approval is enabled, Delay submission is manually

1. Go to the WS chat
2. Create an expense and submit it
3. Open the Reports
4. Approve this expense on search page
5. Verify that the `Approve` doesn't display briefly

### Author Checklist

- [x] I linked the correct issue in the `### Related Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>


https://github.com/user-attachments/assets/6929f089-483b-46c6-85eb-f968273bad78


<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/user-attachments/assets/84c8cda1-83eb-4f99-aedc-4391b15f53d1

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>




<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/user-attachments/assets/4ae72523-b4e7-4cbd-831c-da4e0003a90c

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>


https://github.com/user-attachments/assets/a1bf6769-427c-4072-b223-b8ea9b56b9de


<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>


https://github.com/user-attachments/assets/9037c9ba-4b07-4f6a-9130-32d216f3e511


<!-- add screenshots or videos here -->

</details>


