### PR TITLE
perf: cache useOnyx snapshots

### DIFF
--- a/lib/OnyxConnectionManager.ts
+++ b/lib/OnyxConnectionManager.ts
@@ -263,6 +263,7 @@ class OnyxConnectionManager {
         });
 
         this.connectionsMap.clear();
+
         // Clear snapshot cache when all connections are disconnected
         onyxSnapshotCache.clear();
     }
@@ -272,6 +273,7 @@ class OnyxConnectionManager {
      */
     refreshSessionID(): void {
         this.sessionID = Str.guid();
+
         // Clear snapshot cache when session refreshes to avoid stale cache issues
         onyxSnapshotCache.clear();
     }

--- a/lib/OnyxConnectionManager.ts
+++ b/lib/OnyxConnectionManager.ts
@@ -6,6 +6,7 @@ import * as Str from './Str';
 import type {CollectionConnectCallback, DefaultConnectCallback, DefaultConnectOptions, OnyxKey, OnyxValue} from './types';
 import utils from './utils';
 import cache from './OnyxCache';
+import onyxSnapshotCache from './OnyxSnapshotCache';
 
 type ConnectCallback = DefaultConnectCallback<OnyxKey> | CollectionConnectCallback<OnyxKey>;
 
@@ -262,6 +263,8 @@ class OnyxConnectionManager {
         });
 
         this.connectionsMap.clear();
+        // Clear snapshot cache when all connections are disconnected
+        onyxSnapshotCache.clear();
     }
 
     /**
@@ -269,6 +272,8 @@ class OnyxConnectionManager {
      */
     refreshSessionID(): void {
         this.sessionID = Str.guid();
+        // Clear snapshot cache when session refreshes to avoid stale cache issues
+        onyxSnapshotCache.clear();
     }
 
     /**

--- a/lib/OnyxSnapshotCache.ts
+++ b/lib/OnyxSnapshotCache.ts
@@ -68,10 +68,22 @@ class OnyxSnapshotCache {
     }
 
     /**
-     * O(1) cache invalidation - just delete the entire cache for this key
+     * O(1) cache invalidation - delete cache for this key and related collection keys
      */
     invalidateForKey(keyToInvalidate: string): void {
+        // Always invalidate the exact key
         this.snapshotCache.delete(keyToInvalidate);
+        
+        // For collection member keys, also invalidate the parent collection
+        if (keyToInvalidate.includes('_')) {
+            const baseKey = keyToInvalidate.split('_')[0];
+            // Invalidate all related collection members
+            for (const [cacheKey] of this.snapshotCache) {
+                if (cacheKey.startsWith(baseKey + '_') || cacheKey === baseKey) {
+                    this.snapshotCache.delete(cacheKey);
+                }
+            }
+        }
     }
 
     /**

--- a/lib/OnyxSnapshotCache.ts
+++ b/lib/OnyxSnapshotCache.ts
@@ -39,9 +39,9 @@ class OnyxSnapshotCache {
     }
 
     /**
-     * Fast cache key generation for selector/options combination
+     * Fast cache key generation for useOnyx options combination
      */
