### PR TITLE
fix chat section not updating

### DIFF
--- a/lib/Onyx.ts
+++ b/lib/Onyx.ts
@@ -238,6 +238,11 @@ function multiSet(data: OnyxMultiSetInput): Promise<void> {
 
     const updatePromises = keyValuePairsToSet.map(([key, value]) => {
         const prevValue = cache.get(key, false);
+        // When we use multiSet to set a key we want to clear the current delta changes from Onyx.merge that were queued
+        // before the value was set. If Onyx.merge is currently reading the old value from storage, it will then not apply the changes.
+        if (OnyxUtils.hasPendingMergeForKey(key)) {
+            delete OnyxUtils.getMergeQueue()[key];
+        }
 
         // Update cache and optimistically inform subscribers on the next tick
         cache.set(key, value);

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -1417,7 +1417,10 @@ function updateSnapshots(data: OnyxUpdate[], mergeFn: typeof Onyx.merge): Array<
             }
 
             const oldValue = updatedData[key] || {};
-            const newValue = lodashPick(value, Object.keys(snapshotData[key]));
+            const snapshotKeys = Object.keys(snapshotData[key] || {});
+            const valueKeys = Object.keys(value ?? {});
+            const hasNewKeys = valueKeys.some((k) => !snapshotKeys.includes(k));
+            const newValue = hasNewKeys ? value : lodashPick(value, snapshotKeys);
 
             updatedData = {...updatedData, [key]: Object.assign(oldValue, newValue)};
         });

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -1418,6 +1418,7 @@ function updateSnapshots(data: OnyxUpdate[], mergeFn: typeof Onyx.merge): Array<
 
             const oldValue = updatedData[key] || {};
             const newValue = lodashPick(value, Object.keys(snapshotData[key]));
+
             updatedData = {...updatedData, [key]: Object.assign(oldValue, newValue)};
         });
 

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -1417,11 +1417,7 @@ function updateSnapshots(data: OnyxUpdate[], mergeFn: typeof Onyx.merge): Array<
             }
 
             const oldValue = updatedData[key] || {};
-            const snapshotKeys = Object.keys(snapshotData[key] || {});
-            const valueKeys = Object.keys(value ?? {});
-            const hasNewKeys = valueKeys.some((k) => !snapshotKeys.includes(k));
-            const newValue = hasNewKeys ? value : lodashPick(value, snapshotKeys);
-
+            const newValue = lodashPick(value, Object.keys(snapshotData[key]));
             updatedData = {...updatedData, [key]: Object.assign(oldValue, newValue)};
         });
 

--- a/tests/unit/onyxTest.ts
+++ b/tests/unit/onyxTest.ts
@@ -2029,5 +2029,25 @@ describe('Onyx', () => {
                 [`${ONYX_KEYS.COLLECTION.TEST_KEY}entry2`]: {id: 'entry2_id', name: 'entry2_name'},
             });
         });
+        it('should clear pending merge for a key during multiSet()', async () => {
+            const testKey = `${ONYX_KEYS.COLLECTION.TEST_KEY}entry1`;
+
+            // Mock the merge queue with the correct type
+            const mockMergeQueue: Record<string, unknown[]> = {
+                [testKey]: [{some: 'mergeData'}],
+            };
+
+            // Mock the utility functions
+            jest.spyOn(OnyxUtils, 'hasPendingMergeForKey').mockImplementation((key) => key === testKey);
+            jest.spyOn(OnyxUtils, 'getMergeQueue').mockImplementation(() => mockMergeQueue);
+
+            await Onyx.multiSet({
+                [testKey]: {id: 'entry1_id', name: 'entry1_name'},
+            });
+
+            expect(mockMergeQueue[testKey]).toBeUndefined();
+
+            jest.restoreAllMocks();
+        });
     });
 });


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
Updated logic to return full value if the key doesn't exist in the snapshot, ensuring new keys are correctly preserved in newValue.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
[Expensify/App#61584](https://github.com/Expensify/App/issues/61584)

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Manual Tests

1. Open the Expensify app.
2. Open any chat.
3. Send a message.
4. Navigate to the "Reports" screen.
5. Tap on the dropdown menu and select "Chats".
6. Open the chat where you just sent the message.
7. Send a few more messages in that chat.
8. Tap the arrow on the top left corner to return to "Chats".
9. Observe that the message list is not updated.
10. Navigate to a different section (e.g., Home).
11. Return to the "Chats" screen.
12. Observe that the message list is now updated.
13. Verify that the message list on "Chats" should automatically update after sending more messages.

### Author Checklist

- [x] I linked the correct issue in the `### Related Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>


</details>

<details>
<summary>Android: mWeb Chrome</summary>


</details>

<details>
<summary>iOS: Native</summary>


</details>

<details>
<summary>iOS: mWeb Safari</summary>


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>


</details>

<details>
<summary>MacOS: Desktop</summary>


</details>
