### PR TITLE
[NoQA] Investigating Reassure flakiness

### DIFF
--- a/.github/workflows/reassurePerfTests.yml
+++ b/.github/workflows/reassurePerfTests.yml
@@ -10,7 +10,7 @@ jobs:
   # Note: We run baseline and delta performance checks in the same runner to reduce hardware variance across machines
   perf-tests:
     if: ${{ github.actor != 'OSBotify' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-v4
     steps:
       # v4
       - name: Checkout
@@ -28,7 +28,7 @@ jobs:
         run: npm install
 
       - name: Run Reassure baseline tests
-        run: npx reassure --baseline
+        run: npx reassure --baseline --verbose
 
       - name: Checkout PR head SHA
         run: |
@@ -39,7 +39,15 @@ jobs:
         run: npm install --force
 
       - name: Run Reassure delta tests
-        run: npx reassure --branch
+        run: npx reassure --branch --verbose
+
+      - name: Upload Reassure results
+        uses: actions/upload-artifact@v4
+        with:
+          name: results
+          path: .reassure/
+          if-no-files-found: ignore
+          include-hidden-files: true
 
       - name: Validate output.json
         id: validateReassureOutput

--- a/jest-sequencer.js
+++ b/jest-sequencer.js
@@ -1,0 +1,21 @@
+const Sequencer = require('@jest/test-sequencer').default;
+
+/**
+ * Makes all unit tests run ordered by their path, reducing flakiness on Reassure.
+ */
+class TestSequencer extends Sequencer {
+    shard(tests, {shardIndex, shardCount}) {
+        const shardSize = Math.ceil(tests.length / shardCount);
+        const shardStart = shardSize * (shardIndex - 1);
+        const shardEnd = shardSize * shardIndex;
+
+        return [...tests].sort((a, b) => (a.path > b.path ? 1 : -1)).slice(shardStart, shardEnd);
+    }
+
+    sort(tests) {
+        const copyTests = [...tests];
+        return copyTests.sort((testA, testB) => (testA.path > testB.path ? 1 : -1));
+    }
+}
+
+module.exports = TestSequencer;

--- a/jest.config.js
+++ b/jest.config.js
@@ -14,4 +14,5 @@ module.exports = {
     setupFilesAfterEnv: ['./jestSetup.js'],
     testTimeout: 60000,
     transformIgnorePatterns: ['node_modules/(?!((@)?react-native|@ngneat/falso|uuid)/)'],
+    testSequencer: './jest-sequencer.js',
 };

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -49,17 +49,17 @@ const METHOD = {
 type OnyxMethod = ValueOf<typeof METHOD>;
 
 // Key/value store of Onyx key and arrays of values to merge
-const mergeQueue: Record<OnyxKey, Array<OnyxValue<OnyxKey>>> = {};
-const mergeQueuePromise: Record<OnyxKey, Promise<void>> = {};
+let mergeQueue: Record<OnyxKey, Array<OnyxValue<OnyxKey>>> = {};
+let mergeQueuePromise: Record<OnyxKey, Promise<void>> = {};
 
 // Holds a mapping of all the React components that want their state subscribed to a store key
-const callbackToStateMapping: Record<string, Mapping<OnyxKey>> = {};
+let callbackToStateMapping: Record<string, Mapping<OnyxKey>> = {};
 
 // Keeps a copy of the values of the onyx collection keys as a map for faster lookups
 let onyxCollectionKeySet = new Set<OnyxKey>();
 
 // Holds a mapping of the connected key to the subscriptionID for faster lookups
-const onyxKeyToSubscriptionIDs = new Map();
+let onyxKeyToSubscriptionIDs = new Map();
 
 // Optional user-provided key value states set when Onyx initializes or clears
 let defaultKeyStates: Record<OnyxKey, OnyxValue<OnyxKey>> = {};
@@ -68,7 +68,7 @@ let batchUpdatesPromise: Promise<void> | null = null;
 let batchUpdatesQueue: Array<() => void> = [];
 
 // Used for comparison with a new update to avoid invoking the Onyx.connect callback with the same data.
-const lastConnectionCallbackData = new Map<number, OnyxValue<OnyxKey>>();
+let lastConnectionCallbackData = new Map<number, OnyxValue<OnyxKey>>();
 
 let snapshotKey: OnyxKey | null = null;
 
@@ -1450,6 +1450,18 @@ function updateSnapshots(data: OnyxUpdate[], mergeFn: typeof Onyx.merge): Array<
     return promises;
 }
 
+/**
+ * Clear internal variables used in this file, useful in test environments.
+ */
+function clearOnyxUtilsInternals() {
+    mergeQueue = {};
+    mergeQueuePromise = {};
+    callbackToStateMapping = {};
+    onyxKeyToSubscriptionIDs = new Map();
+    batchUpdatesQueue = [];
+    lastConnectionCallbackData = new Map();
+}
+
 const OnyxUtils = {
     METHOD,
     getMergeQueue,
@@ -1551,3 +1563,4 @@ GlobalSettings.addGlobalSettingsChangeListener(({enablePerformanceMetrics}) => {
 
 export type {OnyxMethod};
 export default OnyxUtils;
+export {clearOnyxUtilsInternals};

--- a/tests/perf-test/OnyxUtils.perf-test.ts
+++ b/tests/perf-test/OnyxUtils.perf-test.ts
@@ -4,7 +4,7 @@ import type {OnyxKey, Selector} from '../../lib';
 import Onyx from '../../lib';
 import StorageMock from '../../lib/storage';
 import OnyxCache from '../../lib/OnyxCache';
-import OnyxUtils from '../../lib/OnyxUtils';
+import OnyxUtils, {clearOnyxUtilsInternals} from '../../lib/OnyxUtils';
 import type GenericCollection from '../utils/GenericCollection';
 import type {Mapping, OnyxUpdate} from '../../lib/Onyx';
 import createDeferredTask from '../../lib/createDeferredTask';
@@ -44,6 +44,7 @@ const mockedReportActionsMap = getRandomReportActions(collectionKey);
 const mockedReportActionsKeys = Object.keys(mockedReportActionsMap);
 
 const clearOnyxAfterEachMeasure = async () => {
+    clearOnyxUtilsInternals();
     await Onyx.clear();
 };
 
@@ -59,6 +60,7 @@ describe('OnyxUtils', () => {
     });
 
     afterEach(async () => {
+        clearOnyxUtilsInternals();
         await Onyx.clear();
     });
 
@@ -321,7 +323,6 @@ describe('OnyxUtils', () => {
                     });
                 },
                 afterEach: async () => {
-                    await clearOnyxAfterEachMeasure();
                     mockedReportActionsKeys.forEach((key) => {
                         const id = subscriptionMap.get(key);
                         if (id) {
@@ -329,6 +330,7 @@ describe('OnyxUtils', () => {
                         }
                     });
                     subscriptionMap.clear();
+                    await clearOnyxAfterEachMeasure();
                 },
             });
         });
@@ -351,11 +353,11 @@ describe('OnyxUtils', () => {
                     }
                 },
                 afterEach: async () => {
-                    await clearOnyxAfterEachMeasure();
                     subscriptionIDs.forEach((id) => {
                         OnyxUtils.unsubscribeFromKey(id);
                     });
                     subscriptionIDs.clear();
+                    await clearOnyxAfterEachMeasure();
                 },
             });
         });
