### PR TITLE
perf: speed up cache read in useOnyx

### DIFF
--- a/lib/OnyxCache.ts
+++ b/lib/OnyxCache.ts
@@ -153,7 +153,6 @@ class OnyxCache {
         if (shouldReindexCache) {
             this.addToAccessedKeys(key);
         }
-
         return this.storageMap[key];
     }
 
@@ -169,10 +168,10 @@ class OnyxCache {
         // since it will either be set to a non nullish value or removed from the cache completely.
         this.nullishStorageKeys.delete(key);
 
+        const collectionKey = this.getCollectionKey(key);
         if (value === null || value === undefined) {
             delete this.storageMap[key];
             // Remove from collection index if it's a collection member
-            const collectionKey = this.getCollectionKey(key);
             if (collectionKey && this.collectionIndex[collectionKey]) {
                 this.collectionIndex[collectionKey].delete(key);
             }
@@ -182,7 +181,6 @@ class OnyxCache {
         this.storageMap[key] = value;
 
         // Update collection index if this is a collection member
-        const collectionKey = this.getCollectionKey(key);
         if (collectionKey) {
             if (!this.collectionIndex[collectionKey]) {
                 this.collectionIndex[collectionKey] = new Set();
@@ -221,24 +219,23 @@ class OnyxCache {
             throw new Error('data passed to cache.merge() must be an Object of onyx key/value pairs');
         }
 
-        // Merge all data into storageMap
         this.storageMap = {...utils.fastMerge(this.storageMap, data)};
 
         Object.entries(data).forEach(([key, value]) => {
             this.addKey(key);
             this.addToAccessedKeys(key);
 
+            const collectionKey = this.getCollectionKey(key);
+
             if (value === null || value === undefined) {
                 this.addNullishStorageKey(key);
                 // Remove from collection index if it's a collection member
-                const collectionKey = this.getCollectionKey(key);
                 if (collectionKey && this.collectionIndex[collectionKey]) {
                     this.collectionIndex[collectionKey].delete(key);
                 }
             } else {
                 this.nullishStorageKeys.delete(key);
                 // Update collection index if this is a collection member
-                const collectionKey = this.getCollectionKey(key);
                 if (collectionKey) {
                     if (!this.collectionIndex[collectionKey]) {
                         this.collectionIndex[collectionKey] = new Set();

--- a/lib/OnyxCache.ts
+++ b/lib/OnyxCache.ts
@@ -172,7 +172,7 @@ class OnyxCache {
         if (value === null || value === undefined) {
             delete this.storageMap[key];
             // Remove from collection index if it's a collection member
-            if (collectionKey && this.collectionIndex[collectionKey]) {
+            if (collectionKey && this.getCollectionMemberKeys(collectionKey)) {
                 this.collectionIndex[collectionKey].delete(key);
             }
             return undefined;
@@ -182,7 +182,7 @@ class OnyxCache {
 
         // Update collection index if this is a collection member
         if (collectionKey) {
-            if (!this.collectionIndex[collectionKey]) {
+            if (!this.getCollectionMemberKeys(collectionKey)) {
                 this.collectionIndex[collectionKey] = new Set();
             }
             this.collectionIndex[collectionKey].add(key);
@@ -197,7 +197,7 @@ class OnyxCache {
 
         // Update collection index if this is a collection member
         const collectionKey = this.getCollectionKey(key);
-        if (collectionKey && this.collectionIndex[collectionKey]) {
+        if (collectionKey && this.getCollectionMemberKeys(collectionKey)) {
             this.collectionIndex[collectionKey].delete(key);
         }
 
@@ -230,14 +230,14 @@ class OnyxCache {
             if (value === null || value === undefined) {
                 this.addNullishStorageKey(key);
                 // Remove from collection index if it's a collection member
-                if (collectionKey && this.collectionIndex[collectionKey]) {
+                if (collectionKey && this.getCollectionMemberKeys(collectionKey)) {
                     this.collectionIndex[collectionKey].delete(key);
                 }
             } else {
                 this.nullishStorageKeys.delete(key);
                 // Update collection index if this is a collection member
                 if (collectionKey) {
-                    if (!this.collectionIndex[collectionKey]) {
+                    if (!this.getCollectionMemberKeys(collectionKey)) {
                         this.collectionIndex[collectionKey] = new Set();
                     }
                     this.collectionIndex[collectionKey].add(key);
@@ -313,7 +313,7 @@ class OnyxCache {
             delete this.storageMap[key];
             // Update collection index if this is a collection member
             const collectionKey = this.getCollectionKey(key);
-            if (collectionKey && this.collectionIndex[collectionKey]) {
+            if (collectionKey && this.getCollectionMemberKeys(collectionKey)) {
                 this.collectionIndex[collectionKey].delete(key);
             }
             this.recentKeys.delete(key);
@@ -427,7 +427,7 @@ class OnyxCache {
         this.collectionKeys = collectionKeys;
         // Initialize collection indexes for existing collection keys
         collectionKeys.forEach((collectionKey) => {
-            if (this.collectionIndex[collectionKey]) {
+            if (this.getCollectionMemberKeys(collectionKey)) {
                 return;
             }
             this.collectionIndex[collectionKey] = new Set();
@@ -457,7 +457,7 @@ class OnyxCache {
      * Get all data for a collection key
      */
     getCollectionData(collectionKey: OnyxKey): Record<OnyxKey, OnyxValue<OnyxKey>> | undefined {
-        const memberKeys = this.collectionIndex[collectionKey];
+        const memberKeys = this.getCollectionMemberKeys(collectionKey);
         if (!memberKeys || memberKeys.size === 0) {
             return undefined;
         }

--- a/lib/OnyxCache.ts
+++ b/lib/OnyxCache.ts
@@ -171,6 +171,7 @@ class OnyxCache {
         const collectionKey = this.getCollectionKey(key);
         if (value === null || value === undefined) {
             delete this.storageMap[key];
+
             // Remove from collection index if it's a collection member
             if (collectionKey && this.getCollectionMemberKeys(collectionKey)) {
                 this.collectionIndex[collectionKey].delete(key);
@@ -229,12 +230,14 @@ class OnyxCache {
 
             if (value === null || value === undefined) {
                 this.addNullishStorageKey(key);
+
                 // Remove from collection index if it's a collection member
                 if (collectionKey && this.getCollectionMemberKeys(collectionKey)) {
                     this.collectionIndex[collectionKey].delete(key);
                 }
             } else {
                 this.nullishStorageKeys.delete(key);
+
                 // Update collection index if this is a collection member
                 if (collectionKey) {
                     if (!this.getCollectionMemberKeys(collectionKey)) {
@@ -311,6 +314,7 @@ class OnyxCache {
 
         for (const key of keysToRemove) {
             delete this.storageMap[key];
+
             // Update collection index if this is a collection member
             const collectionKey = this.getCollectionKey(key);
             if (collectionKey && this.getCollectionMemberKeys(collectionKey)) {
@@ -425,6 +429,7 @@ class OnyxCache {
      */
     setCollectionKeys(collectionKeys: Set<OnyxKey>): void {
         this.collectionKeys = collectionKeys;
+
         // Initialize collection indexes for existing collection keys
         collectionKeys.forEach((collectionKey) => {
             if (this.getCollectionMemberKeys(collectionKey)) {

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -582,6 +582,7 @@ function getCachedCollection<TKey extends CollectionKeyBase>(collectionKey: TKey
             });
             return filteredCollection;
         }
+
         // Return a copy to avoid mutations affecting the cache
         return {...collectionData};
     }


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Performance improvements related to accessing data from cache. Instead of looping on all keys when connecting to entire collection, hold an indexed map for quick access to all collection items.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
$ https://github.com/Expensify/App/issues/64950

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Manual Tests
<!---
Each set of changes should be tested against the Expensify/App repo on all platforms to verify it does not break our staging App.
--->
1. Login into the app
2. Verify the app loads correctly
3. Close the app/Refresh the app (if web)
4. Open the app again
5. Verify the app loads correctly
### Author Checklist

- [x] I linked the correct issue in the `### Related Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/c35bd818-42cd-4170-ac38-4d9b43a1b44e


<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/user-attachments/assets/dc033870-738a-43b3-860a-8c2a6ce3bf12


<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/cd45715f-f19e-4299-bf19-3be22edc61ca


<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/user-attachments/assets/4f057769-cc42-4533-993f-fc8b26f95d5b


<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/434ef8c1-b79c-468d-8c6b-e90c0c43af48


<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

https://github.com/user-attachments/assets/6fe4f84d-b8a7-42d1-9c58-bfe119fe6d16


<!-- add screenshots or videos here -->

</details>
