### PR TITLE
Revert "Merge pull request #669 from callstack-internal/VickyStash/refactor/batch-all-subscribers-updates"

### DIFF
--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -622,7 +622,6 @@ function keysChanged<TKey extends CollectionKeyBase>(
     partialPreviousCollection: OnyxCollection<KeyValueMapping[TKey]> | undefined,
     notifyConnectSubscribers = true,
     notifyWithOnyxSubscribers = true,
-    notifyUseOnyxHookSubscribers = true,
 ): void {
     // We prepare the "cached collection" which is the entire collection + the new partial data that
     // was merged in via mergeCollection().
@@ -658,8 +657,7 @@ function keysChanged<TKey extends CollectionKeyBase>(
 
         // Regular Onyx.connect() subscriber found.
         if (typeof subscriber.callback === 'function') {
-            // Check if it's a useOnyx or a regular Onyx.connect() subscriber
-            if ((subscriber.isUseOnyxSubscriber && !notifyUseOnyxHookSubscribers) || (!subscriber.isUseOnyxSubscriber && !notifyConnectSubscribers)) {
+            if (!notifyConnectSubscribers) {
                 continue;
             }
 
@@ -818,7 +816,6 @@ function keyChanged<TKey extends OnyxKey>(
     canUpdateSubscriber: (subscriber?: Mapping<OnyxKey>) => boolean = () => true,
     notifyConnectSubscribers = true,
     notifyWithOnyxSubscribers = true,
-    notifyUseOnyxHookSubscribers = true,
 ): void {
     // Add or remove this key from the recentlyAccessedKeys lists
     if (value !== null) {
@@ -860,8 +857,7 @@ function keyChanged<TKey extends OnyxKey>(
 
         // Subscriber is a regular call to connect() and provided a callback
         if (typeof subscriber.callback === 'function') {
-            // Check if it's a useOnyx or a regular Onyx.connect() subscriber
-            if ((subscriber.isUseOnyxSubscriber && !notifyUseOnyxHookSubscribers) || (!subscriber.isUseOnyxSubscriber && !notifyConnectSubscribers)) {
+            if (!notifyConnectSubscribers) {
                 continue;
             }
             if (lastConnectionCallbackData.has(subscriber.subscriptionID) && lastConnectionCallbackData.get(subscriber.subscriptionID) === value) {
@@ -1082,8 +1078,8 @@ function scheduleSubscriberUpdate<TKey extends OnyxKey>(
     previousValue: OnyxValue<TKey>,
     canUpdateSubscriber: (subscriber?: Mapping<OnyxKey>) => boolean = () => true,
 ): Promise<void> {
-    const promise = Promise.resolve().then(() => keyChanged(key, value, previousValue, canUpdateSubscriber, true, false, false));
-    batchUpdates(() => keyChanged(key, value, previousValue, canUpdateSubscriber, false, true, true));
+    const promise = Promise.resolve().then(() => keyChanged(key, value, previousValue, canUpdateSubscriber, true, false));
+    batchUpdates(() => keyChanged(key, value, previousValue, canUpdateSubscriber, false, true));
     return Promise.all([maybeFlushBatchUpdates(), promise]).then(() => undefined);
 }
 
@@ -1097,8 +1093,8 @@ function scheduleNotifyCollectionSubscribers<TKey extends OnyxKey>(
     value: OnyxCollection<KeyValueMapping[TKey]>,
     previousValue?: OnyxCollection<KeyValueMapping[TKey]>,
 ): Promise<void> {
-    const promise = Promise.resolve().then(() => keysChanged(key, value, previousValue, true, false, false));
-    batchUpdates(() => keysChanged(key, value, previousValue, false, true, true));
+    const promise = Promise.resolve().then(() => keysChanged(key, value, previousValue, true, false));
+    batchUpdates(() => keysChanged(key, value, previousValue, false, true));
     return Promise.all([maybeFlushBatchUpdates(), promise]).then(() => undefined);
 }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -273,9 +273,6 @@ type BaseConnectOptions = {
      * with the same connect configurations.
      */
     reuseConnection?: boolean;
-
-    /** Indicates whether this subscriber is created from the useOnyx hook. */
-    isUseOnyxSubscriber?: boolean;
 };
 
 /** Represents the callback function used in `Onyx.connect()` method with a regular key. */

--- a/lib/useOnyx.ts
+++ b/lib/useOnyx.ts
@@ -359,7 +359,6 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
                 initWithStoredValues: options?.initWithStoredValues,
                 waitForCollectionCallback: OnyxUtils.isCollectionKey(key) as true,
                 reuseConnection: options?.reuseConnection,
-                isUseOnyxSubscriber: true,
             });
 
             checkEvictableKey();

--- a/tests/unit/useOnyxTest.ts
+++ b/tests/unit/useOnyxTest.ts
@@ -162,7 +162,7 @@ describe('useOnyx', () => {
         });
 
         it('should return value and loaded state when loading cached key', async () => {
-            await act(async () => Onyx.set(ONYXKEYS.TEST_KEY, 'test'));
+            Onyx.set(ONYXKEYS.TEST_KEY, 'test');
 
             const {result} = renderHook(() => useOnyx(ONYXKEYS.TEST_KEY));
 
@@ -201,7 +201,7 @@ describe('useOnyx', () => {
         });
 
         it('should return value from cache, and return updated value after a merge operation', async () => {
-            await act(async () => Onyx.set(ONYXKEYS.TEST_KEY, 'test1'));
+            Onyx.set(ONYXKEYS.TEST_KEY, 'test1');
 
             const {result} = renderHook(() => useOnyx(ONYXKEYS.TEST_KEY));
 
@@ -227,7 +227,8 @@ describe('useOnyx', () => {
             expect(result2.current[0]).toBeUndefined();
             expect(result2.current[1].status).toEqual('loaded');
 
-            await act(async () => Onyx.merge(ONYXKEYS.TEST_KEY, 'test2'));
+            Onyx.merge(ONYXKEYS.TEST_KEY, 'test2');
+            await act(async () => waitForPromisesToResolve());
 
             expect(result1.current[0]).toEqual('test2');
             expect(result1.current[1].status).toEqual('loaded');
@@ -259,7 +260,8 @@ describe('useOnyx', () => {
             expect(result3.current[0]).toBeUndefined();
             expect(result3.current[1].status).toEqual('loaded');
 
-            await act(async () => Onyx.merge(ONYXKEYS.TEST_KEY, 'test2'));
+            Onyx.merge(ONYXKEYS.TEST_KEY, 'test2');
+            await act(async () => waitForPromisesToResolve());
 
             expect(result1.current[0]).toEqual('test2');
             expect(result1.current[1].status).toEqual('loaded');
@@ -272,7 +274,7 @@ describe('useOnyx', () => {
 
     describe('selector', () => {
         it('should return selected data from a non-collection key', async () => {
-            await act(async () => Onyx.set(ONYXKEYS.TEST_KEY, {id: 'test_id', name: 'test_name'}));
+            Onyx.set(ONYXKEYS.TEST_KEY, {id: 'test_id', name: 'test_name'});
 
             const {result} = renderHook(() =>
                 useOnyx(ONYXKEYS.TEST_KEY, {
@@ -291,13 +293,11 @@ describe('useOnyx', () => {
         });
 
         it('should return selected data from a collection key', async () => {
-            await act(async () =>
-                Onyx.mergeCollection(ONYXKEYS.COLLECTION.TEST_KEY, {
-                    [`${ONYXKEYS.COLLECTION.TEST_KEY}entry1`]: {id: 'entry1_id', name: 'entry1_name'},
-                    [`${ONYXKEYS.COLLECTION.TEST_KEY}entry2`]: {id: 'entry2_id', name: 'entry2_name'},
-                    [`${ONYXKEYS.COLLECTION.TEST_KEY}entry3`]: {id: 'entry3_id', name: 'entry3_name'},
-                } as GenericCollection),
-            );
+            Onyx.mergeCollection(ONYXKEYS.COLLECTION.TEST_KEY, {
+                [`${ONYXKEYS.COLLECTION.TEST_KEY}entry1`]: {id: 'entry1_id', name: 'entry1_name'},
+                [`${ONYXKEYS.COLLECTION.TEST_KEY}entry2`]: {id: 'entry2_id', name: 'entry2_name'},
+                [`${ONYXKEYS.COLLECTION.TEST_KEY}entry3`]: {id: 'entry3_id', name: 'entry3_name'},
+            } as GenericCollection);
 
             const {result} = renderHook(() =>
                 useOnyx(ONYXKEYS.COLLECTION.TEST_KEY, {
@@ -320,9 +320,6 @@ describe('useOnyx', () => {
             expect(result.current[1].status).toEqual('loaded');
 
             await act(async () => Onyx.merge(`${ONYXKEYS.COLLECTION.TEST_KEY}entry2`, null));
-            // Onyx.merge() with null value resolves immediately, but notifies subscribers asynchronously.
-            // waitForPromisesToResolve() ensures these async operations complete before test assertions run.
-            await act(async () => waitForPromisesToResolve());
 
             expect(result.current[0]).toEqual({
                 [`${ONYXKEYS.COLLECTION.TEST_KEY}entry1`]: 'entry1_id',
@@ -332,7 +329,7 @@ describe('useOnyx', () => {
         });
 
         it('should not change selected data if a property outside that data was changed', async () => {
-            await act(async () => Onyx.set(ONYXKEYS.TEST_KEY, {id: 'test_id', name: 'test_name'}));
+            Onyx.set(ONYXKEYS.TEST_KEY, {id: 'test_id', name: 'test_name'});
 
             // primitive
             const {result: primitiveResult} = renderHook(() =>
@@ -373,13 +370,11 @@ describe('useOnyx', () => {
         });
 
         it('should not change selected collection data if a property outside that data was changed', async () => {
-            await act(async () =>
-                Onyx.mergeCollection(ONYXKEYS.COLLECTION.TEST_KEY, {
-                    [`${ONYXKEYS.COLLECTION.TEST_KEY}entry1`]: {id: 'entry1_id', name: 'entry1_name'},
-                    [`${ONYXKEYS.COLLECTION.TEST_KEY}entry2`]: {id: 'entry2_id', name: 'entry2_name'},
-                    [`${ONYXKEYS.COLLECTION.TEST_KEY}entry3`]: {id: 'entry3_id', name: 'entry3_name'},
-                } as GenericCollection),
-            );
+            Onyx.mergeCollection(ONYXKEYS.COLLECTION.TEST_KEY, {
+                [`${ONYXKEYS.COLLECTION.TEST_KEY}entry1`]: {id: 'entry1_id', name: 'entry1_name'},
+                [`${ONYXKEYS.COLLECTION.TEST_KEY}entry2`]: {id: 'entry2_id', name: 'entry2_name'},
+                [`${ONYXKEYS.COLLECTION.TEST_KEY}entry3`]: {id: 'entry3_id', name: 'entry3_name'},
+            } as GenericCollection);
 
             const {result} = renderHook(() =>
                 useOnyx(ONYXKEYS.COLLECTION.TEST_KEY, {
@@ -399,7 +394,7 @@ describe('useOnyx', () => {
         });
 
         it('should always use the current selector reference to return new data', async () => {
-            await act(async () => Onyx.set(ONYXKEYS.TEST_KEY, {id: 'test_id', name: 'test_name'}));
+            Onyx.set(ONYXKEYS.TEST_KEY, {id: 'test_id', name: 'test_name'});
 
             let selector = (entry: OnyxEntry<{id: string; name: string}>) => `id - ${entry?.id}, name - ${entry?.name}`;
 
@@ -422,7 +417,7 @@ describe('useOnyx', () => {
         });
 
         it('should memoize selector output and return same reference when input unchanged', async () => {
-            await act(async () => Onyx.set(ONYXKEYS.TEST_KEY, {id: 'test_id', name: 'test_name', count: 1}));
+            Onyx.set(ONYXKEYS.TEST_KEY, {id: 'test_id', name: 'test_name', count: 1});
 
             const {result} = renderHook(() =>
                 useOnyx(ONYXKEYS.TEST_KEY, {
@@ -446,7 +441,7 @@ describe('useOnyx', () => {
         });
 
         it('should return new reference when selector input changes', async () => {
-            await act(async () => Onyx.set(ONYXKEYS.TEST_KEY, {id: 'test_id', name: 'test_name'}));
+            Onyx.set(ONYXKEYS.TEST_KEY, {id: 'test_id', name: 'test_name'});
 
             const {result} = renderHook(() =>
                 useOnyx(ONYXKEYS.TEST_KEY, {
@@ -473,7 +468,7 @@ describe('useOnyx', () => {
         it('should memoize selector output using deep equality check', async () => {
             let selectorCallCount = 0;
 
-            await act(async () => Onyx.set(ONYXKEYS.TEST_KEY, {id: 'test_id', name: 'test_name'}));
+            Onyx.set(ONYXKEYS.TEST_KEY, {id: 'test_id', name: 'test_name'});
 
             const {result} = renderHook(() =>
                 useOnyx(ONYXKEYS.TEST_KEY, {
@@ -500,7 +495,7 @@ describe('useOnyx', () => {
         });
 
         it('should memoize primitive selector results correctly', async () => {
-            await act(async () => Onyx.set(ONYXKEYS.TEST_KEY, {count: 5, name: 'test'}));
+            Onyx.set(ONYXKEYS.TEST_KEY, {count: 5, name: 'test'});
 
             const {result} = renderHook(() =>
                 useOnyx(ONYXKEYS.TEST_KEY, {
@@ -906,13 +901,11 @@ describe('useOnyx', () => {
 
     describe('dependencies', () => {
         it('should return the updated selected value when a external value passed to the dependencies list changes', async () => {
-            await act(async () =>
-                Onyx.mergeCollection(ONYXKEYS.COLLECTION.TEST_KEY, {
-                    [`${ONYXKEYS.COLLECTION.TEST_KEY}entry1`]: {id: 'entry1_id', name: 'entry1_name'},
-                    [`${ONYXKEYS.COLLECTION.TEST_KEY}entry2`]: {id: 'entry2_id', name: 'entry2_name'},
-                    [`${ONYXKEYS.COLLECTION.TEST_KEY}entry3`]: {id: 'entry3_id', name: 'entry3_name'},
-                } as GenericCollection),
-            );
+            Onyx.mergeCollection(ONYXKEYS.COLLECTION.TEST_KEY, {
+                [`${ONYXKEYS.COLLECTION.TEST_KEY}entry1`]: {id: 'entry1_id', name: 'entry1_name'},
+                [`${ONYXKEYS.COLLECTION.TEST_KEY}entry2`]: {id: 'entry2_id', name: 'entry2_name'},
+                [`${ONYXKEYS.COLLECTION.TEST_KEY}entry3`]: {id: 'entry3_id', name: 'entry3_name'},
+            } as GenericCollection);
 
             let externalValue = 'ex1';
 
@@ -957,13 +950,11 @@ describe('useOnyx', () => {
 
     describe('skippable collection member ids', () => {
         it('should always return undefined entry when subscribing to a collection with skippable member ids', async () => {
-            await act(async () =>
-                Onyx.mergeCollection(ONYXKEYS.COLLECTION.TEST_KEY, {
-                    [`${ONYXKEYS.COLLECTION.TEST_KEY}entry1`]: {id: 'entry1_id', name: 'entry1_name'},
-                    [`${ONYXKEYS.COLLECTION.TEST_KEY}entry2`]: {id: 'entry2_id', name: 'entry2_name'},
-                    [`${ONYXKEYS.COLLECTION.TEST_KEY}skippable-id`]: {id: 'skippable-id_id', name: 'skippable-id_name'},
-                } as GenericCollection),
-            );
+            Onyx.mergeCollection(ONYXKEYS.COLLECTION.TEST_KEY, {
+                [`${ONYXKEYS.COLLECTION.TEST_KEY}entry1`]: {id: 'entry1_id', name: 'entry1_name'},
+                [`${ONYXKEYS.COLLECTION.TEST_KEY}entry2`]: {id: 'entry2_id', name: 'entry2_name'},
+                [`${ONYXKEYS.COLLECTION.TEST_KEY}skippable-id`]: {id: 'skippable-id_id', name: 'skippable-id_name'},
+            } as GenericCollection);
 
             const {result} = renderHook(() => useOnyx(ONYXKEYS.COLLECTION.TEST_KEY));
 
@@ -1038,9 +1029,6 @@ describe('useOnyx', () => {
             expect(result1.current[0]).toBe('test');
 
             await act(async () => Onyx.set(ONYXKEYS.TEST_KEY, null));
-            // Onyx.set() with null value resolves immediately, but notifies subscribers asynchronously.
-            // waitForPromisesToResolve() ensures these async operations complete before test assertions run.
-            await act(async () => waitForPromisesToResolve());
 
             expect(result1.current[0]).toBeUndefined();
             expect(logAlertFn).not.toBeCalled();
@@ -1074,9 +1062,6 @@ describe('useOnyx', () => {
             expect(result1.current[0]).toBe('test');
 
             await act(async () => Onyx.set(ONYXKEYS.TEST_KEY, null));
-            // Onyx.set() with null value resolves immediately, but notifies subscribers asynchronously.
-            // waitForPromisesToResolve() ensures these async operations complete before test assertions run.
-            await act(async () => waitForPromisesToResolve());
 
             expect(result1.current[0]).toBeUndefined();
             expect(logAlertFn).toHaveBeenCalledTimes(2);
@@ -1108,9 +1093,6 @@ describe('useOnyx', () => {
             expect(result1.current[0]).toBe('test_changed');
 
             await act(async () => Onyx.set(ONYXKEYS.TEST_KEY, null));
-            // Onyx.set() with null value resolves immediately, but notifies subscribers asynchronously.
-            // waitForPromisesToResolve() ensures these async operations complete before test assertions run.
-            await act(async () => waitForPromisesToResolve());
 
             expect(result1.current[0]).toBeUndefined();
             expect(logAlertFn).toHaveBeenCalledTimes(2);
@@ -1139,9 +1121,6 @@ describe('useOnyx', () => {
             expect(result1.current[0]).toBe('test_changed');
 
             await act(async () => Onyx.set(ONYXKEYS.TEST_KEY, null));
-            // Onyx.set() with null value resolves immediately, but notifies subscribers asynchronously.
-            // waitForPromisesToResolve() ensures these async operations complete before test assertions run.
-            await act(async () => waitForPromisesToResolve());
 
             expect(result1.current[0]).toBe('undefined_changed');
             expect(logAlertFn).toHaveBeenCalledTimes(2);
@@ -1201,11 +1180,9 @@ describe('useOnyx', () => {
         });
 
         it('should add the connection to the blocklist when setting "canEvict" to false', async () => {
-            await act(async () =>
-                Onyx.mergeCollection(ONYXKEYS.COLLECTION.EVICTABLE_TEST_KEY, {
-                    [`${ONYXKEYS.COLLECTION.EVICTABLE_TEST_KEY}entry1`]: {id: 'entry1_id', name: 'entry1_name'},
-                } as GenericCollection),
-            );
+            Onyx.mergeCollection(ONYXKEYS.COLLECTION.EVICTABLE_TEST_KEY, {
+                [`${ONYXKEYS.COLLECTION.EVICTABLE_TEST_KEY}entry1`]: {id: 'entry1_id', name: 'entry1_name'},
+            } as GenericCollection);
 
             renderHook(() => useOnyx(`${ONYXKEYS.COLLECTION.EVICTABLE_TEST_KEY}entry1`, {canEvict: false}));
 
@@ -1216,12 +1193,10 @@ describe('useOnyx', () => {
         });
 
         it('should handle removal/adding the connection to the blocklist properly when changing the evictable key to another', async () => {
-            await act(async () =>
-                Onyx.mergeCollection(ONYXKEYS.COLLECTION.EVICTABLE_TEST_KEY, {
-                    [`${ONYXKEYS.COLLECTION.EVICTABLE_TEST_KEY}entry1`]: {id: 'entry1_id', name: 'entry1_name'},
-                    [`${ONYXKEYS.COLLECTION.EVICTABLE_TEST_KEY}entry2`]: {id: 'entry2_id', name: 'entry2_name'},
-                } as GenericCollection),
-            );
+            Onyx.mergeCollection(ONYXKEYS.COLLECTION.EVICTABLE_TEST_KEY, {
+                [`${ONYXKEYS.COLLECTION.EVICTABLE_TEST_KEY}entry1`]: {id: 'entry1_id', name: 'entry1_name'},
+                [`${ONYXKEYS.COLLECTION.EVICTABLE_TEST_KEY}entry2`]: {id: 'entry2_id', name: 'entry2_name'},
+            } as GenericCollection);
 
             const {rerender} = renderHook((key: string) => useOnyx(key, {canEvict: false}), {initialProps: `${ONYXKEYS.COLLECTION.EVICTABLE_TEST_KEY}entry1` as string});
 
@@ -1240,11 +1215,9 @@ describe('useOnyx', () => {
         });
 
         it('should remove the connection from the blocklist when setting "canEvict" to true', async () => {
-            await act(async () =>
-                Onyx.mergeCollection(ONYXKEYS.COLLECTION.EVICTABLE_TEST_KEY, {
-                    [`${ONYXKEYS.COLLECTION.EVICTABLE_TEST_KEY}entry1`]: {id: 'entry1_id', name: 'entry1_name'},
-                } as GenericCollection),
-            );
+            Onyx.mergeCollection(ONYXKEYS.COLLECTION.EVICTABLE_TEST_KEY, {
+                [`${ONYXKEYS.COLLECTION.EVICTABLE_TEST_KEY}entry1`]: {id: 'entry1_id', name: 'entry1_name'},
+            } as GenericCollection);
 
             const {rerender} = renderHook((canEvict: boolean) => useOnyx(`${ONYXKEYS.COLLECTION.EVICTABLE_TEST_KEY}entry1`, {canEvict}), {initialProps: false as boolean});
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

Revert of https://github.com/Expensify/react-native-onyx/pull/669

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

N/A

### Manual Tests
<!---
Each set of changes should be tested against the Expensify/App repo on all platforms to verify it does not break our staging App.
--->

N/A

### Author Checklist

- [x] I linked the correct issue in the `### Related Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.