### PR TITLE
Rollback to push all `merge` operations to `update()` final promise instead of the first one

### DIFF
--- a/lib/Onyx.ts
+++ b/lib/Onyx.ts
@@ -612,10 +612,9 @@ function update(data: OnyxUpdate[]): Promise<void> {
             return;
         }
 
-        const mergePromises = operations.map((operation) => {
-            return merge(key, operation);
+        operations.forEach((operation) => {
+            promises.push(() => merge(key, operation));
         });
-        promises.push(() => mergePromises.at(0) ?? Promise.resolve());
     });
 
     const snapshotPromises = OnyxUtils.updateSnapshots(data, merge);

--- a/tests/unit/onyxTest.ts
+++ b/tests/unit/onyxTest.ts
@@ -2089,436 +2089,6 @@ describe('Onyx', () => {
             });
         });
 
-        describe('merge', () => {
-            it('should replace the old value after a null merge in the top-level object when batching merges', async () => {
-                let result: unknown;
-                connection = Onyx.connect({
-                    key: ONYX_KEYS.COLLECTION.TEST_UPDATE,
-                    waitForCollectionCallback: true,
-                    callback: (value) => {
-                        result = value;
-                    },
-                });
-
-                await Onyx.multiSet({
-                    [`${ONYX_KEYS.COLLECTION.TEST_UPDATE}entry1`]: {
-                        id: 'entry1',
-                        someKey: 'someValue',
-                    },
-                });
-
-                // Removing the entire object in this merge.
-                // Any subsequent changes to this key should completely replace the old value.
-                Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_UPDATE}entry1`, null);
-
-                // This change should completely replace `${ONYX_KEYS.COLLECTION.TEST_UPDATE}entry1` old value.
-                Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_UPDATE}entry1`, {
-                    someKey: 'someValueChanged',
-                });
-
-                await waitForPromisesToResolve();
-
-                expect(result).toEqual({[`${ONYX_KEYS.COLLECTION.TEST_UPDATE}entry1`]: {someKey: 'someValueChanged'}});
-                expect(await StorageMock.getItem(`${ONYX_KEYS.COLLECTION.TEST_UPDATE}entry1`)).toEqual({someKey: 'someValueChanged'});
-            });
-
-            describe('should replace the old value after a null merge in a nested property when batching merges', () => {
-                let result: unknown;
-
-                beforeEach(() => {
-                    connection = Onyx.connect({
-                        key: ONYX_KEYS.COLLECTION.TEST_UPDATE,
-                        waitForCollectionCallback: true,
-                        callback: (value) => {
-                            result = value;
-                        },
-                    });
-                });
-
-                it('replacing old object after null merge', async () => {
-                    const entry1: GenericDeepRecord = {
-                        sub_entry1: {
-                            id: 'sub_entry1',
-                            someKey: 'someValue',
-                        },
-                    };
-                    await Onyx.multiSet({[`${ONYX_KEYS.COLLECTION.TEST_UPDATE}entry1`]: entry1});
-
-                    const entry1ExpectedResult = lodashCloneDeep(entry1);
-
-                    Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_UPDATE}entry1`, {
-                        // Removing the "sub_entry1" object in this merge.
-                        // Any subsequent changes to this object should completely replace the existing object in store.
-                        sub_entry1: null,
-                    });
-                    delete entry1ExpectedResult.sub_entry1;
-
-                    Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_UPDATE}entry1`, {
-                        // This change should completely replace "sub_entry1" existing object in store.
-                        sub_entry1: {
-                            newKey: 'newValue',
-                        },
-                    });
-                    entry1ExpectedResult.sub_entry1 = {newKey: 'newValue'};
-
-                    await waitForPromisesToResolve();
-
-                    expect(result).toEqual({[`${ONYX_KEYS.COLLECTION.TEST_UPDATE}entry1`]: entry1ExpectedResult});
-                    expect(await StorageMock.getItem(`${ONYX_KEYS.COLLECTION.TEST_UPDATE}entry1`)).toEqual(entry1ExpectedResult);
-                });
-
-                it('setting new object after null merge', async () => {
-                    const entry1: GenericDeepRecord = {
-                        sub_entry1: {
-                            id: 'sub_entry1',
-                            someKey: 'someValue',
-                            someNestedObject: {
-                                someNestedKey: 'someNestedValue',
-                                anotherNestedObject: {
-                                    anotherNestedKey: 'anotherNestedValue',
-                                },
-                            },
-                        },
-                    };
-                    await Onyx.multiSet({[`${ONYX_KEYS.COLLECTION.TEST_UPDATE}entry1`]: entry1});
-
-                    const entry1ExpectedResult = lodashCloneDeep(entry1);
-
-                    Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_UPDATE}entry1`, {
-                        sub_entry1: {
-                            someNestedObject: {
-                                // Introducing a new "anotherNestedObject2" object in this merge.
-                                anotherNestedObject2: {
-                                    anotherNestedKey2: 'anotherNestedValue2',
-                                },
-                            },
-                        },
-                    });
-                    entry1ExpectedResult.sub_entry1.someNestedObject.anotherNestedObject2 = {anotherNestedKey2: 'anotherNestedValue2'};
-
-                    Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_UPDATE}entry1`, {
-                        sub_entry1: {
-                            someNestedObject: {
-                                // Removing the "anotherNestedObject2" object in this merge.
-                                // This property was only introduced in a previous merge, so we don't need to care
-                                // about an old existing value because there isn't one.
-                                anotherNestedObject2: null,
-                            },
-                        },
-                    });
-                    delete entry1ExpectedResult.sub_entry1.someNestedObject.anotherNestedObject2;
-
-                    Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_UPDATE}entry1`, {
-                        sub_entry1: {
-                            someNestedObject: {
-                                // Introducing the "anotherNestedObject2" object again with this update.
-                                anotherNestedObject2: {
-                                    newNestedKey2: 'newNestedValue2',
-                                },
-                            },
-                        },
-                    });
-                    entry1ExpectedResult.sub_entry1.someNestedObject.anotherNestedObject2 = {newNestedKey2: 'newNestedValue2'};
-
-                    await waitForPromisesToResolve();
-
-                    expect(result).toEqual({[`${ONYX_KEYS.COLLECTION.TEST_UPDATE}entry1`]: entry1ExpectedResult});
-                    expect(await StorageMock.getItem(`${ONYX_KEYS.COLLECTION.TEST_UPDATE}entry1`)).toEqual(entry1ExpectedResult);
-                });
-
-                it('setting new object after null merge of a primitive property', async () => {
-                    const entry1: GenericDeepRecord = {
-                        sub_entry1: {
-                            id: 'sub_entry1',
-                            someKey: 'someValue',
-                            someNestedObject: {
-                                someNestedKey: 'someNestedValue',
-                                anotherNestedObject: {
-                                    anotherNestedKey: 'anotherNestedValue',
-                                },
-                            },
-                        },
-                    };
-                    await Onyx.multiSet({[`${ONYX_KEYS.COLLECTION.TEST_UPDATE}entry1`]: entry1});
-
-                    const entry1ExpectedResult = lodashCloneDeep(entry1);
-
-                    Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_UPDATE}entry1`, {
-                        sub_entry1: {
-                            someNestedObject: {
-                                anotherNestedObject: {
-                                    // Removing the "anotherNestedKey" property in this merge.
-                                    // This property's existing value in store is a primitive value, so we don't need to care
-                                    // about it when merging new values in any next merges.
-                                    anotherNestedKey: null,
-                                },
-                            },
-                        },
-                    });
-                    delete entry1ExpectedResult.sub_entry1.someNestedObject.anotherNestedObject.anotherNestedKey;
-
-                    Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_UPDATE}entry1`, {
-                        sub_entry1: {
-                            someNestedObject: {
-                                anotherNestedObject: {
-                                    // Setting a new object to the "anotherNestedKey" property.
-                                    anotherNestedKey: {
-                                        newNestedKey: 'newNestedValue',
-                                    },
-                                },
-                            },
-                        },
-                    });
-                    entry1ExpectedResult.sub_entry1.someNestedObject.anotherNestedObject.anotherNestedKey = {newNestedKey: 'newNestedValue'};
-
-                    await waitForPromisesToResolve();
-
-                    expect(result).toEqual({[`${ONYX_KEYS.COLLECTION.TEST_UPDATE}entry1`]: entry1ExpectedResult});
-                    expect(await StorageMock.getItem(`${ONYX_KEYS.COLLECTION.TEST_UPDATE}entry1`)).toEqual(entry1ExpectedResult);
-                });
-            });
-
-            it('should remove a deeply nested null when merging an existing key', () => {
-                let result: unknown;
-
-                connection = Onyx.connect({
-                    key: ONYX_KEYS.TEST_KEY,
-                    initWithStoredValues: false,
-                    callback: (value) => (result = value),
-                });
-
-                const initialValue = {
-                    waypoints: {
-                        1: 'Home',
-                        2: 'Work',
-                        3: 'Gym',
-                    },
-                };
-
-                return Onyx.set(ONYX_KEYS.TEST_KEY, initialValue)
-                    .then(() => {
-                        expect(result).toEqual(initialValue);
-                        Onyx.merge(ONYX_KEYS.TEST_KEY, {
-                            waypoints: {
-                                1: 'Home',
-                                2: 'Work',
-                                3: null,
-                            },
-                        });
-                        return waitForPromisesToResolve();
-                    })
-                    .then(() => {
-                        expect(result).toEqual({
-                            waypoints: {
-                                1: 'Home',
-                                2: 'Work',
-                            },
-                        });
-                    });
-            });
-        });
-
-        describe('set', () => {
-            it('should work with skipCacheCheck option', () => {
-                let testKeyValue: unknown;
-
-                connection = Onyx.connect({
-                    key: ONYX_KEYS.TEST_KEY,
-                    initWithStoredValues: false,
-                    callback: (value) => {
-                        testKeyValue = value;
-                    },
-                });
-
-                const testData = {id: 1, name: 'test'};
-
-                return Onyx.set(ONYX_KEYS.TEST_KEY, testData)
-                    .then(() => {
-                        expect(testKeyValue).toEqual(testData);
-
-                        return Onyx.set(ONYX_KEYS.TEST_KEY, testData, {skipCacheCheck: true});
-                    })
-                    .then(() => {
-                        expect(testKeyValue).toEqual(testData);
-                    });
-            });
-
-            it('should work with skipNullRemoval option', () => {
-                let testKeyValue: unknown;
-
-                connection = Onyx.connect({
-                    key: ONYX_KEYS.TEST_KEY,
-                    initWithStoredValues: false,
-                    callback: (value) => {
-                        testKeyValue = value;
-                    },
-                });
-
-                const testDataWithNulls = {
-                    id: 1,
-                    name: 'test',
-                    nested: {
-                        validValue: 'keep',
-                        nullValue: null,
-                        undefinedValue: undefined,
-                    },
-                    topLevelNull: null,
-                };
-
-                return Onyx.set(ONYX_KEYS.TEST_KEY, testDataWithNulls, {skipNullRemoval: true}).then(() => {
-                    // The null values should be preserved
-                    expect(testKeyValue).toEqual(testDataWithNulls);
-                });
-            });
-
-            it('should remove null values by default when skipNullRemoval is not set', () => {
-                let testKeyValue: unknown;
-
-                connection = Onyx.connect({
-                    key: ONYX_KEYS.TEST_KEY,
-                    initWithStoredValues: false,
-                    callback: (value) => {
-                        testKeyValue = value;
-                    },
-                });
-
-                const testDataWithNulls = {
-                    id: 1,
-                    name: 'test',
-                    nested: {
-                        validValue: 'keep',
-                        nullValue: null,
-                        undefinedValue: undefined,
-                    },
-                    topLevelNull: null,
-                };
-
-                // Set value without skipNullRemoval (default behavior)
-                return Onyx.set(ONYX_KEYS.TEST_KEY, testDataWithNulls).then(() => {
-                    // The null values should be removed
-                    expect(testKeyValue).toEqual({
-                        id: 1,
-                        name: 'test',
-                        nested: {
-                            validValue: 'keep',
-                        },
-                    });
-                });
-            });
-
-            it('should work with both skipCacheCheck and skipNullRemoval options', () => {
-                let testKeyValue: unknown;
-
-                connection = Onyx.connect({
-                    key: ONYX_KEYS.TEST_KEY,
-                    initWithStoredValues: false,
-                    callback: (value) => {
-                        testKeyValue = value;
-                    },
-                });
-
-                const testDataWithNulls = {
-                    id: 1,
-                    name: 'test',
-                    computed: null,
-                    nested: {
-                        result: null,
-                        valid: 'keep',
-                    },
-                };
-
-                Onyx.set(ONYX_KEYS.TEST_KEY, testDataWithNulls, {
-                    skipCacheCheck: true,
-                    skipNullRemoval: true,
-                }).then(() => {
-                    // The null values should be preserved
-                    expect(testKeyValue).toEqual(testDataWithNulls);
-                });
-            });
-        });
-
-        describe('setCollection', () => {
-            it('should replace all existing collection members with new values and remove old ones', async () => {
-                let result: OnyxCollection<unknown>;
-                const routeA = `${ONYX_KEYS.COLLECTION.ROUTES}A`;
-                const routeB = `${ONYX_KEYS.COLLECTION.ROUTES}B`;
-                const routeB1 = `${ONYX_KEYS.COLLECTION.ROUTES}B1`;
-                const routeC = `${ONYX_KEYS.COLLECTION.ROUTES}C`;
-
-                connection = Onyx.connect({
-                    key: ONYX_KEYS.COLLECTION.ROUTES,
-                    initWithStoredValues: false,
-                    callback: (value) => (result = value),
-                    waitForCollectionCallback: true,
-                });
-
-                // Set initial collection state
-                await Onyx.mergeCollection(ONYX_KEYS.COLLECTION.ROUTES, {
-                    [routeA]: {name: 'Route A'},
-                    [routeB1]: {name: 'Route B1'},
-                    [routeC]: {name: 'Route C'},
-                } as GenericCollection);
-
-                // Replace with new collection data
-                await Onyx.setCollection(ONYX_KEYS.COLLECTION.ROUTES, {
-                    [routeA]: {name: 'New Route A'},
-                    [routeB]: {name: 'New Route B'},
-                    [routeC]: {name: 'New Route C'},
-                } as GenericCollection);
-
-                expect(result).toEqual({
-                    [routeA]: {name: 'New Route A'},
-                    [routeB]: {name: 'New Route B'},
-                    [routeC]: {name: 'New Route C'},
-                });
-            });
-
-            it('should replace the collection with empty values', async () => {
-                let result: OnyxCollection<unknown>;
-                const routeA = `${ONYX_KEYS.COLLECTION.ROUTES}A`;
-
-                connection = Onyx.connect({
-                    key: ONYX_KEYS.COLLECTION.ROUTES,
-                    initWithStoredValues: false,
-                    callback: (value) => (result = value),
-                    waitForCollectionCallback: true,
-                });
-
-                await Onyx.mergeCollection(ONYX_KEYS.COLLECTION.ROUTES, {
-                    [routeA]: {name: 'Route A'},
-                } as GenericCollection);
-
-                await Onyx.setCollection(ONYX_KEYS.COLLECTION.ROUTES, {} as GenericCollection);
-
-                expect(result).toEqual({});
-            });
-
-            it('should reject collection items with invalid keys', async () => {
-                let result: OnyxCollection<unknown>;
-                const routeA = `${ONYX_KEYS.COLLECTION.ROUTES}A`;
-                const invalidRoute = 'invalid_route';
-
-                connection = Onyx.connect({
-                    key: ONYX_KEYS.COLLECTION.ROUTES,
-                    initWithStoredValues: false,
-                    callback: (value) => (result = value),
-                    waitForCollectionCallback: true,
-                });
-
-                await Onyx.mergeCollection(ONYX_KEYS.COLLECTION.ROUTES, {
-                    [routeA]: {name: 'Route A'},
-                } as GenericCollection);
-
-                await Onyx.setCollection(ONYX_KEYS.COLLECTION.ROUTES, {
-                    [invalidRoute]: {name: 'Invalid Route'},
-                } as GenericCollection);
-
-                expect(result).toEqual({
-                    [routeA]: {name: 'Route A'},
-                });
-            });
-        });
-
         it('should properly handle setCollection operations in update()', () => {
             const routeA = `${ONYX_KEYS.COLLECTION.ROUTES}A`;
             const routeB = `${ONYX_KEYS.COLLECTION.ROUTES}B`;
@@ -2615,6 +2185,436 @@ describe('Onyx', () => {
 
                     expect(testKeyValue).toBe('merged value');
                 });
+        });
+    });
+
+    describe('merge', () => {
+        it('should replace the old value after a null merge in the top-level object when batching merges', async () => {
+            let result: unknown;
+            connection = Onyx.connect({
+                key: ONYX_KEYS.COLLECTION.TEST_UPDATE,
+                waitForCollectionCallback: true,
+                callback: (value) => {
+                    result = value;
+                },
+            });
+
+            await Onyx.multiSet({
+                [`${ONYX_KEYS.COLLECTION.TEST_UPDATE}entry1`]: {
+                    id: 'entry1',
+                    someKey: 'someValue',
+                },
+            });
+
+            // Removing the entire object in this merge.
+            // Any subsequent changes to this key should completely replace the old value.
+            Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_UPDATE}entry1`, null);
+
+            // This change should completely replace `${ONYX_KEYS.COLLECTION.TEST_UPDATE}entry1` old value.
+            Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_UPDATE}entry1`, {
+                someKey: 'someValueChanged',
+            });
+
+            await waitForPromisesToResolve();
+
+            expect(result).toEqual({[`${ONYX_KEYS.COLLECTION.TEST_UPDATE}entry1`]: {someKey: 'someValueChanged'}});
+            expect(await StorageMock.getItem(`${ONYX_KEYS.COLLECTION.TEST_UPDATE}entry1`)).toEqual({someKey: 'someValueChanged'});
+        });
+
+        describe('should replace the old value after a null merge in a nested property when batching merges', () => {
+            let result: unknown;
+
+            beforeEach(() => {
+                connection = Onyx.connect({
+                    key: ONYX_KEYS.COLLECTION.TEST_UPDATE,
+                    waitForCollectionCallback: true,
+                    callback: (value) => {
+                        result = value;
+                    },
+                });
+            });
+
+            it('replacing old object after null merge', async () => {
+                const entry1: GenericDeepRecord = {
+                    sub_entry1: {
+                        id: 'sub_entry1',
+                        someKey: 'someValue',
+                    },
+                };
+                await Onyx.multiSet({[`${ONYX_KEYS.COLLECTION.TEST_UPDATE}entry1`]: entry1});
+
+                const entry1ExpectedResult = lodashCloneDeep(entry1);
+
+                Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_UPDATE}entry1`, {
+                    // Removing the "sub_entry1" object in this merge.
+                    // Any subsequent changes to this object should completely replace the existing object in store.
+                    sub_entry1: null,
+                });
+                delete entry1ExpectedResult.sub_entry1;
+
+                Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_UPDATE}entry1`, {
+                    // This change should completely replace "sub_entry1" existing object in store.
+                    sub_entry1: {
+                        newKey: 'newValue',
+                    },
+                });
+                entry1ExpectedResult.sub_entry1 = {newKey: 'newValue'};
+
+                await waitForPromisesToResolve();
+
+                expect(result).toEqual({[`${ONYX_KEYS.COLLECTION.TEST_UPDATE}entry1`]: entry1ExpectedResult});
+                expect(await StorageMock.getItem(`${ONYX_KEYS.COLLECTION.TEST_UPDATE}entry1`)).toEqual(entry1ExpectedResult);
+            });
+
+            it('setting new object after null merge', async () => {
+                const entry1: GenericDeepRecord = {
+                    sub_entry1: {
+                        id: 'sub_entry1',
+                        someKey: 'someValue',
+                        someNestedObject: {
+                            someNestedKey: 'someNestedValue',
+                            anotherNestedObject: {
+                                anotherNestedKey: 'anotherNestedValue',
+                            },
+                        },
+                    },
+                };
+                await Onyx.multiSet({[`${ONYX_KEYS.COLLECTION.TEST_UPDATE}entry1`]: entry1});
+
+                const entry1ExpectedResult = lodashCloneDeep(entry1);
+
+                Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_UPDATE}entry1`, {
+                    sub_entry1: {
+                        someNestedObject: {
+                            // Introducing a new "anotherNestedObject2" object in this merge.
+                            anotherNestedObject2: {
+                                anotherNestedKey2: 'anotherNestedValue2',
+                            },
+                        },
+                    },
+                });
+                entry1ExpectedResult.sub_entry1.someNestedObject.anotherNestedObject2 = {anotherNestedKey2: 'anotherNestedValue2'};
+
+                Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_UPDATE}entry1`, {
+                    sub_entry1: {
+                        someNestedObject: {
+                            // Removing the "anotherNestedObject2" object in this merge.
+                            // This property was only introduced in a previous merge, so we don't need to care
+                            // about an old existing value because there isn't one.
+                            anotherNestedObject2: null,
+                        },
+                    },
+                });
+                delete entry1ExpectedResult.sub_entry1.someNestedObject.anotherNestedObject2;
+
+                Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_UPDATE}entry1`, {
+                    sub_entry1: {
+                        someNestedObject: {
+                            // Introducing the "anotherNestedObject2" object again with this update.
+                            anotherNestedObject2: {
+                                newNestedKey2: 'newNestedValue2',
+                            },
+                        },
+                    },
+                });
+                entry1ExpectedResult.sub_entry1.someNestedObject.anotherNestedObject2 = {newNestedKey2: 'newNestedValue2'};
+
+                await waitForPromisesToResolve();
+
+                expect(result).toEqual({[`${ONYX_KEYS.COLLECTION.TEST_UPDATE}entry1`]: entry1ExpectedResult});
+                expect(await StorageMock.getItem(`${ONYX_KEYS.COLLECTION.TEST_UPDATE}entry1`)).toEqual(entry1ExpectedResult);
+            });
+
+            it('setting new object after null merge of a primitive property', async () => {
+                const entry1: GenericDeepRecord = {
+                    sub_entry1: {
+                        id: 'sub_entry1',
+                        someKey: 'someValue',
+                        someNestedObject: {
+                            someNestedKey: 'someNestedValue',
+                            anotherNestedObject: {
+                                anotherNestedKey: 'anotherNestedValue',
+                            },
+                        },
+                    },
+                };
+                await Onyx.multiSet({[`${ONYX_KEYS.COLLECTION.TEST_UPDATE}entry1`]: entry1});
+
+                const entry1ExpectedResult = lodashCloneDeep(entry1);
+
+                Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_UPDATE}entry1`, {
+                    sub_entry1: {
+                        someNestedObject: {
+                            anotherNestedObject: {
+                                // Removing the "anotherNestedKey" property in this merge.
+                                // This property's existing value in store is a primitive value, so we don't need to care
+                                // about it when merging new values in any next merges.
+                                anotherNestedKey: null,
+                            },
+                        },
+                    },
+                });
+                delete entry1ExpectedResult.sub_entry1.someNestedObject.anotherNestedObject.anotherNestedKey;
+
+                Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_UPDATE}entry1`, {
+                    sub_entry1: {
+                        someNestedObject: {
+                            anotherNestedObject: {
+                                // Setting a new object to the "anotherNestedKey" property.
+                                anotherNestedKey: {
+                                    newNestedKey: 'newNestedValue',
+                                },
+                            },
+                        },
+                    },
+                });
+                entry1ExpectedResult.sub_entry1.someNestedObject.anotherNestedObject.anotherNestedKey = {newNestedKey: 'newNestedValue'};
+
+                await waitForPromisesToResolve();
+
+                expect(result).toEqual({[`${ONYX_KEYS.COLLECTION.TEST_UPDATE}entry1`]: entry1ExpectedResult});
+                expect(await StorageMock.getItem(`${ONYX_KEYS.COLLECTION.TEST_UPDATE}entry1`)).toEqual(entry1ExpectedResult);
+            });
+        });
+
+        it('should remove a deeply nested null when merging an existing key', () => {
+            let result: unknown;
+
+            connection = Onyx.connect({
+                key: ONYX_KEYS.TEST_KEY,
+                initWithStoredValues: false,
+                callback: (value) => (result = value),
+            });
+
+            const initialValue = {
+                waypoints: {
+                    1: 'Home',
+                    2: 'Work',
+                    3: 'Gym',
+                },
+            };
+
+            return Onyx.set(ONYX_KEYS.TEST_KEY, initialValue)
+                .then(() => {
+                    expect(result).toEqual(initialValue);
+                    Onyx.merge(ONYX_KEYS.TEST_KEY, {
+                        waypoints: {
+                            1: 'Home',
+                            2: 'Work',
+                            3: null,
+                        },
+                    });
+                    return waitForPromisesToResolve();
+                })
+                .then(() => {
+                    expect(result).toEqual({
+                        waypoints: {
+                            1: 'Home',
+                            2: 'Work',
+                        },
+                    });
+                });
+        });
+    });
+
+    describe('set', () => {
+        it('should work with skipCacheCheck option', () => {
+            let testKeyValue: unknown;
+
+            connection = Onyx.connect({
+                key: ONYX_KEYS.TEST_KEY,
+                initWithStoredValues: false,
+                callback: (value) => {
+                    testKeyValue = value;
+                },
+            });
+
+            const testData = {id: 1, name: 'test'};
+
+            return Onyx.set(ONYX_KEYS.TEST_KEY, testData)
+                .then(() => {
+                    expect(testKeyValue).toEqual(testData);
+
+                    return Onyx.set(ONYX_KEYS.TEST_KEY, testData, {skipCacheCheck: true});
+                })
+                .then(() => {
+                    expect(testKeyValue).toEqual(testData);
+                });
+        });
+
+        it('should work with skipNullRemoval option', () => {
+            let testKeyValue: unknown;
+
+            connection = Onyx.connect({
+                key: ONYX_KEYS.TEST_KEY,
+                initWithStoredValues: false,
+                callback: (value) => {
+                    testKeyValue = value;
+                },
+            });
+
+            const testDataWithNulls = {
+                id: 1,
+                name: 'test',
+                nested: {
+                    validValue: 'keep',
+                    nullValue: null,
+                    undefinedValue: undefined,
+                },
+                topLevelNull: null,
+            };
+
+            return Onyx.set(ONYX_KEYS.TEST_KEY, testDataWithNulls, {skipNullRemoval: true}).then(() => {
+                // The null values should be preserved
+                expect(testKeyValue).toEqual(testDataWithNulls);
+            });
+        });
+
+        it('should remove null values by default when skipNullRemoval is not set', () => {
+            let testKeyValue: unknown;
+
+            connection = Onyx.connect({
+                key: ONYX_KEYS.TEST_KEY,
+                initWithStoredValues: false,
+                callback: (value) => {
+                    testKeyValue = value;
+                },
+            });
+
+            const testDataWithNulls = {
+                id: 1,
+                name: 'test',
+                nested: {
+                    validValue: 'keep',
+                    nullValue: null,
+                    undefinedValue: undefined,
+                },
+                topLevelNull: null,
+            };
+
+            // Set value without skipNullRemoval (default behavior)
+            return Onyx.set(ONYX_KEYS.TEST_KEY, testDataWithNulls).then(() => {
+                // The null values should be removed
+                expect(testKeyValue).toEqual({
+                    id: 1,
+                    name: 'test',
+                    nested: {
+                        validValue: 'keep',
+                    },
+                });
+            });
+        });
+
+        it('should work with both skipCacheCheck and skipNullRemoval options', () => {
+            let testKeyValue: unknown;
+
+            connection = Onyx.connect({
+                key: ONYX_KEYS.TEST_KEY,
+                initWithStoredValues: false,
+                callback: (value) => {
+                    testKeyValue = value;
+                },
+            });
+
+            const testDataWithNulls = {
+                id: 1,
+                name: 'test',
+                computed: null,
+                nested: {
+                    result: null,
+                    valid: 'keep',
+                },
+            };
+
+            Onyx.set(ONYX_KEYS.TEST_KEY, testDataWithNulls, {
+                skipCacheCheck: true,
+                skipNullRemoval: true,
+            }).then(() => {
+                // The null values should be preserved
+                expect(testKeyValue).toEqual(testDataWithNulls);
+            });
+        });
+    });
+
+    describe('setCollection', () => {
+        it('should replace all existing collection members with new values and remove old ones', async () => {
+            let result: OnyxCollection<unknown>;
+            const routeA = `${ONYX_KEYS.COLLECTION.ROUTES}A`;
+            const routeB = `${ONYX_KEYS.COLLECTION.ROUTES}B`;
+            const routeB1 = `${ONYX_KEYS.COLLECTION.ROUTES}B1`;
+            const routeC = `${ONYX_KEYS.COLLECTION.ROUTES}C`;
+
+            connection = Onyx.connect({
+                key: ONYX_KEYS.COLLECTION.ROUTES,
+                initWithStoredValues: false,
+                callback: (value) => (result = value),
+                waitForCollectionCallback: true,
+            });
+
+            // Set initial collection state
+            await Onyx.mergeCollection(ONYX_KEYS.COLLECTION.ROUTES, {
+                [routeA]: {name: 'Route A'},
+                [routeB1]: {name: 'Route B1'},
+                [routeC]: {name: 'Route C'},
+            } as GenericCollection);
+
+            // Replace with new collection data
+            await Onyx.setCollection(ONYX_KEYS.COLLECTION.ROUTES, {
+                [routeA]: {name: 'New Route A'},
+                [routeB]: {name: 'New Route B'},
+                [routeC]: {name: 'New Route C'},
+            } as GenericCollection);
+
+            expect(result).toEqual({
+                [routeA]: {name: 'New Route A'},
+                [routeB]: {name: 'New Route B'},
+                [routeC]: {name: 'New Route C'},
+            });
+        });
+
+        it('should replace the collection with empty values', async () => {
+            let result: OnyxCollection<unknown>;
+            const routeA = `${ONYX_KEYS.COLLECTION.ROUTES}A`;
+
+            connection = Onyx.connect({
+                key: ONYX_KEYS.COLLECTION.ROUTES,
+                initWithStoredValues: false,
+                callback: (value) => (result = value),
+                waitForCollectionCallback: true,
+            });
+
+            await Onyx.mergeCollection(ONYX_KEYS.COLLECTION.ROUTES, {
+                [routeA]: {name: 'Route A'},
+            } as GenericCollection);
+
+            await Onyx.setCollection(ONYX_KEYS.COLLECTION.ROUTES, {} as GenericCollection);
+
+            expect(result).toEqual({});
+        });
+
+        it('should reject collection items with invalid keys', async () => {
+            let result: OnyxCollection<unknown>;
+            const routeA = `${ONYX_KEYS.COLLECTION.ROUTES}A`;
+            const invalidRoute = 'invalid_route';
+
+            connection = Onyx.connect({
+                key: ONYX_KEYS.COLLECTION.ROUTES,
+                initWithStoredValues: false,
+                callback: (value) => (result = value),
+                waitForCollectionCallback: true,
+            });
+
+            await Onyx.mergeCollection(ONYX_KEYS.COLLECTION.ROUTES, {
+                [routeA]: {name: 'Route A'},
+            } as GenericCollection);
+
+            await Onyx.setCollection(ONYX_KEYS.COLLECTION.ROUTES, {
+                [invalidRoute]: {name: 'Invalid Route'},
+            } as GenericCollection);
+
+            expect(result).toEqual({
+                [routeA]: {name: 'Route A'},
+            });
         });
     });
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details