@@ -384,10 +386,10 @@ describe('OnyxUtils', () => {
                         subscriptionID = OnyxUtils.subscribeToKey({key: collectionKey, callback: jest.fn(), initWithStoredValues: false});
                     },
                     afterEach: async () => {
-                        await clearOnyxAfterEachMeasure();
                         if (subscriptionID) {
                             OnyxUtils.unsubscribeFromKey(subscriptionID);
                         }
+                        await clearOnyxAfterEachMeasure();
                     },
                 },
             );
@@ -417,10 +419,10 @@ describe('OnyxUtils', () => {
                         subscriptionID = OnyxUtils.subscribeToKey({key: collectionKey, callback: jest.fn(), initWithStoredValues: false});
                     },
                     afterEach: async () => {
-                        await clearOnyxAfterEachMeasure();
                         if (subscriptionID) {
                             OnyxUtils.unsubscribeFromKey(subscriptionID);
                         }
+                        await clearOnyxAfterEachMeasure();
                     },
                 },
             );
@@ -466,10 +468,10 @@ describe('OnyxUtils', () => {
                         await Onyx.multiSet(mockedReportActionsMap);
                     },
                     afterEach: async () => {
-                        await clearOnyxAfterEachMeasure();
                         if (subscriptionID) {
                             OnyxUtils.unsubscribeFromKey(subscriptionID);
                         }
+                        await clearOnyxAfterEachMeasure();
                     },
                 },
             );
