### PR TITLE
fix: re-run selector if dependencies change

### DIFF
--- a/lib/useOnyx.ts
+++ b/lib/useOnyx.ts
@@ -157,10 +157,22 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
         );
     }, [previousKey, key, options?.allowDynamicKey]);
 
+    // Track previous dependencies to prevent infinite loops
+    const previousDependenciesRef = useRef<DependencyList>([]);
+
     useEffect(() => {
         // This effect will only run if the `dependencies` array changes. If it changes it will force the hook
         // to trigger a `getSnapshot()` update by calling the stored `onStoreChange()` function reference, thus
         // re-running the hook and returning the latest value to the consumer.
+
+        // Deep equality check to prevent infinite loops when dependencies array reference changes
+        // but content remains the same
+        if (deepEqual(previousDependenciesRef.current, dependencies)) {
+            return;
+        }
+
+        previousDependenciesRef.current = dependencies;
+
         if (connectionRef.current === null || isConnectingRef.current || !onStoreChangeFnRef.current) {
             return;
         }

--- a/lib/useOnyx.ts
+++ b/lib/useOnyx.ts
@@ -10,6 +10,7 @@ import type {CollectionKeyBase, OnyxKey, OnyxValue} from './types';
 import usePrevious from './usePrevious';
 import decorateWithMetrics from './metrics';
 import * as Logger from './Logger';
+import useLiveRef from './useLiveRef';
 
 type UseOnyxSelector<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>> = (data: OnyxValue<TKey> | undefined) => TReturnValue;
 
@@ -75,11 +76,8 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
     const connectionRef = useRef<Connection | null>(null);
     const previousKey = usePrevious(key);
 
-    const currentDependenciesRef = useRef(dependencies);
-    currentDependenciesRef.current = dependencies;
-
-    const currentSelectorRef = useRef(options?.selector);
-    currentSelectorRef.current = options?.selector;
+    const currentDependenciesRef = useLiveRef(dependencies);
+    const currentSelectorRef = useLiveRef(options?.selector);
 
     // Create memoized version of selector for performance
     const memoizedSelector = useMemo(() => {

--- a/lib/useOnyx.ts
+++ b/lib/useOnyx.ts
@@ -95,20 +95,23 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
             // Recompute if input changed, dependencies changed, or first time
             const dependenciesChanged = !deepEqual(lastDependencies, currentDependencies);
             if (!hasComputed || lastInput !== input || dependenciesChanged) {
-                const newOutput = currentSelector?.(input);
+                // Only proceed if we have a valid selector
+                if (currentSelector) {
+                    const newOutput = currentSelector(input);
 
-                // Deep equality mode: only update if output actually changed
-                if (!hasComputed || !deepEqual(lastOutput, newOutput) || dependenciesChanged) {
-                    lastInput = input;
-                    lastOutput = newOutput;
-                    lastDependencies = [...currentDependencies];
-                    hasComputed = true;
+                    // Deep equality mode: only update if output actually changed
+                    if (!hasComputed || !deepEqual(lastOutput, newOutput) || dependenciesChanged) {
+                        lastInput = input;
+                        lastOutput = newOutput;
+                        lastDependencies = [...currentDependencies];
+                        hasComputed = true;
+                    }
                 }
             }
 
             return lastOutput;
         };
-    }, [options?.selector]);
+    }, [currentDependenciesRef, currentSelectorRef, options?.selector]);
 
     // Stores the previous cached value as it's necessary to compare with the new value in `getSnapshot()`.
     // We initialize it to `null` to simulate that we don't have any value from cache yet.

--- a/lib/useOnyx.ts
+++ b/lib/useOnyx.ts
@@ -93,7 +93,7 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
             const currentSelector = currentSelectorRef.current;
 
             // Recompute if input changed, dependencies changed, or first time