Slack thread: https://expensify.slack.com/archives/C05LX9D6E07/p1751978498770109

This PR is a fix to the current Onyx bump PR: https://github.com/Expensify/App/pull/65811.

Some unit tests on E/App are randomly failing with that PR due to the change we made in https://github.com/Expensify/react-native-onyx/pull/620 about how `Onyx.update()` handles the queued operations.

That change was unnecessary and now it's causing race conditions when we have interactions with React logic and Onyx updates. With this PR we are rolling back to the similar old logic which don't cause race conditions.

As an example, how it's working before this PR:

```
Onyx.update updateQueue {"session":[{"authToken":"asdfqwerty","accountID":1,"email":"test@test.com","encryptedAuthToken":"asdfqwerty"}],"credentials":[{"autoGeneratedLogin":"expensify.cash-4e802ab6-9606-9784-59c0-dea478774d42","autoGeneratedPassword":"015f2802-3f73-33d2-2ed2-28438d00028f"},{"validateCode":"Password1"}],"account":[{"isUsingExpensifyCard":false},{"isLoading":false,"loadingForm":null}],"betas":[["all"]],"nvp_private_pushNotificationID":["randomID"],"personalDetailsList":[{}]}
Onyx.update updateQueue key operations session [{"authToken":"asdfqwerty","accountID":1,"email":"test@test.com","encryptedAuthToken":"asdfqwerty"}]
Onyx.merge session {"authToken":"asdfqwerty","accountID":1,"email":"test@test.com","encryptedAuthToken":"asdfqwerty"}

Onyx.update updateQueue key operations credentials [{"autoGeneratedLogin":"expensify.cash-4e802ab6-9606-9784-59c0-dea478774d42","autoGeneratedPassword":"015f2802-3f73-33d2-2ed2-28438d00028f"},{"validateCode":"Password1"}]
Onyx.merge credentials {"autoGeneratedLogin":"expensify.cash-4e802ab6-9606-9784-59c0-dea478774d42","autoGeneratedPassword":"015f2802-3f73-33d2-2ed2-28438d00028f"}
Onyx.merge credentials {"validateCode":"Password1"}

Onyx.update updateQueue key operations account [{"isUsingExpensifyCard":false},{"isLoading":false,"loadingForm":null}]
Onyx.merge account {"isUsingExpensifyCard":false}
Onyx.merge account {"isLoading":false,"loadingForm":null}

Onyx.update updateQueue key operations betas [["all"]]
Onyx.merge betas ["all"]

Onyx.update updateQueue key operations nvp_private_pushNotificationID ["randomID"]
Onyx.merge nvp_private_pushNotificationID "randomID"

Onyx.update updateQueue key operations personalDetailsList [{}]
Onyx.merge personalDetailsList {}
```