@@ -495,7 +497,6 @@ describe('OnyxUtils', () => {
                         });
                     },
                     afterEach: async () => {
-                        await clearOnyxAfterEachMeasure();
                         mockedReportActionsKeys.forEach((key) => {
                             const id = subscriptionMap.get(key);
                             if (id) {
@@ -503,6 +504,7 @@ describe('OnyxUtils', () => {
                             }
                         });
                         subscriptionMap.clear();
+                        await clearOnyxAfterEachMeasure();
                     },
                 },
             );
@@ -526,7 +528,6 @@ describe('OnyxUtils', () => {
                     });
                 },
                 afterEach: async () => {
-                    await clearOnyxAfterEachMeasure();
                     mockedReportActionsKeys.forEach((key) => {
                         const id = subscriptionMap.get(key);
                         if (id) {
@@ -534,6 +535,7 @@ describe('OnyxUtils', () => {
                         }
                     });
                     subscriptionMap.clear();
+                    await clearOnyxAfterEachMeasure();
                 },
             });
         });
@@ -726,8 +728,8 @@ describe('OnyxUtils', () => {
                         await StorageMock.multiSet(Object.entries(mockedReportActionsMap).map(([k, v]) => [k, v]));
                     },
                     afterEach: async () => {
-                        await clearOnyxAfterEachMeasure();
                         OnyxUtils.unsubscribeFromKey(subscriptionID);
+                        await clearOnyxAfterEachMeasure();
                     },
                 },
             );
@@ -753,8 +755,8 @@ describe('OnyxUtils', () => {
                         await StorageMock.multiSet(Object.entries(mockedReportActionsMap).map(([k, v]) => [k, v]));
                     },
                     afterEach: async () => {
-                        await clearOnyxAfterEachMeasure();
                         OnyxUtils.unsubscribeFromKey(subscriptionID);
+                        await clearOnyxAfterEachMeasure();
                     },
                 },
             );
@@ -822,9 +824,9 @@ describe('OnyxUtils', () => {
                     });
                 },
                 afterEach: async () => {
-                    await clearOnyxAfterEachMeasure();
                     OnyxUtils.deleteKeyBySubscriptions(subscriptionID);
                     OnyxUtils.unsubscribeFromKey(subscriptionID);
+                    await clearOnyxAfterEachMeasure();
                 },
             });
         });
@@ -844,8 +846,8 @@ describe('OnyxUtils', () => {
                     OnyxUtils.storeKeyBySubscriptions(key, subscriptionID);
                 },
                 afterEach: async () => {
-                    await clearOnyxAfterEachMeasure();
                     OnyxUtils.unsubscribeFromKey(subscriptionID);
+                    await clearOnyxAfterEachMeasure();
                 },
             });
         });
@@ -865,8 +867,8 @@ describe('OnyxUtils', () => {
                     }),
                 {
                     afterEach: async () => {
-                        await clearOnyxAfterEachMeasure();
                         OnyxCache.removeLastAccessedKey(key);
+                        await clearOnyxAfterEachMeasure();
                     },
                 },
             );


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details

This PR attempts to reduce the flakiness on CI:

- Changes the CI workflow to use the same runner we have for Reassure in E/App, and to output the Reassure results as an artefact so they can be used for data inspection when needed.
- Implements the `clearOnyxUtilsInternals` function to clean up some leftovers we have in OnyxUtils when running Reassure tests in that file.
- Implements a `TestSequencer` in Jest to make all the unit tests always run ordered by their path, reducing flakiness on Reassure.

I tested locally a couple of times and the results looks promising, I ran stability tests multiple times (basically doing baseline and delta tests with the same PR) and there were no crazy regressions anymore. Unfortunately we will still have regressions reported here because the baseline is `main` and the we don't have the improvements there.

@mountiny Do you think we can try merging this PR to see if the next ones will continue to have big flakiness?

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->

https://github.com/Expensify/App/issues/64813

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

N/A

### Manual Tests
<!---
Each set of changes should be tested against the Expensify/App repo on all platforms to verify it does not break our staging App.
--->

N/A

### Author Checklist

- [x] I linked the correct issue in the `### Related Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