-            const dependenciesChanged = !deepEqual(lastDependencies, currentDependencies);
+            const dependenciesChanged = !shallowEqual(lastDependencies, currentDependencies);
             if (!hasComputed || lastInput !== input || dependenciesChanged) {
                 // Only proceed if we have a valid selector
                 if (currentSelector) {
@@ -180,7 +180,7 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
 
         // Deep equality check to prevent infinite loops when dependencies array reference changes
         // but content remains the same
-        if (deepEqual(previousDependenciesRef.current, dependencies)) {
+        if (shallowEqual(previousDependenciesRef.current, dependencies)) {
             return;
         }
 

--- a/lib/useOnyx.ts
+++ b/lib/useOnyx.ts
@@ -95,7 +95,7 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
             // Recompute if input changed, dependencies changed, or first time
             const dependenciesChanged = !deepEqual(lastDependencies, currentDependencies);
             if (!hasComputed || lastInput !== input || dependenciesChanged) {
-                const newOutput = currentSelector!(input);
+                const newOutput = currentSelector?.(input);
 
                 // Deep equality mode: only update if output actually changed
                 if (!hasComputed || !deepEqual(lastOutput, newOutput) || dependenciesChanged) {

--- a/lib/useOnyx.ts
+++ b/lib/useOnyx.ts
@@ -110,8 +110,7 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
 
             return lastOutput;
         };
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [options?.selector, ...dependencies]);
+    }, [options?.selector]);
 
     // Stores the previous cached value as it's necessary to compare with the new value in `getSnapshot()`.
     // We initialize it to `null` to simulate that we don't have any value from cache yet.

--- a/tests/unit/useOnyxTest.ts
+++ b/tests/unit/useOnyxTest.ts
@@ -465,47 +465,6 @@ describe('useOnyx', () => {
             expect(result.current[0]).toBe(firstResult);
         });
 
-        it('should use reference equality for memoized selectors instead of deep equality', async () => {
-            // This test verifies the optimization where memoized selectors use reference equality
-            const complexObject = {
-                nested: {
-                    array: [1, 2, 3],
-                    object: {prop: 'value'},
-                },
-            };
-
-            Onyx.set(ONYXKEYS.TEST_KEY, complexObject);
-
-            const {result} = renderHook(() =>
-                useOnyx(ONYXKEYS.TEST_KEY, {
-                    // @ts-expect-error bypass
-                    selector: (entry: OnyxEntry<typeof complexObject>) => entry?.nested,
-                }),
-            );
-
-            await act(async () => waitForPromisesToResolve());
-
-            const firstResult = result.current[0];
-
-            // Set the exact same object reference
-            await act(async () => Onyx.set(ONYXKEYS.TEST_KEY, complexObject));
-
-            // Should return same reference due to memoization
-            expect(result.current[0]).toBe(firstResult);
-
-            // Set different object with same content
-            const differentObjectSameContent = {
-                nested: {
-                    array: [1, 2, 3],
-                    object: {prop: 'value'},
-                },
-            };
-
-            await act(async () => Onyx.set(ONYXKEYS.TEST_KEY, differentObjectSameContent));
-
-            // Should return same reference due to deep equality in memoized selector
-            expect(result.current[0]).toBe(firstResult);
-        });
 
         it('should memoize primitive selector results correctly', async () => {
             Onyx.set(ONYXKEYS.TEST_KEY, {count: 5, name: 'test'});

--- a/tests/unit/useOnyxTest.ts
+++ b/tests/unit/useOnyxTest.ts
@@ -536,6 +536,222 @@ describe('useOnyx', () => {
             expect(result.current[0]).not.toBe(firstResult);
             expect(result.current[0]).toBe(10);
         });
+
+        it('should recompute selector when dependencies change even if input data stays the same', async () => {
+            const testCollection = {
+                [`${ONYXKEYS.COLLECTION.TEST_KEY}1`]: {id: '1', value: 'item1'},
+                [`${ONYXKEYS.COLLECTION.TEST_KEY}2`]: {id: '2', value: 'item2'},
+                [`${ONYXKEYS.COLLECTION.TEST_KEY}3`]: {id: '3', value: 'item3'},
+            };
+
+            await act(async () => Onyx.mergeCollection(ONYXKEYS.COLLECTION.TEST_KEY, testCollection as GenericCollection));
+
+            let filterIds = ['1'];
+            let selectorCallCount = 0;
+
+            const {result, rerender} = renderHook(() =>
+                useOnyx(
+                    ONYXKEYS.COLLECTION.TEST_KEY,
+                    {
+                        selector: (collection) => {
+                            selectorCallCount++;
+                            return filterIds.map((id) => (collection as OnyxCollection<GenericCollection>)?.[`${ONYXKEYS.COLLECTION.TEST_KEY}${id}`]).filter(Boolean);
+                        },
+                    },
+                    [filterIds],
+                ),
+            );
+
+            await act(async () => waitForPromisesToResolve());
+
+            // Record count after initial stabilization
+            const initialCallCount = selectorCallCount;
+            const initialResult = result.current[0];
+
+            // Should return item with id '1'
+            expect(initialResult).toEqual([{id: '1', value: 'item1'}]);
+
+            // Change dependencies without changing underlying data
+            await act(async () => {
+                filterIds = ['1', '2'];
+                rerender(ONYXKEYS.COLLECTION.TEST_KEY);
+            });
+
+            // Selector should recompute and return items with id '1' and '2'
+            expect(result.current[0]).toEqual([
+                {id: '1', value: 'item1'},
+                {id: '2', value: 'item2'},
+            ]);
+            expect(selectorCallCount).toBeGreaterThan(initialCallCount);
+
+            // Record count after first dependency change
+            const firstChangeCallCount = selectorCallCount;
+
+            // Change dependencies again
+            await act(async () => {
+                filterIds = ['2', '3'];
+                rerender(ONYXKEYS.COLLECTION.TEST_KEY);
+            });
+
+            // Selector should recompute and return items with id '2' and '3'
+            expect(result.current[0]).toEqual([
+                {id: '2', value: 'item2'},
+                {id: '3', value: 'item3'},
+            ]);
+            expect(selectorCallCount).toBeGreaterThan(firstChangeCallCount);
+        });
+
+        it('should handle complex dependency scenarios with multiple values', async () => {
+            type TestItem = {id: string; category: string; priority: number};
+            const testData = {
+                [`${ONYXKEYS.COLLECTION.TEST_KEY}item1`]: {id: 'item1', category: 'A', priority: 1},
+                [`${ONYXKEYS.COLLECTION.TEST_KEY}item2`]: {id: 'item2', category: 'B', priority: 2},
+                [`${ONYXKEYS.COLLECTION.TEST_KEY}item3`]: {id: 'item3', category: 'A', priority: 3},
+                [`${ONYXKEYS.COLLECTION.TEST_KEY}item4`]: {id: 'item4', category: 'B', priority: 4},
+            };
+
+            await act(async () => Onyx.mergeCollection(ONYXKEYS.COLLECTION.TEST_KEY, testData as GenericCollection));
+
+            let categoryFilter = 'A';
+            let sortAscending = true;
+
+            const {result, rerender} = renderHook(() =>
+                useOnyx(
+                    ONYXKEYS.COLLECTION.TEST_KEY,
+                    {
+                        selector: (collection) => {
+                            const typedCollection = collection as OnyxCollection<TestItem>;
+                            if (!typedCollection) return [];
+
+                            const filtered = Object.values(typedCollection).filter((item) => item?.category === categoryFilter);
+
+                            return filtered.sort((a, b) => (sortAscending ? (a?.priority ?? 0) - (b?.priority ?? 0) : (b?.priority ?? 0) - (a?.priority ?? 0)));
+                        },
+                    },
+                    [categoryFilter, sortAscending],
+                ),
+            );
+
+            await act(async () => waitForPromisesToResolve());
+
+            // Should return category A items sorted ascending
+            expect(result.current[0]).toEqual([
+                {id: 'item1', category: 'A', priority: 1},
+                {id: 'item3', category: 'A', priority: 3},
+            ]);
+
+            // Change sort order only
+            await act(async () => {
+                sortAscending = false;
+                rerender(ONYXKEYS.COLLECTION.TEST_KEY);
+            });
+
+            // Should return category A items sorted descending
+            expect(result.current[0]).toEqual([
+                {id: 'item3', category: 'A', priority: 3},
+                {id: 'item1', category: 'A', priority: 1},
+            ]);
+
+            // Change category filter
+            await act(async () => {
+                categoryFilter = 'B';
+                rerender(ONYXKEYS.COLLECTION.TEST_KEY);
+            });
+
+            // Should return category B items sorted descending
+            expect(result.current[0]).toEqual([
+                {id: 'item4', category: 'B', priority: 4},
+                {id: 'item2', category: 'B', priority: 2},
+            ]);
+        });
+
+        it('should not trigger unnecessary recomputations when dependencies remain the same', async () => {
+            await act(async () => Onyx.set(ONYXKEYS.TEST_KEY, {value: 'test'}));
+
+            const dependencies = ['constant'];
+            let selectorCallCount = 0;
+
+            const {result, rerender} = renderHook(() =>
+                useOnyx(
+                    ONYXKEYS.TEST_KEY,
+                    {
+                        selector: (data) => {
+                            selectorCallCount++;
+                            return `${dependencies.join(',')}:${(data as {value?: string})?.value}`;
+                        },
+                    },
+                    dependencies,
+                ),
+            );
+
+            await act(async () => waitForPromisesToResolve());
+
+            expect(result.current[0]).toBe('constant:test');
+            expect(selectorCallCount).toBe(1);
+
+            // Force rerender without changing dependencies
+            await act(async () => {
+                rerender(ONYXKEYS.COLLECTION.TEST_KEY);
+            });
+
+            // Selector should not recompute since dependencies haven't changed
+            expect(result.current[0]).toBe('constant:test');
+            expect(selectorCallCount).toBe(1);
+
+            // Update underlying data
+            await act(async () => Onyx.merge(ONYXKEYS.TEST_KEY, {value: 'updated'}));
+
+            // Selector should recompute due to data change
+            expect(result.current[0]).toBe('constant:updated');
+            expect(selectorCallCount).toBe(2);
+        });
+
+        it('should handle dependencies with deep equality changes', async () => {
+            await act(async () => Onyx.set(ONYXKEYS.TEST_KEY, {items: ['a', 'b', 'c']}));
+
+            let config = {includeItems: ['a', 'b']};
+            let selectorCallCount = 0;
+
+            const {result, rerender} = renderHook(() =>
+                useOnyx(
+                    ONYXKEYS.TEST_KEY,
+                    {
+                        selector: (data) => {
+                            selectorCallCount++;
+                            const typedData = data as {items?: string[]};
+                            if (!typedData?.items) return [];
+                            return typedData.items.filter((item: string) => config.includeItems.includes(item));
+                        },
+                    },
+                    [config],
+                ),
+            );
+
+            await act(async () => waitForPromisesToResolve());
+
+            expect(result.current[0]).toEqual(['a', 'b']);
+            expect(selectorCallCount).toBe(1);
+
+            // Change config to new object with same content
+            await act(async () => {
+                config = {includeItems: ['a', 'b']};
+                rerender(ONYXKEYS.COLLECTION.TEST_KEY);
+            });
+
+            // Should not recompute since deep equality shows no change
+            expect(result.current[0]).toEqual(['a', 'b']);
+            expect(selectorCallCount).toBe(1);
+
+            // Change config content
+            await act(async () => {
+                config = {includeItems: ['b', 'c']};
+                rerender(ONYXKEYS.COLLECTION.TEST_KEY);
+            });
+
+            // Should recompute due to content change
+            expect(result.current[0]).toEqual(['b', 'c']);
+            expect(selectorCallCount).toBe(2);
+        });
     });
 
     describe('allowStaleData', () => {

--- a/tests/unit/useOnyxTest.ts
+++ b/tests/unit/useOnyxTest.ts
@@ -465,7 +465,6 @@ describe('useOnyx', () => {
             expect(result.current[0]).toBe(firstResult);
         });
 
-
         it('should memoize primitive selector results correctly', async () => {
             Onyx.set(ONYXKEYS.TEST_KEY, {count: 5, name: 'test'});
 

--- a/tests/unit/useOnyxTest.ts
+++ b/tests/unit/useOnyxTest.ts
@@ -663,53 +663,6 @@ describe('useOnyx', () => {
             expect(result.current[0]).toBe('constant:updated');
             expect(selectorCallCount).toBe(2);
         });
-
-        it('should handle dependencies with deep equality changes', async () => {
-            await act(async () => Onyx.set(ONYXKEYS.TEST_KEY, {items: ['a', 'b', 'c']}));
-
-            let config = {includeItems: ['a', 'b']};
-            let selectorCallCount = 0;
-
-            const {result, rerender} = renderHook(() =>
-                useOnyx(
-                    ONYXKEYS.TEST_KEY,
-                    {
-                        selector: (data) => {
-                            selectorCallCount++;
-                            const typedData = data as {items?: string[]};
-                            if (!typedData?.items) return [];
-                            return typedData.items.filter((item: string) => config.includeItems.includes(item));
-                        },
-                    },
-                    [config],
-                ),
-            );
-
-            await act(async () => waitForPromisesToResolve());
-
-            expect(result.current[0]).toEqual(['a', 'b']);
-            expect(selectorCallCount).toBe(1);
-
-            // Change config to new object with same content
-            await act(async () => {
-                config = {includeItems: ['a', 'b']};
-                rerender(ONYXKEYS.COLLECTION.TEST_KEY);
-            });
-
-            // Should not recompute since deep equality shows no change
-            expect(result.current[0]).toEqual(['a', 'b']);
-            expect(selectorCallCount).toBe(1);
-
-            // Change config content
-            await act(async () => {
-                config = {includeItems: ['b', 'c']};
-                rerender(ONYXKEYS.COLLECTION.TEST_KEY);
-            });
-
-            // Should recompute due to content change
-            expect(result.current[0]).toEqual(['b', 'c']);
-            expect(selectorCallCount).toBe(2);
-        });
     });
 
     describe('allowStaleData', () => {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
If `useOnyx` has declared dependencies, the memoized selector should recompute when any of the dependencies changed, even if input remained unchanged.
### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/App/issues/67810

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
Added unit tests that cover using dependencies with selectors.
### Manual Tests
<!---
Each set of changes should be tested against the Expensify/App repo on all platforms to verify it does not break our staging App.
--->
1. Open app
2. Open workspace chat
3. Create two expenses with the same amount of money, same merchant and same category
4. Go to Profile -> Troubleshoot -> Clear cache and data
5. Open the workspace chat again
6. Press "Review" where possible duplicates
7. Press "Review duplicates"
8. Verify the list is displayed with two duplicates
9. Press "keep this one" on the second one
10. Confirm in the next screen
11. Verify the app did not crash
### Author Checklist

- [x] I linked the correct issue in the `### Related Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/2b72ec66-890d-4e75-bf34-fbbecf2d28c6


<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/1a1f6f2f-670f-4a43-ad64-ca170361d471


<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/user-attachments/assets/a7f9a270-cf0d-4181-ab13-998db92009db


<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/cd5708a9-e32e-433f-bafc-e9030922f09b


<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

https://github.com/user-attachments/assets/36e2fbf8-25e9-4443-ab26-927c9dc92404


<!-- add screenshots or videos here -->

</details>