And how it will work after this PR (that actually was how it was similarly working before https://github.com/Expensify/react-native-onyx/pull/620):

```
Onyx.update updateQueue {"session":[{"authToken":"asdfqwerty","accountID":1,"email":"test@test.com","encryptedAuthToken":"asdfqwerty"}],"credentials":[{"autoGeneratedLogin":"expensify.cash-c3c902cd-0d49-151c-0b72-23035925ddad","autoGeneratedPassword":"aebea4a5-8e5d-0193-c2fd-8210eaf303ff"},{"validateCode":"Password1"}],"account":[{"isUsingExpensifyCard":false},{"isLoading":false,"loadingForm":null}],"betas":[["all"]],"nvp_private_pushNotificationID":["randomID"],"personalDetailsList":[{}]}
Onyx.update updateQueue key operations session [{"authToken":"asdfqwerty","accountID":1,"email":"test@test.com","encryptedAuthToken":"asdfqwerty"}]
Onyx.update updateQueue key operations credentials [{"autoGeneratedLogin":"expensify.cash-c3c902cd-0d49-151c-0b72-23035925ddad","autoGeneratedPassword":"aebea4a5-8e5d-0193-c2fd-8210eaf303ff"},{"validateCode":"Password1"}]
Onyx.update updateQueue key operations account [{"isUsingExpensifyCard":false},{"isLoading":false,"loadingForm":null}]
Onyx.update updateQueue key operations betas [["all"]]
Onyx.update updateQueue key operations nvp_private_pushNotificationID ["randomID"]
Onyx.update updateQueue key operations personalDetailsList [{}]

Onyx.merge session {"authToken":"asdfqwerty","accountID":1,"email":"test@test.com","encryptedAuthToken":"asdfqwerty"}
Onyx.merge credentials {"autoGeneratedLogin":"expensify.cash-c3c902cd-0d49-151c-0b72-23035925ddad","autoGeneratedPassword":"aebea4a5-8e5d-0193-c2fd-8210eaf303ff"}
Onyx.merge credentials {"validateCode":"Password1"}
Onyx.merge account {"isUsingExpensifyCard":false}
Onyx.merge account {"isLoading":false,"loadingForm":null}
Onyx.merge betas ["all"]
Onyx.merge nvp_private_pushNotificationID "randomID"
Onyx.merge personalDetailsList {}
```

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/App/issues/65715

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

Unfortunately I couldn't find a way to design unit tests that would simulate these racing conditions between React and Onyx.

### Manual Tests
<!---
Each set of changes should be tested against the Expensify/App repo on all platforms to verify it does not break our staging App.
--->

1. Checkout the [Onyx bump PR](https://github.com/Expensify/App/pull/65811) in E/App repo and install dependencies.
2. Checkout this PR in your Onyx repo and connect to E/App repo with [these instructions](https://github.com/Expensify/react-native-onyx/?tab=readme-ov-file#development).
3. Run the unit tests a couple of times and assert they pass all times.

### Author Checklist

- [x] I linked the correct issue in the `### Related Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