-    generateSelectorKey<TKey extends OnyxKey, TReturnValue>(options?: UseOnyxOptions<TKey, TReturnValue>): string {
+    generateCacheKey<TKey extends OnyxKey, TReturnValue>(options?: UseOnyxOptions<TKey, TReturnValue>): string {
         const selectorId = options?.selector ? this.getSelectorId(options.selector) : 'no_selector';
         // Create options hash without expensive JSON.stringify
         const initWithStoredValues = options?.initWithStoredValues ?? true;
@@ -51,21 +51,21 @@ class OnyxSnapshotCache {
     }
 
     /**
-     * Get cached snapshot result for a key and selector combination
+     * Get cached snapshot result for a key and cache key combination
      */
-    getCachedResult(key: string, selectorKey: string): any {
+    getCachedResult(key: string, cacheKey: string): any {
         const keyCache = this.snapshotCache.get(key);
-        return keyCache?.get(selectorKey);
+        return keyCache?.get(cacheKey);
     }
 
     /**
-     * Set cached snapshot result for a key and selector combination
+     * Set cached snapshot result for a key and cache key combination
      */
-    setCachedResult(key: string, selectorKey: string, result: any): void {
+    setCachedResult(key: string, cacheKey: string, result: any): void {
         if (!this.snapshotCache.has(key)) {
             this.snapshotCache.set(key, new Map());
         }
-        this.snapshotCache.get(key)!.set(selectorKey, result);
+        this.snapshotCache.get(key)!.set(cacheKey, result);
     }
 
     /**

--- a/lib/OnyxSnapshotCache.ts
+++ b/lib/OnyxSnapshotCache.ts
@@ -17,15 +17,22 @@ class OnyxSnapshotCache {
      */
     private selectorIdMap: Map<UseOnyxSelector<any, any>, string>;
 
-    /**
-     * Counter for generating unique selector IDs
-     */
-    private selectorCounter: number;
-
     constructor() {
         this.snapshotCache = new Map();
         this.selectorIdMap = new Map();
-        this.selectorCounter = 0;
+    }
+
+    /**
+     * Hash string to generate deterministic ID
+     */
+    private hashString(str: string): string {
+        let hash = 0;
+        for (let i = 0; i < str.length; i++) {
+            const char = str.charCodeAt(i);
+            hash = (hash << 5) - hash + char;
+            hash = hash & hash; // Convert to 32-bit integer
+        }
+        return Math.abs(hash).toString(36);
     }
 
     /**
@@ -33,7 +40,11 @@ class OnyxSnapshotCache {
      */
     getSelectorId(selector: UseOnyxSelector<any, any>): string {
         if (!this.selectorIdMap.has(selector)) {
-            this.selectorIdMap.set(selector, `selector_${++this.selectorCounter}`);
+            const funcStr = selector.toString();
+            const funcName = selector.name || 'anonymous';
+            const hash = this.hashString(funcStr);
+            const id = `${funcName}_${hash}`;
+            this.selectorIdMap.set(selector, id);
         }
         return this.selectorIdMap.get(selector)!;
     }
@@ -99,7 +110,6 @@ class OnyxSnapshotCache {
      */
     clearSelectorIds(): void {
         this.selectorIdMap.clear();
-        this.selectorCounter = 0;
     }
 }
 

--- a/lib/OnyxSnapshotCache.ts
+++ b/lib/OnyxSnapshotCache.ts
@@ -54,7 +54,7 @@ class OnyxSnapshotCache {
      * Other options like `canEvict`, `reuseConnection`, and `allowDynamicKey` don't affect the data transformation
      * or timing behavior of getSnapshot, so they're excluded from the cache key for better cache hit rates.
      */
-    generateCacheKey<TKey extends OnyxKey, TReturnValue>(options?: UseOnyxOptions<TKey, TReturnValue>): string {
+    generateCacheKey<TKey extends OnyxKey, TReturnValue>(options: Pick<UseOnyxOptions<TKey, TReturnValue>, 'selector' | 'initWithStoredValues' | 'allowStaleData' | 'canBeMissing'>): string {
         const selectorId = options?.selector ? this.getSelectorId(options.selector) : 'no_selector';
         // Create options hash without expensive JSON.stringify
         const initWithStoredValues = options?.initWithStoredValues ?? true;

--- a/lib/OnyxSnapshotCache.ts
+++ b/lib/OnyxSnapshotCache.ts
@@ -1,0 +1,97 @@
+import type {OnyxKey} from './types';
+import type {UseOnyxOptions, UseOnyxSelector} from './useOnyx';
+
+/**
+ * Manages snapshot caching for useOnyx hook performance optimization.
+ * Handles selector function tracking and memoized getSnapshot results.
+ */
+class OnyxSnapshotCache {
+    /**
+     * Snapshot cache for ultimate performance - separate cache per Onyx key
+     */
+    private snapshotCache: Map<string, Map<string, any>>;
+
+    /**
+     * Maps selector functions to unique IDs for cache key generation
+     */
+    private selectorIdMap: Map<UseOnyxSelector<any, any>, string>;
+
+    /**
+     * Counter for generating unique selector IDs
+     */
+    private selectorCounter: number;
+
+    constructor() {
+        this.snapshotCache = new Map();
+        this.selectorIdMap = new Map();
+        this.selectorCounter = 0;
+    }
+
+    /**
+     * Generate unique ID for selector functions
+     */
+    getSelectorId(selector: UseOnyxSelector<any, any>): string {
+        if (!this.selectorIdMap.has(selector)) {
+            this.selectorIdMap.set(selector, `selector_${++this.selectorCounter}`);
+        }
+        return this.selectorIdMap.get(selector)!;
+    }
+
+    /**
+     * Fast cache key generation for selector/options combination
+     */
+    generateSelectorKey<TKey extends OnyxKey, TReturnValue>(options?: UseOnyxOptions<TKey, TReturnValue>): string {
+        const selectorId = options?.selector ? this.getSelectorId(options.selector) : 'no_selector';
+        // Create options hash without expensive JSON.stringify
+        const initWithStoredValues = options?.initWithStoredValues ?? true;
+        const allowStaleData = options?.allowStaleData ?? false;
+        const canBeMissing = options?.canBeMissing ?? true;
+        return `${selectorId}_${initWithStoredValues}_${allowStaleData}_${canBeMissing}`;
+    }
+
+    /**
+     * Get cached snapshot result for a key and selector combination
+     */
+    getCachedResult(key: string, selectorKey: string): any {
+        const keyCache = this.snapshotCache.get(key);
+        return keyCache?.get(selectorKey);
+    }
+
+    /**
+     * Set cached snapshot result for a key and selector combination
+     */
+    setCachedResult(key: string, selectorKey: string, result: any): void {
+        if (!this.snapshotCache.has(key)) {
+            this.snapshotCache.set(key, new Map());
+        }
+        this.snapshotCache.get(key)!.set(selectorKey, result);
+    }
+
+    /**
+     * O(1) cache invalidation - just delete the entire cache for this key
+     */
+    invalidateForKey(keyToInvalidate: string): void {
+        this.snapshotCache.delete(keyToInvalidate);
+    }
+
+    /**
+     * Clear all snapshot cache
+     */
+    clear(): void {
+        this.snapshotCache.clear();
+    }
+
+    /**
+     * Clear selector ID mappings (useful for testing)
+     */
+    clearSelectorIds(): void {
+        this.selectorIdMap.clear();
+        this.selectorCounter = 0;
+    }
+}
+
+// Create and export a singleton instance
+const onyxSnapshotCache = new OnyxSnapshotCache();
+
+export default onyxSnapshotCache;
+export {OnyxSnapshotCache};

--- a/lib/OnyxSnapshotCache.ts
+++ b/lib/OnyxSnapshotCache.ts
@@ -17,33 +17,23 @@ class OnyxSnapshotCache {
      */
     private selectorIdMap: Map<UseOnyxSelector<any, any>, string>;
 
+    /**
+     * Counter for generating incremental selector IDs
+     */
+    private selectorIdCounter: number;
+
     constructor() {
         this.snapshotCache = new Map();
         this.selectorIdMap = new Map();
+        this.selectorIdCounter = 0;
     }
 
     /**
-     * Hash string to generate deterministic ID
-     */
-    private hashString(str: string): string {
-        let hash = 0;
-        for (let i = 0; i < str.length; i++) {
-            const char = str.charCodeAt(i);
-            hash = (hash << 5) - hash + char;
-            hash = hash & hash; // Convert to 32-bit integer
-        }
-        return Math.abs(hash).toString(36);
-    }
-
-    /**
-     * Generate unique ID for selector functions
+     * Generate unique ID for selector functions using incrementing numbers
      */
     getSelectorId(selector: UseOnyxSelector<any, any>): string {
         if (!this.selectorIdMap.has(selector)) {
-            const funcStr = selector.toString();
-            const funcName = selector.name || 'anonymous';
-            const hash = this.hashString(funcStr);
-            const id = `${funcName}_${hash}`;
+            const id = `selector_${this.selectorIdCounter++}`;
             this.selectorIdMap.set(selector, id);
         }
         return this.selectorIdMap.get(selector)!;
@@ -110,6 +100,7 @@ class OnyxSnapshotCache {
      */
     clearSelectorIds(): void {
         this.selectorIdMap.clear();
+        this.selectorIdCounter = 0;
     }
 }
 

--- a/lib/OnyxSnapshotCache.ts
+++ b/lib/OnyxSnapshotCache.ts
@@ -90,15 +90,12 @@ class OnyxSnapshotCache {
         // Always invalidate the exact key
         this.snapshotCache.delete(keyToInvalidate);
 
-        // Handle collection-related keys with selective invalidation
-        if (OnyxUtils.isCollectionKey(keyToInvalidate)) {
-            const baseKey = OnyxUtils.getCollectionKey(keyToInvalidate);
-
-            // If this is a collection member key (e.g., "reports_123")
-            // Only invalidate upward to the collection base key
-            if (baseKey !== keyToInvalidate) {
-                this.snapshotCache.delete(baseKey);
-            }
+        try {
+            // Check if the key is a collection member and invalidate the collection base key
+            const collectionBaseKey = OnyxUtils.getCollectionKey(keyToInvalidate);
+            this.snapshotCache.delete(collectionBaseKey);
+        } catch (e) {
+            // do nothing - this just means the key is not a collection member
         }
     }
 

--- a/lib/OnyxSnapshotCache.ts
+++ b/lib/OnyxSnapshotCache.ts
@@ -58,13 +58,13 @@ class OnyxSnapshotCache {
      * or timing behavior of getSnapshot, so they're excluded from the cache key for better cache hit rates.
      */
     generateCacheKey<TKey extends OnyxKey, TReturnValue>(options: Pick<UseOnyxOptions<TKey, TReturnValue>, 'selector' | 'initWithStoredValues' | 'allowStaleData' | 'canBeMissing'>): string {
-        const selectorId = options?.selector ? this.getSelectorID(options.selector) : 'no_selector';
+        const selectorID = options?.selector ? this.getSelectorID(options.selector) : 'no_selector';
 
         // Create options hash without expensive JSON.stringify
         const initWithStoredValues = options?.initWithStoredValues ?? true;
         const allowStaleData = options?.allowStaleData ?? false;
         const canBeMissing = options?.canBeMissing ?? true;
-        return `${selectorId}_${initWithStoredValues}_${allowStaleData}_${canBeMissing}`;
+        return `${selectorID}_${initWithStoredValues}_${allowStaleData}_${canBeMissing}`;
     }
 
     /**

--- a/lib/OnyxSnapshotCache.ts
+++ b/lib/OnyxSnapshotCache.ts
@@ -15,29 +15,29 @@ class OnyxSnapshotCache {
     /**
      * Maps selector functions to unique IDs for cache key generation
      */
-    private selectorIdMap: Map<UseOnyxSelector<OnyxKey, unknown>, number>;
+    private selectorIDMap: Map<UseOnyxSelector<OnyxKey, unknown>, number>;
 
     /**
      * Counter for generating incremental selector IDs
      */
-    private selectorIdCounter: number;
+    private selectorIDCounter: number;
 
     constructor() {
         this.snapshotCache = new Map();
-        this.selectorIdMap = new Map();
-        this.selectorIdCounter = 0;
+        this.selectorIDMap = new Map();
+        this.selectorIDCounter = 0;
     }
 
     /**
      * Generate unique ID for selector functions using incrementing numbers
      */
-    getSelectorId<TKey extends OnyxKey, TReturnValue>(selector: UseOnyxSelector<TKey, TReturnValue>): number {
+    getSelectorID<TKey extends OnyxKey, TReturnValue>(selector: UseOnyxSelector<TKey, TReturnValue>): number {
         const typedSelector = selector as unknown as UseOnyxSelector<OnyxKey, unknown>;
-        if (!this.selectorIdMap.has(typedSelector)) {
-            const id = this.selectorIdCounter++;
-            this.selectorIdMap.set(typedSelector, id);
+        if (!this.selectorIDMap.has(typedSelector)) {
+            const id = this.selectorIDCounter++;
+            this.selectorIDMap.set(typedSelector, id);
         }
-        return this.selectorIdMap.get(typedSelector)!;
+        return this.selectorIDMap.get(typedSelector)!;
     }
 
     /**
@@ -55,7 +55,8 @@ class OnyxSnapshotCache {
      * or timing behavior of getSnapshot, so they're excluded from the cache key for better cache hit rates.
      */
     generateCacheKey<TKey extends OnyxKey, TReturnValue>(options: Pick<UseOnyxOptions<TKey, TReturnValue>, 'selector' | 'initWithStoredValues' | 'allowStaleData' | 'canBeMissing'>): string {
-        const selectorId = options?.selector ? this.getSelectorId(options.selector) : 'no_selector';
+        const selectorId = options?.selector ? this.getSelectorID(options.selector) : 'no_selector';
+
         // Create options hash without expensive JSON.stringify
         const initWithStoredValues = options?.initWithStoredValues ?? true;
         const allowStaleData = options?.allowStaleData ?? false;
@@ -112,8 +113,8 @@ class OnyxSnapshotCache {
      * Clear selector ID mappings (useful for testing)
      */
     clearSelectorIds(): void {
-        this.selectorIdMap.clear();
-        this.selectorIdCounter = 0;
+        this.selectorIDMap.clear();
+        this.selectorIDCounter = 0;
     }
 }
 

--- a/lib/OnyxSnapshotCache.ts
+++ b/lib/OnyxSnapshotCache.ts
@@ -10,12 +10,12 @@ class OnyxSnapshotCache {
     /**
      * Snapshot cache for ultimate performance - separate cache per Onyx key
      */
-    private snapshotCache: Map<string, Map<string, any>>;
+    private snapshotCache: Map<string, Map<string, unknown>>;
 
     /**
      * Maps selector functions to unique IDs for cache key generation
      */
-    private selectorIdMap: Map<UseOnyxSelector<any, any>, string>;
+    private selectorIdMap: Map<UseOnyxSelector<OnyxKey, unknown>, string>;
 
     /**
      * Counter for generating incremental selector IDs
@@ -31,12 +31,13 @@ class OnyxSnapshotCache {
     /**
      * Generate unique ID for selector functions using incrementing numbers
      */
-    getSelectorId(selector: UseOnyxSelector<any, any>): string {
-        if (!this.selectorIdMap.has(selector)) {
+    getSelectorId<TKey extends OnyxKey, TReturnValue>(selector: UseOnyxSelector<TKey, TReturnValue>): string {
+        const typedSelector = selector as unknown as UseOnyxSelector<OnyxKey, unknown>;
+        if (!this.selectorIdMap.has(typedSelector)) {
             const id = `selector_${this.selectorIdCounter++}`;
-            this.selectorIdMap.set(selector, id);
+            this.selectorIdMap.set(typedSelector, id);
         }
-        return this.selectorIdMap.get(selector)!;
+        return this.selectorIdMap.get(typedSelector)!;
     }
 
     /**
@@ -54,15 +55,15 @@ class OnyxSnapshotCache {
     /**
      * Get cached snapshot result for a key and cache key combination
      */
-    getCachedResult(key: string, cacheKey: string): any {
+    getCachedResult<T>(key: string, cacheKey: string): T | undefined {
         const keyCache = this.snapshotCache.get(key);
-        return keyCache?.get(cacheKey);
+        return keyCache?.get(cacheKey) as T | undefined;
     }
 
     /**
      * Set cached snapshot result for a key and cache key combination
      */
-    setCachedResult(key: string, cacheKey: string, result: any): void {
+    setCachedResult<T>(key: string, cacheKey: string, result: T): void {
         if (!this.snapshotCache.has(key)) {
             this.snapshotCache.set(key, new Map());
         }

--- a/lib/OnyxSnapshotCache.ts
+++ b/lib/OnyxSnapshotCache.ts
@@ -15,7 +15,7 @@ class OnyxSnapshotCache {
     /**
      * Maps selector functions to unique IDs for cache key generation
      */
-    private selectorIdMap: Map<UseOnyxSelector<OnyxKey, unknown>, string>;
+    private selectorIdMap: Map<UseOnyxSelector<OnyxKey, unknown>, number>;
 
     /**
      * Counter for generating incremental selector IDs
@@ -31,10 +31,10 @@ class OnyxSnapshotCache {
     /**
      * Generate unique ID for selector functions using incrementing numbers
      */
-    getSelectorId<TKey extends OnyxKey, TReturnValue>(selector: UseOnyxSelector<TKey, TReturnValue>): string {
+    getSelectorId<TKey extends OnyxKey, TReturnValue>(selector: UseOnyxSelector<TKey, TReturnValue>): number {
         const typedSelector = selector as unknown as UseOnyxSelector<OnyxKey, unknown>;
         if (!this.selectorIdMap.has(typedSelector)) {
-            const id = `selector_${this.selectorIdCounter++}`;
+            const id = this.selectorIdCounter++;
             this.selectorIdMap.set(typedSelector, id);
         }
         return this.selectorIdMap.get(typedSelector)!;

--- a/lib/OnyxSnapshotCache.ts
+++ b/lib/OnyxSnapshotCache.ts
@@ -34,7 +34,7 @@ class OnyxSnapshotCache {
     /**
      * Generate unique ID for selector functions using incrementing numbers
      */
-    private getSelectorID<TKey extends OnyxKey, TReturnValue>(selector: UseOnyxSelector<TKey, TReturnValue>): number {
+    getSelectorID<TKey extends OnyxKey, TReturnValue>(selector: UseOnyxSelector<TKey, TReturnValue>): number {
         const typedSelector = selector as unknown as UseOnyxSelector<OnyxKey, unknown>;
         if (!this.selectorIDMap.has(typedSelector)) {
             const id = this.selectorIDCounter++;

--- a/lib/OnyxSnapshotCache.ts
+++ b/lib/OnyxSnapshotCache.ts
@@ -1,6 +1,6 @@
 import OnyxUtils from './OnyxUtils';
-import type {OnyxKey} from './types';
-import type {UseOnyxOptions, UseOnyxSelector} from './useOnyx';
+import type {OnyxKey, OnyxValue} from './types';
+import type {UseOnyxOptions, UseOnyxResult, UseOnyxSelector} from './useOnyx';
 
 /**
  * Manages snapshot caching for useOnyx hook performance optimization.
@@ -10,7 +10,7 @@ class OnyxSnapshotCache {
     /**
      * Snapshot cache for ultimate performance - separate cache per Onyx key
      */
-    private snapshotCache: Map<string, Map<string, unknown>>;
+    private snapshotCache: Map<OnyxKey, Map<string, UseOnyxResult<OnyxValue<OnyxKey>>>>;
 
     /**
      * Maps selector functions to unique IDs for cache key generation
@@ -55,15 +55,15 @@ class OnyxSnapshotCache {
     /**
      * Get cached snapshot result for a key and cache key combination
      */
-    getCachedResult<T>(key: string, cacheKey: string): T | undefined {
+    getCachedResult<TResult extends UseOnyxResult<OnyxValue<OnyxKey>>>(key: OnyxKey, cacheKey: string): TResult | undefined {
         const keyCache = this.snapshotCache.get(key);
-        return keyCache?.get(cacheKey) as T | undefined;
+        return keyCache?.get(cacheKey) as TResult | undefined;
     }
 
     /**
      * Set cached snapshot result for a key and cache key combination
      */
-    setCachedResult<T>(key: string, cacheKey: string, result: T): void {
+    setCachedResult<TResult extends UseOnyxResult<OnyxValue<OnyxKey>>>(key: OnyxKey, cacheKey: string, result: TResult): void {
         if (!this.snapshotCache.has(key)) {
             this.snapshotCache.set(key, new Map());
         }
@@ -74,7 +74,7 @@ class OnyxSnapshotCache {
      * Selective cache invalidation to prevent data unavailability
      * Collection members invalidate upward, collections don't cascade downward
      */
-    invalidateForKey(keyToInvalidate: string): void {
+    invalidateForKey(keyToInvalidate: OnyxKey): void {
         // Always invalidate the exact key
         this.snapshotCache.delete(keyToInvalidate);
 

--- a/lib/OnyxSnapshotCache.ts
+++ b/lib/OnyxSnapshotCache.ts
@@ -1,3 +1,4 @@
+import OnyxUtils from './OnyxUtils';
 import type {OnyxKey} from './types';
 import type {UseOnyxOptions, UseOnyxSelector} from './useOnyx';
 
@@ -73,13 +74,13 @@ class OnyxSnapshotCache {
     invalidateForKey(keyToInvalidate: string): void {
         // Always invalidate the exact key
         this.snapshotCache.delete(keyToInvalidate);
-        
+
         // For collection member keys, also invalidate the parent collection
-        if (keyToInvalidate.includes('_')) {
-            const baseKey = keyToInvalidate.split('_')[0];
+        if (OnyxUtils.isCollectionKey(keyToInvalidate)) {
+            const baseKey = OnyxUtils.getCollectionKey(keyToInvalidate);
             // Invalidate all related collection members
             for (const [cacheKey] of this.snapshotCache) {
-                if (cacheKey.startsWith(baseKey + '_') || cacheKey === baseKey) {
+                if (cacheKey.startsWith(baseKey) || cacheKey === baseKey) {
                     this.snapshotCache.delete(cacheKey);
                 }
             }

--- a/lib/OnyxSnapshotCache.ts
+++ b/lib/OnyxSnapshotCache.ts
@@ -15,7 +15,7 @@ class OnyxSnapshotCache {
     /**
      * Maps selector functions to unique IDs for cache key generation
      */
-    private selectorIDMap: Map<UseOnyxSelector<OnyxKey, unknown>, number>;
+    private selectorIDMap: WeakMap<UseOnyxSelector<OnyxKey, unknown>, number>;
 
     /**
      * Counter for generating incremental selector IDs
@@ -31,7 +31,7 @@ class OnyxSnapshotCache {
     /**
      * Generate unique ID for selector functions using incrementing numbers
      */
-    getSelectorID<TKey extends OnyxKey, TReturnValue>(selector: UseOnyxSelector<TKey, TReturnValue>): number {
+    private getSelectorID<TKey extends OnyxKey, TReturnValue>(selector: UseOnyxSelector<TKey, TReturnValue>): number {
         const typedSelector = selector as unknown as UseOnyxSelector<OnyxKey, unknown>;
         if (!this.selectorIDMap.has(typedSelector)) {
             const id = this.selectorIDCounter++;
@@ -113,7 +113,6 @@ class OnyxSnapshotCache {
      * Clear selector ID mappings (useful for testing)
      */
     clearSelectorIds(): void {
-        this.selectorIDMap.clear();
         this.selectorIDCounter = 0;
     }
 }

--- a/lib/OnyxSnapshotCache.ts
+++ b/lib/OnyxSnapshotCache.ts
@@ -8,7 +8,10 @@ import type {UseOnyxOptions, UseOnyxResult, UseOnyxSelector} from './useOnyx';
  */
 class OnyxSnapshotCache {
     /**
-     * Snapshot cache for ultimate performance - separate cache per Onyx key
+     * Snapshot cache is a two-level map. The top-level keys are Onyx keys. The top-level values maps.
+     * The second-level keys are a custom composite string defined by this.generateCacheKey. These represent a unique useOnyx config, which is not fully represented by the Onyx key alone.
+     * The reason we have two levels is for performance: not to make cache access faster, but to make cache invalidation faster.
+     * We can invalidate the snapshot cache for a given Onyx key with one map.delete operation on the top-level map, rather than having to loop through a large single-level map and delete any matching keys.
      */
     private snapshotCache: Map<OnyxKey, Map<string, UseOnyxResult<OnyxValue<OnyxKey>>>>;
 

--- a/lib/OnyxSnapshotCache.ts
+++ b/lib/OnyxSnapshotCache.ts
@@ -71,20 +71,21 @@ class OnyxSnapshotCache {
     }
 
     /**
-     * O(1) cache invalidation - delete cache for this key and related collection keys
+     * Selective cache invalidation to prevent data unavailability
+     * Collection members invalidate upward, collections don't cascade downward
      */
     invalidateForKey(keyToInvalidate: string): void {
         // Always invalidate the exact key
         this.snapshotCache.delete(keyToInvalidate);
 
-        // For collection member keys, also invalidate the parent collection
+        // Handle collection-related keys with selective invalidation
         if (OnyxUtils.isCollectionKey(keyToInvalidate)) {
             const baseKey = OnyxUtils.getCollectionKey(keyToInvalidate);
-            // Invalidate all related collection members
-            for (const [cacheKey] of this.snapshotCache) {
-                if (cacheKey.startsWith(baseKey) || cacheKey === baseKey) {
-                    this.snapshotCache.delete(cacheKey);
-                }
+
+            // If this is a collection member key (e.g., "reports_123")
+            // Only invalidate upward to the collection base key
+            if (baseKey !== keyToInvalidate) {
+                this.snapshotCache.delete(baseKey);
             }
         }
     }

--- a/lib/OnyxSnapshotCache.ts
+++ b/lib/OnyxSnapshotCache.ts
@@ -41,7 +41,18 @@ class OnyxSnapshotCache {
     }
 
     /**
-     * Fast cache key generation for useOnyx options combination
+     * Fast cache key generation for useOnyx options combination.
+     *
+     * The properties used to generate the cache key are handpicked for performance reasons and
+     * according to their purpose and effect they produce in the useOnyx hook behavior:
+     *
+     * - `selector`: Different selectors produce different results, so each selector needs its own cache entry
+     * - `initWithStoredValues`: This flag changes the initial loading behavior and affects the returned fetch status
+     * - `allowStaleData`: Controls whether stale data can be returned during pending merges, affecting result timing
+     * - `canBeMissing`: Determines logging behavior for missing data, but doesn't affect the actual data returned
+     *
+     * Other options like `canEvict`, `reuseConnection`, and `allowDynamicKey` don't affect the data transformation
+     * or timing behavior of getSnapshot, so they're excluded from the cache key for better cache hit rates.
      */
     generateCacheKey<TKey extends OnyxKey, TReturnValue>(options?: UseOnyxOptions<TKey, TReturnValue>): string {
         const selectorId = options?.selector ? this.getSelectorId(options.selector) : 'no_selector';

--- a/lib/useOnyx.ts
+++ b/lib/useOnyx.ts
@@ -69,7 +69,7 @@ type UseOnyxResult<TValue> = [NonNullable<TValue> | undefined, ResultMetadata<TV
 
 // Global snapshot cache for ultimate performance - separate cache per Onyx key
 const globalSnapshotCache = new Map<string, Map<string, any>>();
-const selectorIdMap = new WeakMap<UseOnyxSelector<any, any>, string>();
+const selectorIdMap = new Map<UseOnyxSelector<any, any>, string>();
 let selectorCounter = 0;
 
 // Generate unique ID for selector functions
@@ -397,5 +397,6 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
 }
 
 export default useOnyx;
+export {globalSnapshotCache, selectorIdMap};
 
 export type {FetchStatus, ResultMetadata, UseOnyxResult, UseOnyxOptions};

--- a/lib/useOnyx.ts
+++ b/lib/useOnyx.ts
@@ -90,7 +90,7 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
                 const newOutput = options.selector!(input);
 
                 // Deep equality mode: only update if output actually changed
-                const areEqual = hasComputed && deepEqual(lastOutput, newOutput);
+                const areEqual = deepEqual(lastOutput, newOutput);
 
                 if (!hasComputed || !areEqual) {
                     lastInput = input;

--- a/lib/useOnyx.ts
+++ b/lib/useOnyx.ts
@@ -245,6 +245,7 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
         // We return the initial result right away during the first connection if `initWithStoredValues` is set to `false`.
         if (isFirstConnectionRef.current && options?.initWithStoredValues === false) {
             const result = resultRef.current;
+
             // Store result in snapshot cache
             onyxSnapshotCache.setCachedResult<UseOnyxResult<TReturnValue>>(key, cacheKey, result);
             return result;

--- a/lib/useOnyx.ts
+++ b/lib/useOnyx.ts
@@ -149,7 +149,16 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
     const sourceValueRef = useRef<NonNullable<TReturnValue> | undefined>(undefined);
 
     // Cache the options key to avoid regenerating it every getSnapshot call
-    const cacheKey = useMemo(() => onyxSnapshotCache.generateCacheKey(options), [options]);
+    const cacheKey = useMemo(
+        () =>
+            onyxSnapshotCache.generateCacheKey({
+                selector: options?.selector,
+                initWithStoredValues: options?.initWithStoredValues,
+                allowStaleData: options?.allowStaleData,
+                canBeMissing: options?.canBeMissing,
+            }),
+        [options?.selector, options?.initWithStoredValues, options?.allowStaleData, options?.canBeMissing],
+    );
 
     useEffect(() => {
         // These conditions will ensure we can only handle dynamic collection member keys from the same collection.

--- a/lib/useOnyx.ts
+++ b/lib/useOnyx.ts
@@ -99,10 +99,9 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
                 // Only proceed if we have a valid selector
                 if (currentSelector) {
                     const newOutput = currentSelector(input);
-                    const areEqual = deepEqual(lastOutput, newOutput);
 
                     // Deep equality mode: only update if output actually changed
-                    if (!hasComputed || !areEqual || dependenciesChanged) {
+                    if (!hasComputed || !deepEqual(lastOutput, newOutput) || dependenciesChanged) {
                         lastInput = input;
                         lastOutput = newOutput;
                         lastDependencies = [...currentDependencies];

--- a/lib/useOnyx.ts
+++ b/lib/useOnyx.ts
@@ -202,7 +202,7 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
         }
 
         // Invalidate cache when dependencies change so selector runs with new closure values
-        onyxSnapshotCache.invalidateForKey(key as string);
+        onyxSnapshotCache.invalidateForKey(key);
         shouldGetCachedValueRef.current = true;
         onStoreChangeFnRef.current();
         // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -227,13 +227,12 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
 
     const getSnapshot = useCallback(() => {
         const cacheKey = cacheKeyRef.current!;
-        const keyStr = key as string;
 
         // Check if we have any cache for this Onyx key
         // Don't use cache for first connection with initWithStoredValues: false
         // Also don't use cache during active data updates (when shouldGetCachedValueRef is true)
         if (!(isFirstConnectionRef.current && options?.initWithStoredValues === false) && !shouldGetCachedValueRef.current) {
-            const cachedResult = onyxSnapshotCache.getCachedResult<UseOnyxResult<TReturnValue>>(keyStr, cacheKey);
+            const cachedResult = onyxSnapshotCache.getCachedResult<UseOnyxResult<TReturnValue>>(key, cacheKey);
             if (cachedResult !== undefined) {
                 resultRef.current = cachedResult;
                 return cachedResult;
@@ -246,7 +245,7 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
         if (isFirstConnectionRef.current && options?.initWithStoredValues === false) {
             const result = resultRef.current;
             // Store result in snapshot cache
-            onyxSnapshotCache.setCachedResult<UseOnyxResult<TReturnValue>>(keyStr, cacheKey, result);
+            onyxSnapshotCache.setCachedResult<UseOnyxResult<TReturnValue>>(key, cacheKey, result);
             return result;
         }
 
@@ -322,7 +321,7 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
             }
         }
 
-        onyxSnapshotCache.setCachedResult<UseOnyxResult<TReturnValue>>(keyStr, cacheKey, resultRef.current);
+        onyxSnapshotCache.setCachedResult<UseOnyxResult<TReturnValue>>(key, cacheKey, resultRef.current);
 
         return resultRef.current;
     }, [options?.initWithStoredValues, options?.allowStaleData, options?.canBeMissing, key, memoizedSelector]);
@@ -349,7 +348,7 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
                     sourceValueRef.current = sourceValue as NonNullable<TReturnValue>;
 
                     // Invalidate snapshot cache for this key when data changes
-                    onyxSnapshotCache.invalidateForKey(key as string);
+                    onyxSnapshotCache.invalidateForKey(key);
 
                     // Finally, we signal that the store changed, making `getSnapshot()` be called again.
                     onStoreChange();

--- a/lib/useOnyx.ts
+++ b/lib/useOnyx.ts
@@ -208,7 +208,7 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
         // Check if we have any cache for this Onyx key
         // Don't use cache for first connection with initWithStoredValues: false
         // Also don't use cache during active data updates (when shouldGetCachedValueRef is true)
-        if (!memoizedSelector && !(isFirstConnectionRef.current && options?.initWithStoredValues === false) && !shouldGetCachedValueRef.current) {
+        if (!(isFirstConnectionRef.current && options?.initWithStoredValues === false) && !shouldGetCachedValueRef.current) {
             const cachedResult = onyxSnapshotCache.getCachedResult(keyStr, cacheKey);
             if (cachedResult !== undefined) {
                 resultRef.current = cachedResult;
@@ -298,10 +298,7 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
             }
         }
 
-        // Cache the result for other useOnyx instances (but not for selectors to avoid staleness)
-        if (!memoizedSelector) {
-            onyxSnapshotCache.setCachedResult(keyStr, cacheKey, resultRef.current);
-        }
+        onyxSnapshotCache.setCachedResult(keyStr, cacheKey, resultRef.current);
 
         return resultRef.current;
     }, [options?.initWithStoredValues, options?.allowStaleData, options?.canBeMissing, key, memoizedSelector]);

--- a/lib/useOnyx.ts
+++ b/lib/useOnyx.ts
@@ -273,14 +273,14 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
         }
 
         // Optimized equality checking:
-        // - For memoized selectors, use deep equality since reference equality is too strict when cache is involved
+        // - Memoized selectors already handle deep equality internally, so we can use fast reference equality
         // - Non-selector cases use shallow equality for object reference checks
         // - Normalize null to undefined to ensure consistent comparison (both represent "no value")
         let areValuesEqual: boolean;
         if (memoizedSelector) {
             const normalizedPrevious = previousValueRef.current ?? undefined;
             const normalizedNew = newValueRef.current ?? undefined;
-            areValuesEqual = deepEqual(normalizedPrevious, normalizedNew);
+            areValuesEqual = normalizedPrevious === normalizedNew;
         } else {
             areValuesEqual = shallowEqual(previousValueRef.current ?? undefined, newValueRef.current);
         }

--- a/lib/useOnyx.ts
+++ b/lib/useOnyx.ts
@@ -209,7 +209,7 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
         // Don't use cache for first connection with initWithStoredValues: false
         // Also don't use cache during active data updates (when shouldGetCachedValueRef is true)
         if (!(isFirstConnectionRef.current && options?.initWithStoredValues === false) && !shouldGetCachedValueRef.current) {
-            const cachedResult = onyxSnapshotCache.getCachedResult(keyStr, cacheKey);
+            const cachedResult = onyxSnapshotCache.getCachedResult<UseOnyxResult<TReturnValue>>(keyStr, cacheKey);
             if (cachedResult !== undefined) {
                 resultRef.current = cachedResult;
                 return cachedResult;
@@ -222,7 +222,7 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
         if (isFirstConnectionRef.current && options?.initWithStoredValues === false) {
             const result = resultRef.current;
             // Store result in snapshot cache
-            onyxSnapshotCache.setCachedResult(keyStr, cacheKey, result);
+            onyxSnapshotCache.setCachedResult<UseOnyxResult<TReturnValue>>(keyStr, cacheKey, result);
             return result;
         }
 
@@ -298,7 +298,7 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
             }
         }
 
-        onyxSnapshotCache.setCachedResult(keyStr, cacheKey, resultRef.current);
+        onyxSnapshotCache.setCachedResult<UseOnyxResult<TReturnValue>>(keyStr, cacheKey, resultRef.current);
 
         return resultRef.current;
     }, [options?.initWithStoredValues, options?.allowStaleData, options?.canBeMissing, key, memoizedSelector]);

--- a/lib/useOnyx.ts
+++ b/lib/useOnyx.ts
@@ -205,7 +205,8 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
 
         // Check if we have any cache for this Onyx key
         // Don't use cache for first connection with initWithStoredValues: false
-        if (!(isFirstConnectionRef.current && options?.initWithStoredValues === false)) {
+        // Also don't use cache during active data updates (when shouldGetCachedValueRef is true)
+        if (!(isFirstConnectionRef.current && options?.initWithStoredValues === false) && !shouldGetCachedValueRef.current) {
             const cachedResult = onyxSnapshotCache.getCachedResult(keyStr, selectorKey);
             if (cachedResult !== undefined) {
                 resultRef.current = cachedResult;

--- a/lib/useOnyx.ts
+++ b/lib/useOnyx.ts
@@ -149,13 +149,7 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
     const sourceValueRef = useRef<NonNullable<TReturnValue> | undefined>(undefined);
 
     // Cache the options key to avoid regenerating it every getSnapshot call
-    const cacheKeyRef = useRef<string | null>(null);
-
-    // Generate cache key and update when options change
-    const currentCacheKey = onyxSnapshotCache.generateCacheKey(options);
-    if (cacheKeyRef.current !== currentCacheKey) {
-        cacheKeyRef.current = currentCacheKey;
-    }
+    const cacheKey = useMemo(() => onyxSnapshotCache.generateCacheKey(options), [options]);
 
     useEffect(() => {
         // These conditions will ensure we can only handle dynamic collection member keys from the same collection.
@@ -226,8 +220,6 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
     }, [key, options?.canEvict]);
 
     const getSnapshot = useCallback(() => {
-        const cacheKey = cacheKeyRef.current!;
-
         // Check if we have any cache for this Onyx key
         // Don't use cache for first connection with initWithStoredValues: false
         // Also don't use cache during active data updates (when shouldGetCachedValueRef is true)
@@ -324,7 +316,7 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
         onyxSnapshotCache.setCachedResult<UseOnyxResult<TReturnValue>>(key, cacheKey, resultRef.current);
 
         return resultRef.current;
-    }, [options?.initWithStoredValues, options?.allowStaleData, options?.canBeMissing, key, memoizedSelector]);
+    }, [options?.initWithStoredValues, options?.allowStaleData, options?.canBeMissing, key, memoizedSelector, cacheKey]);
 
     const subscribe = useCallback(
         (onStoreChange: () => void) => {

--- a/lib/useOnyx.ts
+++ b/lib/useOnyx.ts
@@ -150,7 +150,7 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
     // Cache the options key to avoid regenerating it every getSnapshot call
     const cacheKey = useMemo(
         () =>
-            onyxSnapshotCache.generateCacheKey({
+            onyxSnapshotCache.registerConsumer({
                 selector: options?.selector,
                 initWithStoredValues: options?.initWithStoredValues,
                 allowStaleData: options?.allowStaleData,
@@ -158,6 +158,8 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
             }),
         [options?.selector, options?.initWithStoredValues, options?.allowStaleData, options?.canBeMissing],
     );
+
+    useEffect(() => () => onyxSnapshotCache.deregisterConsumer(key, cacheKey), [key, cacheKey]);
 
     useEffect(() => {
         // These conditions will ensure we can only handle dynamic collection member keys from the same collection.

--- a/lib/useOnyx.ts
+++ b/lib/useOnyx.ts
@@ -134,13 +134,13 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
     // Inside useOnyx.ts, we need to track the sourceValue separately
     const sourceValueRef = useRef<NonNullable<TReturnValue> | undefined>(undefined);
 
-    // Cache the selector key to avoid regenerating it every getSnapshot call
-    const selectorKeyRef = useRef<string | null>(null);
+    // Cache the options key to avoid regenerating it every getSnapshot call
+    const cacheKeyRef = useRef<string | null>(null);
 
-    // Generate selector key and update when selector changes
-    const currentSelectorKey = onyxSnapshotCache.generateSelectorKey(options);
-    if (selectorKeyRef.current !== currentSelectorKey) {
-        selectorKeyRef.current = currentSelectorKey;
+    // Generate cache key and update when options change
+    const currentCacheKey = onyxSnapshotCache.generateCacheKey(options);
+    if (cacheKeyRef.current !== currentCacheKey) {
+        cacheKeyRef.current = currentCacheKey;
     }
 
     useEffect(() => {
@@ -200,14 +200,14 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
     }, [key, options?.canEvict]);
 
     const getSnapshot = useCallback(() => {
-        const selectorKey = selectorKeyRef.current!;
+        const cacheKey = cacheKeyRef.current!;
         const keyStr = key as string;
 
         // Check if we have any cache for this Onyx key
         // Don't use cache for first connection with initWithStoredValues: false
         // Also don't use cache during active data updates (when shouldGetCachedValueRef is true)
         if (!(isFirstConnectionRef.current && options?.initWithStoredValues === false) && !shouldGetCachedValueRef.current) {
-            const cachedResult = onyxSnapshotCache.getCachedResult(keyStr, selectorKey);
+            const cachedResult = onyxSnapshotCache.getCachedResult(keyStr, cacheKey);
             if (cachedResult !== undefined) {
                 resultRef.current = cachedResult;
                 return cachedResult;
@@ -220,7 +220,7 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
         if (isFirstConnectionRef.current && options?.initWithStoredValues === false) {
             const result = resultRef.current;
             // Store result in snapshot cache
-            onyxSnapshotCache.setCachedResult(keyStr, selectorKey, result);
+            onyxSnapshotCache.setCachedResult(keyStr, cacheKey, result);
             return result;
         }
 
@@ -297,7 +297,7 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
         }
 
         // Cache the result for other useOnyx instances
-        onyxSnapshotCache.setCachedResult(keyStr, selectorKey, resultRef.current);
+        onyxSnapshotCache.setCachedResult(keyStr, cacheKey, resultRef.current);
 
         return resultRef.current;
     }, [options?.initWithStoredValues, options?.allowStaleData, options?.canBeMissing, key, memoizedSelector]);

--- a/tests/perf-test/OnyxSnapshotCache.perf-test.ts
+++ b/tests/perf-test/OnyxSnapshotCache.perf-test.ts
@@ -101,11 +101,11 @@ describe('OnyxSnapshotCache', () => {
         });
     });
 
-    describe('generateCacheKey', () => {
+    describe('registerConsumer', () => {
         test('generating key for selector options', async () => {
             await measureFunction(
                 () => {
-                    cache.generateCacheKey(selectorOptions);
+                    cache.registerConsumer(selectorOptions);
                 },
                 {
                     beforeEach: resetCacheBeforeEachMeasure,
@@ -116,7 +116,7 @@ describe('OnyxSnapshotCache', () => {
         test('generating key for complex selector options', async () => {
             await measureFunction(
                 () => {
-                    cache.generateCacheKey(complexSelectorOptions);
+                    cache.registerConsumer(complexSelectorOptions);
                 },
                 {
                     beforeEach: resetCacheBeforeEachMeasure,
@@ -130,7 +130,7 @@ describe('OnyxSnapshotCache', () => {
                     for (let i = 0; i < 1000; i++) {
                         const selector: UseOnyxSelector<OnyxKey, string> = (data) => ((data as MockData | undefined)?.field ?? '') + i;
                         const options: UseOnyxOptions<string, string> = {...selectorOptions, selector};
-                        cache.generateCacheKey(options);
+                        cache.registerConsumer(options);
                     }
                 },
                 {
@@ -142,7 +142,7 @@ describe('OnyxSnapshotCache', () => {
 
     describe('getCachedResult', () => {
         test('getting cached result (cache hit)', async () => {
-            const cacheKey = cache.generateCacheKey(selectorOptions);
+            const cacheKey = cache.registerConsumer(selectorOptions);
             await measureFunction(
                 () => {
                     cache.getCachedResult(ONYXKEYS.TEST_KEY, cacheKey);
@@ -150,7 +150,7 @@ describe('OnyxSnapshotCache', () => {
                 {
                     beforeEach: () => {
                         resetCacheBeforeEachMeasure();
-                        const key = cache.generateCacheKey(selectorOptions);
+                        const key = cache.registerConsumer(selectorOptions);
                         cache.setCachedResult(ONYXKEYS.TEST_KEY, key, mockResult);
                     },
                 },
@@ -158,7 +158,7 @@ describe('OnyxSnapshotCache', () => {
         });
 
         test('getting cached result with complex selector (cache hit)', async () => {
-            const cacheKey = cache.generateCacheKey(complexSelectorOptions);
+            const cacheKey = cache.registerConsumer(complexSelectorOptions);
             const complexResult: UseOnyxResult<ComplexSelectorResult> = [
                 {id: 1, name: 'Test', computed: 84, formatted: 'Test: 42'},
                 {status: 'loaded', sourceValue: {id: 1, name: 'Test', computed: 84, formatted: 'Test: 42'}},
@@ -170,7 +170,7 @@ describe('OnyxSnapshotCache', () => {
                 {
                     beforeEach: () => {
                         resetCacheBeforeEachMeasure();
-                        const key = cache.generateCacheKey(complexSelectorOptions);
+                        const key = cache.registerConsumer(complexSelectorOptions);
                         cache.setCachedResult(ONYXKEYS.TEST_KEY, key, complexResult);
                     },
                 },
@@ -178,7 +178,7 @@ describe('OnyxSnapshotCache', () => {
         });
 
         test('getting cached result with 1000 keys in cache', async () => {
-            const cacheKey = cache.generateCacheKey(selectorOptions);
+            const cacheKey = cache.registerConsumer(selectorOptions);
             await measureFunction(
                 () => {
                     cache.getCachedResult(ONYXKEYS.TEST_KEY, cacheKey);
@@ -202,7 +202,7 @@ describe('OnyxSnapshotCache', () => {
 
     describe('setCachedResult', () => {
         test('setting cached result for new key', async () => {
-            const cacheKey = cache.generateCacheKey(selectorOptions);
+            const cacheKey = cache.registerConsumer(selectorOptions);
             await measureFunction(
                 () => {
                     cache.setCachedResult(ONYXKEYS.TEST_KEY, cacheKey, mockResult);
@@ -214,7 +214,7 @@ describe('OnyxSnapshotCache', () => {
         });
 
         test('setting cached result for existing key', async () => {
-            const cacheKey = cache.generateCacheKey(selectorOptions);
+            const cacheKey = cache.registerConsumer(selectorOptions);
             await measureFunction(
                 () => {
                     cache.setCachedResult(ONYXKEYS.TEST_KEY, cacheKey, mockResult);
@@ -239,7 +239,7 @@ describe('OnyxSnapshotCache', () => {
                 {
                     beforeEach: () => {
                         resetCacheBeforeEachMeasure();
-                        const cacheKey = cache.generateCacheKey(selectorOptions);
+                        const cacheKey = cache.registerConsumer(selectorOptions);
                         cache.setCachedResult(ONYXKEYS.TEST_KEY, cacheKey, mockResult);
                     },
                 },
@@ -255,7 +255,7 @@ describe('OnyxSnapshotCache', () => {
                 {
                     beforeEach: () => {
                         resetCacheBeforeEachMeasure();
-                        const cacheKey = cache.generateCacheKey(selectorOptions);
+                        const cacheKey = cache.registerConsumer(selectorOptions);
                         // Cache both collection and member
                         cache.setCachedResult(ONYXKEYS.COLLECTION.REPORTS, cacheKey, mockResult);
                         cache.setCachedResult(collectionMemberKey, cacheKey, mockResult);

--- a/tests/perf-test/OnyxSnapshotCache.perf-test.ts
+++ b/tests/perf-test/OnyxSnapshotCache.perf-test.ts
@@ -1,0 +1,266 @@
+import {measureFunction} from 'reassure';
+import {OnyxSnapshotCache} from '../../lib/OnyxSnapshotCache';
+import type {UseOnyxOptions, UseOnyxResult} from '../../lib/useOnyx';
+
+// Define types for test data
+type MockData = {
+    id: number;
+    name: string;
+    value: number;
+    field?: string;
+};
+
+const ONYXKEYS = {
+    TEST_KEY: 'test',
+    TEST_KEY_2: 'test2',
+    COLLECTION: {
+        TEST_KEY: 'test_',
+        TEST_KEY_2: 'test2_',
+        REPORTS: 'reports_',
+    },
+};
+
+// Mock selector functions
+const simpleSelector = (data: unknown) => (data as MockData | undefined)?.value;
+
+const complexSelector = (data: unknown) => {
+    const mockData = data as MockData | undefined;
+    return {
+        id: mockData?.id,
+        name: mockData?.name,
+        computed: mockData?.value ? mockData.value * 2 : 0,
+        formatted: `${mockData?.name}: ${mockData?.value}`,
+    };
+};
+
+const selectorOptions: UseOnyxOptions<string, number | undefined> = {
+    selector: simpleSelector,
+    initWithStoredValues: true,
+    allowStaleData: false,
+    canBeMissing: true,
+};
+
+const complexSelectorOptions: UseOnyxOptions<string, {id?: number; name?: string; computed: number; formatted: string}> = {
+    selector: complexSelector,
+    initWithStoredValues: true,
+    allowStaleData: false,
+    canBeMissing: true,
+};
+
+// Mock results
+const mockResult: UseOnyxResult<MockData> = [
+    {id: 1, name: 'Test', value: 42},
+    {status: 'loaded' as const, sourceValue: {id: 1, name: 'Test', value: 42}},
+];
+
+const mockResults = Array.from(
+    {length: 1000},
+    (_, i) =>
+        [
+            {id: i, name: `Test${i}`, value: i * 10},
+            {status: 'loaded' as const, sourceValue: {id: i, name: `Test${i}`, value: i * 10}},
+        ] as UseOnyxResult<MockData>,
+);
+
+describe('OnyxSnapshotCache', () => {
+    let cache: OnyxSnapshotCache;
+
+    const resetCacheBeforeEachMeasure = () => {
+        cache = new OnyxSnapshotCache();
+    };
+
+    describe('getSelectorId', () => {
+        test('getting ID for new selector', async () => {
+            await measureFunction(
+                () => {
+                    cache.getSelectorId(simpleSelector);
+                },
+                {
+                    beforeEach: resetCacheBeforeEachMeasure,
+                },
+            );
+        });
+
+        test('getting ID for cached selector (1000 existing selectors)', async () => {
+            await measureFunction(
+                () => {
+                    cache.getSelectorId(simpleSelector);
+                },
+                {
+                    beforeEach: () => {
+                        resetCacheBeforeEachMeasure();
+                        // Pre-populate with 1000 selectors
+                        for (let i = 0; i < 1000; i++) {
+                            const selector = (data: unknown) => ((data as MockData | undefined)?.field ?? '') + i;
+                            cache.getSelectorId(selector);
+                        }
+                    },
+                },
+            );
+        });
+    });
+
+    describe('generateCacheKey', () => {
+        test('generating key for selector options', async () => {
+            await measureFunction(
+                () => {
+                    cache.generateCacheKey(selectorOptions);
+                },
+                {
+                    beforeEach: resetCacheBeforeEachMeasure,
+                },
+            );
+        });
+
+        test('generating key for complex selector options', async () => {
+            await measureFunction(
+                () => {
+                    cache.generateCacheKey(complexSelectorOptions);
+                },
+                {
+                    beforeEach: resetCacheBeforeEachMeasure,
+                },
+            );
+        });
+
+        test('generating 1000 cache keys with different selectors', async () => {
+            await measureFunction(
+                () => {
+                    for (let i = 0; i < 1000; i++) {
+                        const selector = (data: unknown) => ((data as MockData | undefined)?.field ?? '') + i;
+                        const options: UseOnyxOptions<string, string> = {...selectorOptions, selector};
+                        cache.generateCacheKey(options);
+                    }
+                },
+                {
+                    beforeEach: resetCacheBeforeEachMeasure,
+                },
+            );
+        });
+    });
+
+    describe('getCachedResult', () => {
+        test('getting cached result (cache hit)', async () => {
+            const cacheKey = cache.generateCacheKey(selectorOptions);
+            await measureFunction(
+                () => {
+                    cache.getCachedResult(ONYXKEYS.TEST_KEY, cacheKey);
+                },
+                {
+                    beforeEach: () => {
+                        resetCacheBeforeEachMeasure();
+                        const key = cache.generateCacheKey(selectorOptions);
+                        cache.setCachedResult(ONYXKEYS.TEST_KEY, key, mockResult);
+                    },
+                },
+            );
+        });
+
+        test('getting cached result with complex selector (cache hit)', async () => {
+            const cacheKey = cache.generateCacheKey(complexSelectorOptions);
+            const complexResult: UseOnyxResult<{id?: number; name?: string; computed: number; formatted: string}> = [
+                {id: 1, name: 'Test', computed: 84, formatted: 'Test: 42'},
+                {status: 'loaded' as const, sourceValue: {id: 1, name: 'Test', computed: 84, formatted: 'Test: 42'}},
+            ];
+            await measureFunction(
+                () => {
+                    cache.getCachedResult(ONYXKEYS.TEST_KEY, cacheKey);
+                },
+                {
+                    beforeEach: () => {
+                        resetCacheBeforeEachMeasure();
+                        const key = cache.generateCacheKey(complexSelectorOptions);
+                        cache.setCachedResult(ONYXKEYS.TEST_KEY, key, complexResult);
+                    },
+                },
+            );
+        });
+
+        test('getting cached result with 1000 keys in cache', async () => {
+            const cacheKey = cache.generateCacheKey(selectorOptions);
+            await measureFunction(
+                () => {
+                    cache.getCachedResult(ONYXKEYS.TEST_KEY, cacheKey);
+                },
+                {
+                    beforeEach: () => {
+                        resetCacheBeforeEachMeasure();
+                        // Pre-populate cache with 1000 entries
+                        for (let i = 0; i < 1000; i++) {
+                            const key = `test_key_${i}`;
+                            const result = mockResults[i];
+                            cache.setCachedResult(key, `cache_key_${i}`, result);
+                        }
+                        // Set our target entry
+                        cache.setCachedResult(ONYXKEYS.TEST_KEY, cacheKey, mockResult);
+                    },
+                },
+            );
+        });
+    });
+
+    describe('setCachedResult', () => {
+        test('setting cached result for new key', async () => {
+            const cacheKey = cache.generateCacheKey(selectorOptions);
+            await measureFunction(
+                () => {
+                    cache.setCachedResult(ONYXKEYS.TEST_KEY, cacheKey, mockResult);
+                },
+                {
+                    beforeEach: resetCacheBeforeEachMeasure,
+                },
+            );
+        });
+
+        test('setting cached result for existing key', async () => {
+            const cacheKey = cache.generateCacheKey(selectorOptions);
+            await measureFunction(
+                () => {
+                    cache.setCachedResult(ONYXKEYS.TEST_KEY, cacheKey, mockResult);
+                },
+                {
+                    beforeEach: () => {
+                        resetCacheBeforeEachMeasure();
+                        // Pre-create the key cache
+                        cache.setCachedResult(ONYXKEYS.TEST_KEY, 'other_cache_key', mockResult);
+                    },
+                },
+            );
+        });
+    });
+
+    describe('invalidateForKey', () => {
+        test('invalidating single key (cache hit)', async () => {
+            await measureFunction(
+                () => {
+                    cache.invalidateForKey(ONYXKEYS.TEST_KEY);
+                },
+                {
+                    beforeEach: () => {
+                        resetCacheBeforeEachMeasure();
+                        const cacheKey = cache.generateCacheKey(selectorOptions);
+                        cache.setCachedResult(ONYXKEYS.TEST_KEY, cacheKey, mockResult);
+                    },
+                },
+            );
+        });
+
+        test('invalidating collection member key', async () => {
+            const collectionMemberKey = `${ONYXKEYS.COLLECTION.REPORTS}123`;
+            await measureFunction(
+                () => {
+                    cache.invalidateForKey(collectionMemberKey);
+                },
+                {
+                    beforeEach: () => {
+                        resetCacheBeforeEachMeasure();
+                        const cacheKey = cache.generateCacheKey(selectorOptions);
+                        // Cache both collection and member
+                        cache.setCachedResult(ONYXKEYS.COLLECTION.REPORTS, cacheKey, mockResult);
+                        cache.setCachedResult(collectionMemberKey, cacheKey, mockResult);
+                    },
+                },
+            );
+        });
+    });
+});

--- a/tests/perf-test/OnyxSnapshotCache.perf-test.ts
+++ b/tests/perf-test/OnyxSnapshotCache.perf-test.ts
@@ -74,7 +74,7 @@ describe('OnyxSnapshotCache', () => {
         test('getting ID for new selector', async () => {
             await measureFunction(
                 () => {
-                    cache.getSelectorId(simpleSelector);
+                    cache.getSelectorID(simpleSelector);
                 },
                 {
                     beforeEach: resetCacheBeforeEachMeasure,
@@ -85,7 +85,7 @@ describe('OnyxSnapshotCache', () => {
         test('getting ID for cached selector (1000 existing selectors)', async () => {
             await measureFunction(
                 () => {
-                    cache.getSelectorId(simpleSelector);
+                    cache.getSelectorID(simpleSelector);
                 },
                 {
                     beforeEach: () => {
@@ -93,7 +93,7 @@ describe('OnyxSnapshotCache', () => {
                         // Pre-populate with 1000 selectors
                         for (let i = 0; i < 1000; i++) {
                             const selector: UseOnyxSelector<OnyxKey, string> = (data) => ((data as MockData | undefined)?.field ?? '') + i;
-                            cache.getSelectorId(selector);
+                            cache.getSelectorID(selector);
                         }
                     },
                 },

--- a/tests/unit/OnyxSnapshotCacheTest.ts
+++ b/tests/unit/OnyxSnapshotCacheTest.ts
@@ -1,6 +1,7 @@
+import type {OnyxKey} from '../../lib';
 import {OnyxSnapshotCache} from '../../lib/OnyxSnapshotCache';
 import OnyxUtils from '../../lib/OnyxUtils';
-import type {UseOnyxOptions, UseOnyxResult} from '../../lib/useOnyx';
+import type {UseOnyxOptions, UseOnyxResult, UseOnyxSelector} from '../../lib/useOnyx';
 
 // Mock OnyxUtils for testing
 jest.mock('../../lib/OnyxUtils', () => ({
@@ -19,7 +20,7 @@ type TestData = {
 
 type TestResult = UseOnyxResult<{data: string}>;
 
-type TestSelector = (data: unknown) => string;
+type TestSelector = UseOnyxSelector<OnyxKey, string>;
 
 describe('OnyxSnapshotCache', () => {
     let cache: OnyxSnapshotCache;
@@ -31,26 +32,24 @@ describe('OnyxSnapshotCache', () => {
 
     describe('basic cache operations', () => {
         it('should generate unique cache keys for different options', () => {
-            const selector: TestSelector = (data: unknown) => {
+            const selector: TestSelector = (data) => {
                 const testData = data as TestData | undefined;
                 return testData?.name ?? '';
             };
-            const optionsWithSelector: UseOnyxOptions<string, string> = {
+            const optionsWithSelector: UseOnyxOptions<OnyxKey, string> = {
                 selector,
                 initWithStoredValues: true,
                 allowStaleData: false,
                 canBeMissing: true,
             };
-            const optionsWithoutSelector: UseOnyxOptions<string, string> = {
+            const optionsWithoutSelector: UseOnyxOptions<OnyxKey, string> = {
                 initWithStoredValues: false,
                 allowStaleData: true,
                 canBeMissing: false,
             };
-            const undefinedOptions: UseOnyxOptions<string, string> | undefined = undefined;
-
             const keyWithSelector = cache.generateCacheKey(optionsWithSelector);
             const keyWithoutSelector = cache.generateCacheKey(optionsWithoutSelector);
-            const keyWithUndefined = cache.generateCacheKey(undefinedOptions);
+            const keyWithUndefined = cache.generateCacheKey({});
 
             // Different option combinations should produce different cache keys
             expect(keyWithSelector).toContain('0_'); // Should contain selector ID
@@ -93,11 +92,11 @@ describe('OnyxSnapshotCache', () => {
 
     describe('selector ID management', () => {
         it('should generate unique IDs for different selectors', () => {
-            const nameSelector: TestSelector = (data: unknown) => {
+            const nameSelector: TestSelector = (data) => {
                 const testData = data as TestData | undefined;
                 return testData?.name ?? '';
             };
-            const idSelector: TestSelector = (data: unknown) => {
+            const idSelector: TestSelector = (data) => {
                 const testData = data as TestData | undefined;
                 return testData?.id ?? '';
             };
@@ -110,7 +109,7 @@ describe('OnyxSnapshotCache', () => {
         });
 
         it('should return the same ID for the same selector function', () => {
-            const selector: TestSelector = (data: unknown) => {
+            const selector: TestSelector = (data) => {
                 const testData = data as TestData | undefined;
                 return testData?.name ?? '';
             };
@@ -125,11 +124,11 @@ describe('OnyxSnapshotCache', () => {
         });
 
         it('should clear selector IDs and reset counter', () => {
-            const selector1: TestSelector = (data: unknown) => {
+            const selector1: TestSelector = (data) => {
                 const testData = data as TestData | undefined;
                 return testData?.name ?? '';
             };
-            const selector2: TestSelector = (data: unknown) => {
+            const selector2: TestSelector = (data) => {
                 const testData = data as TestData | undefined;
                 return testData?.id ?? '';
             };

--- a/tests/unit/OnyxSnapshotCacheTest.ts
+++ b/tests/unit/OnyxSnapshotCacheTest.ts
@@ -47,9 +47,9 @@ describe('OnyxSnapshotCache', () => {
                 allowStaleData: true,
                 canBeMissing: false,
             };
-            const keyWithSelector = cache.generateCacheKey(optionsWithSelector);
-            const keyWithoutSelector = cache.generateCacheKey(optionsWithoutSelector);
-            const keyWithUndefined = cache.generateCacheKey({});
+            const keyWithSelector = cache.registerConsumer(optionsWithSelector);
+            const keyWithoutSelector = cache.registerConsumer(optionsWithoutSelector);
+            const keyWithUndefined = cache.registerConsumer({});
 
             // Different option combinations should produce different cache keys
             expect(keyWithSelector).toContain('0_'); // Should contain selector ID

--- a/tests/unit/OnyxSnapshotCacheTest.ts
+++ b/tests/unit/OnyxSnapshotCacheTest.ts
@@ -101,8 +101,8 @@ describe('OnyxSnapshotCache', () => {
                 return testData?.id ?? '';
             };
 
-            const nameId = cache.getSelectorId(nameSelector);
-            const idSelectorId = cache.getSelectorId(idSelector);
+            const nameId = cache.getSelectorID(nameSelector);
+            const idSelectorId = cache.getSelectorID(idSelector);
 
             // Different selectors should get different IDs
             expect(nameId).not.toBe(idSelectorId);
@@ -114,9 +114,9 @@ describe('OnyxSnapshotCache', () => {
                 return testData?.name ?? '';
             };
 
-            const firstCall = cache.getSelectorId(selector);
-            const secondCall = cache.getSelectorId(selector);
-            const thirdCall = cache.getSelectorId(selector);
+            const firstCall = cache.getSelectorID(selector);
+            const secondCall = cache.getSelectorID(selector);
+            const thirdCall = cache.getSelectorID(selector);
 
             // Multiple calls with same selector should return identical ID
             expect(firstCall).toBe(secondCall);
@@ -137,8 +137,8 @@ describe('OnyxSnapshotCache', () => {
             cache.clearSelectorIds();
 
             // After clearing, selectors should get new IDs starting from 0
-            const id1After = cache.getSelectorId(selector1);
-            const id2After = cache.getSelectorId(selector2);
+            const id1After = cache.getSelectorID(selector1);
+            const id2After = cache.getSelectorID(selector2);
 
             expect(id1After).toBe(0); // First selector after clear should get ID 0
             expect(id2After).toBe(1); // Second selector should get ID 1

--- a/tests/unit/OnyxSnapshotCacheTest.ts
+++ b/tests/unit/OnyxSnapshotCacheTest.ts
@@ -1,0 +1,244 @@
+import {OnyxSnapshotCache} from '../../lib/OnyxSnapshotCache';
+import OnyxUtils from '../../lib/OnyxUtils';
+import type {UseOnyxOptions} from '../../lib/useOnyx';
+
+// Mock OnyxUtils for testing
+jest.mock('../../lib/OnyxUtils', () => ({
+    isCollectionKey: jest.fn(),
+    getCollectionKey: jest.fn(),
+}));
+
+const mockedOnyxUtils = OnyxUtils as jest.Mocked<typeof OnyxUtils>;
+
+// Test types
+type TestData = {
+    data: string;
+    id?: string;
+    name?: string;
+};
+
+type TestResult = {
+    data: string;
+    status?: string;
+};
+
+type TestSelector = (data: unknown) => string;
+
+describe('OnyxSnapshotCache', () => {
+    let cache: OnyxSnapshotCache;
+
+    beforeEach(() => {
+        cache = new OnyxSnapshotCache();
+        jest.clearAllMocks();
+    });
+
+    describe('basic cache operations', () => {
+        it('should generate unique cache keys for different options', () => {
+            const selector: TestSelector = (data: unknown) => {
+                const testData = data as TestData | undefined;
+                return testData?.name ?? '';
+            };
+            const optionsWithSelector: UseOnyxOptions<string, string> = {
+                selector,
+                initWithStoredValues: true,
+                allowStaleData: false,
+                canBeMissing: true,
+            };
+            const optionsWithoutSelector: UseOnyxOptions<string, string> = {
+                initWithStoredValues: false,
+                allowStaleData: true,
+                canBeMissing: false,
+            };
+            const undefinedOptions: UseOnyxOptions<string, string> | undefined = undefined;
+
+            const keyWithSelector = cache.generateCacheKey(optionsWithSelector);
+            const keyWithoutSelector = cache.generateCacheKey(optionsWithoutSelector);
+            const keyWithUndefined = cache.generateCacheKey(undefinedOptions);
+
+            // Different option combinations should produce different cache keys
+            expect(keyWithSelector).toContain('0_'); // Should contain selector ID
+            expect(keyWithoutSelector).toContain('no_selector'); // Should indicate no selector
+            expect(keyWithUndefined).toContain('no_selector'); // Should indicate no selector
+
+            // All keys should be unique
+            expect(new Set([keyWithSelector, keyWithoutSelector, keyWithUndefined]).size).toBe(3);
+        });
+
+        it('should store and retrieve cached results', () => {
+            const key = 'testKey';
+            const cacheKey = 'testCacheKey';
+            const result: TestResult = {data: 'test', status: 'loaded'};
+
+            cache.setCachedResult<TestResult>(key, cacheKey, result);
+            const retrieved = cache.getCachedResult<TestResult>(key, cacheKey);
+
+            expect(retrieved).toEqual(result);
+        });
+
+        it('should return undefined for non-existent cache entries', () => {
+            const result = cache.getCachedResult<TestResult>('nonExistentKey', 'nonExistentCacheKey');
+            expect(result).toBeUndefined();
+        });
+
+        it('should clear all caches', () => {
+            const result1: TestResult = {data: 'test1'};
+            const result2: TestResult = {data: 'test2'};
+
+            cache.setCachedResult<TestResult>('key1', 'cacheKey1', result1);
+            cache.setCachedResult<TestResult>('key2', 'cacheKey2', result2);
+
+            cache.clear();
+
+            expect(cache.getCachedResult<TestResult>('key1', 'cacheKey1')).toBeUndefined();
+            expect(cache.getCachedResult<TestResult>('key2', 'cacheKey2')).toBeUndefined();
+        });
+    });
+
+    describe('selector ID management', () => {
+        it('should generate unique IDs for different selectors', () => {
+            const nameSelector: TestSelector = (data: unknown) => {
+                const testData = data as TestData | undefined;
+                return testData?.name ?? '';
+            };
+            const idSelector: TestSelector = (data: unknown) => {
+                const testData = data as TestData | undefined;
+                return testData?.id ?? '';
+            };
+
+            const nameId = cache.getSelectorId(nameSelector);
+            const idSelectorId = cache.getSelectorId(idSelector);
+
+            // Different selectors should get different IDs
+            expect(nameId).not.toBe(idSelectorId);
+        });
+
+        it('should return the same ID for the same selector function', () => {
+            const selector: TestSelector = (data: unknown) => {
+                const testData = data as TestData | undefined;
+                return testData?.name ?? '';
+            };
+
+            const firstCall = cache.getSelectorId(selector);
+            const secondCall = cache.getSelectorId(selector);
+            const thirdCall = cache.getSelectorId(selector);
+
+            // Multiple calls with same selector should return identical ID
+            expect(firstCall).toBe(secondCall);
+            expect(secondCall).toBe(thirdCall);
+        });
+
+        it('should clear selector IDs and reset counter', () => {
+            const selector1: TestSelector = (data: unknown) => {
+                const testData = data as TestData | undefined;
+                return testData?.name ?? '';
+            };
+            const selector2: TestSelector = (data: unknown) => {
+                const testData = data as TestData | undefined;
+                return testData?.id ?? '';
+            };
+
+            // Clear the selector IDs
+            cache.clearSelectorIds();
+
+            // After clearing, selectors should get new IDs starting from 0
+            const id1After = cache.getSelectorId(selector1);
+            const id2After = cache.getSelectorId(selector2);
+
+            expect(id1After).toBe(0); // First selector after clear should get ID 0
+            expect(id2After).toBe(1); // Second selector should get ID 1
+        });
+    });
+
+    describe('cache invalidation', () => {
+        beforeEach(() => {
+            // Set up cache with multiple entries
+            cache.setCachedResult<TestResult>('reports_', 'cache1', {data: 'collection'});
+            cache.setCachedResult<TestResult>('reports_123', 'cache2', {data: 'member1'});
+            cache.setCachedResult<TestResult>('reports_456', 'cache3', {data: 'member2'});
+            cache.setCachedResult<TestResult>('users_', 'cache4', {data: 'users collection'});
+            cache.setCachedResult<TestResult>('users_789', 'cache5', {data: 'user member'});
+            cache.setCachedResult<TestResult>('nonCollectionKey', 'cache6', {data: 'regular key'});
+        });
+
+        it('should invalidate non-collection keys without affecting others', () => {
+            mockedOnyxUtils.isCollectionKey.mockReturnValue(false);
+
+            cache.invalidateForKey('nonCollectionKey');
+
+            // Non-collection key should be invalidated
+            expect(cache.getCachedResult<TestResult>('nonCollectionKey', 'cache6')).toBeUndefined();
+
+            // All other keys should remain
+            expect(cache.getCachedResult<TestResult>('reports_', 'cache1')).toBeDefined();
+            expect(cache.getCachedResult<TestResult>('reports_123', 'cache2')).toBeDefined();
+            expect(cache.getCachedResult<TestResult>('reports_456', 'cache3')).toBeDefined();
+            expect(cache.getCachedResult<TestResult>('users_', 'cache4')).toBeDefined();
+            expect(cache.getCachedResult<TestResult>('users_789', 'cache5')).toBeDefined();
+        });
+
+        it('should invalidate collection member key and its base collection only', () => {
+            mockedOnyxUtils.isCollectionKey.mockReturnValue(true);
+            mockedOnyxUtils.getCollectionKey.mockReturnValue('reports_');
+
+            cache.invalidateForKey('reports_123');
+
+            // Collection member and base should be invalidated
+            expect(cache.getCachedResult<TestResult>('reports_123', 'cache2')).toBeUndefined();
+            expect(cache.getCachedResult<TestResult>('reports_', 'cache1')).toBeUndefined();
+
+            // Other collection members should remain (selective invalidation)
+            expect(cache.getCachedResult<TestResult>('reports_456', 'cache3')).toBeDefined();
+
+            // Unrelated keys should remain
+            expect(cache.getCachedResult<TestResult>('users_', 'cache4')).toBeDefined();
+            expect(cache.getCachedResult<TestResult>('users_789', 'cache5')).toBeDefined();
+            expect(cache.getCachedResult<TestResult>('nonCollectionKey', 'cache6')).toBeDefined();
+        });
+
+        it('should invalidate collection base key without cascading to members', () => {
+            mockedOnyxUtils.isCollectionKey.mockReturnValue(true);
+            mockedOnyxUtils.getCollectionKey.mockReturnValue('reports_');
+
+            // When base key equals the key to invalidate, it's a collection base key
+            cache.invalidateForKey('reports_');
+
+            // Only the base collection should be invalidated
+            expect(cache.getCachedResult<TestResult>('reports_', 'cache1')).toBeUndefined();
+
+            // Collection members should remain (no cascade deletion)
+            expect(cache.getCachedResult<TestResult>('reports_123', 'cache2')).toBeDefined();
+            expect(cache.getCachedResult<TestResult>('reports_456', 'cache3')).toBeDefined();
+
+            // Unrelated keys should remain
+            expect(cache.getCachedResult<TestResult>('users_', 'cache4')).toBeDefined();
+            expect(cache.getCachedResult<TestResult>('users_789', 'cache5')).toBeDefined();
+            expect(cache.getCachedResult<TestResult>('nonCollectionKey', 'cache6')).toBeDefined();
+        });
+
+        it('should handle multiple different collection keys independently', () => {
+            // Invalidate reports collection member
+            mockedOnyxUtils.isCollectionKey.mockReturnValueOnce(true);
+            mockedOnyxUtils.getCollectionKey.mockReturnValueOnce('reports_');
+            cache.invalidateForKey('reports_123');
+
+            // Invalidate users collection member
+            mockedOnyxUtils.isCollectionKey.mockReturnValueOnce(true);
+            mockedOnyxUtils.getCollectionKey.mockReturnValueOnce('users_');
+            cache.invalidateForKey('users_789');
+
+            // Reports: member and base should be invalidated
+            expect(cache.getCachedResult<TestResult>('reports_123', 'cache2')).toBeUndefined();
+            expect(cache.getCachedResult<TestResult>('reports_', 'cache1')).toBeUndefined();
+
+            // Users: member and base should be invalidated
+            expect(cache.getCachedResult<TestResult>('users_789', 'cache5')).toBeUndefined();
+            expect(cache.getCachedResult<TestResult>('users_', 'cache4')).toBeUndefined();
+
+            // Other collection members should remain
+            expect(cache.getCachedResult<TestResult>('reports_456', 'cache3')).toBeDefined();
+
+            // Non-collection keys should remain
+            expect(cache.getCachedResult<TestResult>('nonCollectionKey', 'cache6')).toBeDefined();
+        });
+    });
+});

--- a/tests/unit/OnyxSnapshotCacheTest.ts
+++ b/tests/unit/OnyxSnapshotCacheTest.ts
@@ -1,6 +1,6 @@
 import {OnyxSnapshotCache} from '../../lib/OnyxSnapshotCache';
 import OnyxUtils from '../../lib/OnyxUtils';
-import type {UseOnyxOptions} from '../../lib/useOnyx';
+import type {UseOnyxOptions, UseOnyxResult} from '../../lib/useOnyx';
 
 // Mock OnyxUtils for testing
 jest.mock('../../lib/OnyxUtils', () => ({
@@ -17,10 +17,7 @@ type TestData = {
     name?: string;
 };
 
-type TestResult = {
-    data: string;
-    status?: string;
-};
+type TestResult = UseOnyxResult<{data: string}>;
 
 type TestSelector = (data: unknown) => string;
 
@@ -67,7 +64,7 @@ describe('OnyxSnapshotCache', () => {
         it('should store and retrieve cached results', () => {
             const key = 'testKey';
             const cacheKey = 'testCacheKey';
-            const result: TestResult = {data: 'test', status: 'loaded'};
+            const result: TestResult = [{data: 'test'}, {status: 'loaded'}];
 
             cache.setCachedResult<TestResult>(key, cacheKey, result);
             const retrieved = cache.getCachedResult<TestResult>(key, cacheKey);
@@ -81,8 +78,8 @@ describe('OnyxSnapshotCache', () => {
         });
 
         it('should clear all caches', () => {
-            const result1: TestResult = {data: 'test1'};
-            const result2: TestResult = {data: 'test2'};
+            const result1: TestResult = [{data: 'test1'}, {status: 'loaded'}];
+            const result2: TestResult = [{data: 'test2'}, {status: 'loaded'}];
 
             cache.setCachedResult<TestResult>('key1', 'cacheKey1', result1);
             cache.setCachedResult<TestResult>('key2', 'cacheKey2', result2);
@@ -152,12 +149,12 @@ describe('OnyxSnapshotCache', () => {
     describe('cache invalidation', () => {
         beforeEach(() => {
             // Set up cache with multiple entries
-            cache.setCachedResult<TestResult>('reports_', 'cache1', {data: 'collection'});
-            cache.setCachedResult<TestResult>('reports_123', 'cache2', {data: 'member1'});
-            cache.setCachedResult<TestResult>('reports_456', 'cache3', {data: 'member2'});
-            cache.setCachedResult<TestResult>('users_', 'cache4', {data: 'users collection'});
-            cache.setCachedResult<TestResult>('users_789', 'cache5', {data: 'user member'});
-            cache.setCachedResult<TestResult>('nonCollectionKey', 'cache6', {data: 'regular key'});
+            cache.setCachedResult<TestResult>('reports_', 'cache1', [{data: 'collection'}, {status: 'loaded'}]);
+            cache.setCachedResult<TestResult>('reports_123', 'cache2', [{data: 'member1'}, {status: 'loaded'}]);
+            cache.setCachedResult<TestResult>('reports_456', 'cache3', [{data: 'member2'}, {status: 'loaded'}]);
+            cache.setCachedResult<TestResult>('users_', 'cache4', [{data: 'users collection'}, {status: 'loaded'}]);
+            cache.setCachedResult<TestResult>('users_789', 'cache5', [{data: 'user member'}, {status: 'loaded'}]);
+            cache.setCachedResult<TestResult>('nonCollectionKey', 'cache6', [{data: 'regular key'}, {status: 'loaded'}]);
         });
 
         it('should invalidate non-collection keys without affecting others', () => {

--- a/tests/unit/useOnyxTest.ts
+++ b/tests/unit/useOnyxTest.ts
@@ -6,7 +6,7 @@ import StorageMock from '../../lib/storage';
 import type GenericCollection from '../utils/GenericCollection';
 import waitForPromisesToResolve from '../utils/waitForPromisesToResolve';
 import * as Logger from '../../lib/Logger';
-import {globalSnapshotCache, selectorIdMap} from '../../lib/useOnyx';
+import onyxSnapshotCache from '../../lib/OnyxSnapshotCache';
 
 const ONYXKEYS = {
     TEST_KEY: 'test',
@@ -26,8 +26,8 @@ Onyx.init({
 
 beforeEach(async () => {
     await Onyx.clear();
-    globalSnapshotCache.clear();
-    selectorIdMap.clear();
+    onyxSnapshotCache.clear();
+    onyxSnapshotCache.clearSelectorIds();
 });
 
 describe('useOnyx', () => {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
$ https://github.com/Expensify/App/issues/68014

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
Added corresponding tests to `useOnyxTest.ts` file and created tests for snapshot cache. All tests in the E/App codebase are passing as well.
### Manual Tests
<!---
Each set of changes should be tested against the Expensify/App repo on all platforms to verify it does not break our staging App.
--->
1. Create fresh account
2. Create new workspace
3. Verify the workspace was created
4. Create two expenses in a workspace with the same amount, merchant and category
5. Verify the RBR is displayed in LHN
6. Enter the expense chat
7. Resolve duplicates
9. Send message
10. Go back to LHN
11. Verify the RBR is not displayed in the LHN 
12. Long press on the Concierge chat
13. Pin the chat
14. Verify the chat was pinned
### Author Checklist

- [x] I linked the correct issue in the `### Related Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/2c307b2f-7441-4db2-9362-d20d67e35865


<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/81f6a25c-2704-449a-a746-0282830285f4


<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/user-attachments/assets/473a59b2-de8f-4dab-b7c5-ed05b3c3cae2


<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/ed446cec-ab28-4734-a7ca-ab7cad84efe3


<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

https://github.com/user-attachments/assets/53b652d5-18fe-4f91-92b9-0a6d629d295d


<!-- add screenshots or videos here -->

</details>
