### PR TITLE
feat: add blob support

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -106,7 +106,7 @@ function fastMerge<TValue>(target: TValue, source: TValue, shouldRemoveNestedNul
 
 /** Deep removes the nested null values from the given value. */
 function removeNestedNullValues<TValue extends OnyxInput<OnyxKey> | null>(value: TValue): TValue {
-    if (typeof value === 'object' && !Array.isArray(value)) {
+    if (isMergeableObject(value)) {
         const objectValue = value as Record<string, unknown>;
         return fastMerge(objectValue, objectValue) as TValue;
     }

--- a/tests/unit/onyxBlobTest.ts
+++ b/tests/unit/onyxBlobTest.ts
@@ -1,4 +1,4 @@
-import {Connection} from '../../lib';
+import type {Connection} from '../../lib';
 import Onyx from '../../lib/Onyx';
 
 // Define test keys
@@ -36,19 +36,7 @@ describe('Onyx Blob Handling', () => {
         // Set the Blob value
         await Onyx.set(ONYX_KEYS.TEST_BLOB, testBlob);
 
-        // Verify that we received a value
-        expect(testBlobValue).toBeTruthy();
-
-        // Read the original blob content
-        const originalBlobContent = await new Promise<string>((resolve) => {
-            const reader = new FileReader();
-            reader.onload = () => {
-                resolve(reader.result as string);
-            };
-            reader.readAsText(testBlob);
-        });
-
-        // Verify that the original content matches what we expected
-        expect(originalBlobContent).toBe(blobTestContent);
+        // Verify that the value is an instance of Blob
+        expect(testBlobValue instanceof Blob).toBeTruthy();
     });
 });


### PR DESCRIPTION
### Details

### Related Issues
$ https://github.com/Expensify/App/issues/9402

### Automated Tests
Unit tests were added to cover this fix.

### Manual Tests
1. Apply this changes to E/App
2. Run & Open the App
3. Turn off your internet
4. Go to any report & upload any image
5. Make sure there are no errors
6. Refresh the App
7. Make sure the image is still loads correctly

### Author Checklist

- [X] I linked the correct issue in the `### Related Issues` section above
- [X] I wrote clear testing steps that cover the changes made in this PR
    - [X] I added steps for local testing in the `Tests` section
    - [X] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [X] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [X] I ran the tests on **all platforms** & verified they passed on:
    - [X] Android / native
    - [X] Android / Chrome
    - [X] iOS / native
    - [X] iOS / Safari
    - [X] MacOS / Chrome / Safari
    - [X] MacOS / Desktop
- [X] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [X] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [X] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [X] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [X] I verified that comments were added to code that is not self explanatory
    - [X] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [X] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [X] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [X] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [X] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [X] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [X] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [X] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [X] I verified that if a function's arguments changed that all usages have also been updated correctly
- [X] If a new component is created I verified that:
    - [X] A similar component doesn't exist in the codebase
    - [X] All props are defined accurately and each prop has a `/** comment above it */`
    - [X] The file is named correctly
    - [X] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [X] The only data being stored in the state is data necessary for rendering and nothing else
    - [X] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [X] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [X] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [X] All JSX used for rendering exists in the render method
    - [X] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [X] If any new file was added I verified that:
    - [X] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [X] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [X] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [X] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/user-attachments/assets/22fc6602-bfd2-42c1-9fc2-0261ef418290


</details>

<details>
<summary>iOS: Native</summary>

</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/user-attachments/assets/6ff61b33-986d-4765-aacc-4e4a1f343dc4


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/aa0e8c60-7aae-4ac6-a391-eafc29dd70de


</details>

<details>
<summary>MacOS: Desktop</summary>

https://github.com/user-attachments/assets/bc680b4f-0092-4aa7-8726-b73821e29f2f


</details>
