### PR TITLE
Revert "Update batching to be applied to useOnyx if they come from `Onyx.update`"

### DIFF
--- a/lib/Onyx.ts
+++ b/lib/Onyx.ts
@@ -162,13 +162,6 @@ function disconnect(connection: Connection): void {
  * @param options optional configuration object
  */
 function set<TKey extends OnyxKey>(key: TKey, value: OnyxSetInput<TKey>, options?: SetOptions): Promise<void> {
-    return setInternal(key, value, options);
-}
-/**
- * @param isFromUpdate - Whether this call originates from Onyx.update()
- * When isFromUpdate = true (called from Onyx.update()), useOnyx hook subscribers are batched to escape excessive re-renders in components
- */
-function setInternal<TKey extends OnyxKey>(key: TKey, value: OnyxSetInput<TKey>, options?: SetOptions, isFromUpdate = false): Promise<void> {
     // When we use Onyx.set to set a key we want to clear the current delta changes from Onyx.merge that were queued
     // before the value was set. If Onyx.merge is currently reading the old value from storage, it will then not apply the changes.
     if (OnyxUtils.hasPendingMergeForKey(key)) {
@@ -221,7 +214,7 @@ function setInternal<TKey extends OnyxKey>(key: TKey, value: OnyxSetInput<TKey>,
     OnyxUtils.logKeyChanged(OnyxUtils.METHOD.SET, key, value, hasChanged);
 
     // This approach prioritizes fast UI changes without waiting for data to be stored in device storage.
-    const updatePromise = OnyxUtils.broadcastUpdate(key, valueWithoutNestedNullValues, hasChanged, isFromUpdate);
+    const updatePromise = OnyxUtils.broadcastUpdate(key, valueWithoutNestedNullValues, hasChanged);
 
     // If the value has not changed or the key got removed, calling Storage.setItem() would be redundant and a waste of performance, so return early instead.
     if (!hasChanged) {
@@ -229,7 +222,7 @@ function setInternal<TKey extends OnyxKey>(key: TKey, value: OnyxSetInput<TKey>,
     }
 
     return Storage.setItem(key, valueWithoutNestedNullValues)
-        .catch((error) => OnyxUtils.evictStorageAndRetry(error, setInternal, key, valueWithoutNestedNullValues, undefined, isFromUpdate))
+        .catch((error) => OnyxUtils.evictStorageAndRetry(error, set, key, valueWithoutNestedNullValues))
         .then(() => {
             OnyxUtils.sendActionToDevTools(OnyxUtils.METHOD.SET, key, valueWithoutNestedNullValues);
             return updatePromise;
@@ -244,13 +237,6 @@ function setInternal<TKey extends OnyxKey>(key: TKey, value: OnyxSetInput<TKey>,
  * @param data object keyed by ONYXKEYS and the values to set
  */
 function multiSet(data: OnyxMultiSetInput): Promise<void> {
-    return multiSetInternal(data);
-}
-/**
- * @param isFromUpdate - Whether this call originates from Onyx.update()
- * When isFromUpdate = true (called from Onyx.update()), useOnyx hook subscribers are batched to escape excessive re-renders in components
- */
-function multiSetInternal(data: OnyxMultiSetInput, isFromUpdate = false): Promise<void> {
     let newData = data;
 
     const skippableCollectionMemberIDs = OnyxUtils.getSkippableCollectionMemberIDs();
@@ -283,11 +269,11 @@ function multiSetInternal(data: OnyxMultiSetInput, isFromUpdate = false): Promis
 
         // Update cache and optimistically inform subscribers on the next tick
         cache.set(key, value);
-        return OnyxUtils.scheduleSubscriberUpdate(key, value, prevValue, undefined, isFromUpdate);
+        return OnyxUtils.scheduleSubscriberUpdate(key, value, prevValue);
     });
 
     return Storage.multiSet(keyValuePairsToSet)
-        .catch((error) => OnyxUtils.evictStorageAndRetry(error, multiSetInternal, newData, isFromUpdate))
+        .catch((error) => OnyxUtils.evictStorageAndRetry(error, multiSet, newData))
         .then(() => {
             OnyxUtils.sendActionToDevTools(OnyxUtils.METHOD.MULTI_SET, undefined, newData);
             return Promise.all(updatePromises);
@@ -312,13 +298,6 @@ function multiSetInternal(data: OnyxMultiSetInput, isFromUpdate = false): Promis
  * Onyx.merge(ONYXKEYS.POLICY, {name: 'My Workspace'}); // -> {id: 1, name: 'My Workspace'}
  */
 function merge<TKey extends OnyxKey>(key: TKey, changes: OnyxMergeInput<TKey>): Promise<void> {
-    return mergeInternal(key, changes);
-}
-/**
- * @param isFromUpdate - Whether this call originates from Onyx.update()
- * When isFromUpdate = true (called from Onyx.update()), useOnyx hook subscribers are batched to escape excessive re-renders in components
- */
-function mergeInternal<TKey extends OnyxKey>(key: TKey, changes: OnyxMergeInput<TKey>, isFromUpdate = false): Promise<void> {
     const skippableCollectionMemberIDs = OnyxUtils.getSkippableCollectionMemberIDs();
     if (skippableCollectionMemberIDs.size) {
         try {
@@ -381,7 +360,7 @@ function mergeInternal<TKey extends OnyxKey>(key: TKey, changes: OnyxMergeInput<
                 return Promise.resolve();
             }
 
-            return OnyxMerge.applyMerge(key, existingValue, validChanges, isFromUpdate).then(({mergedValue, updatePromise}) => {
+            return OnyxMerge.applyMerge(key, existingValue, validChanges).then(({mergedValue, updatePromise}) => {
                 OnyxUtils.sendActionToDevTools(OnyxUtils.METHOD.MERGE, key, changes, mergedValue);
                 return updatePromise;
             });
@@ -408,14 +387,7 @@ function mergeInternal<TKey extends OnyxKey>(key: TKey, changes: OnyxMergeInput<
  * @param collection Object collection keyed by individual collection member keys and values
  */
 function mergeCollection<TKey extends CollectionKeyBase, TMap>(collectionKey: TKey, collection: OnyxMergeCollectionInput<TKey, TMap>): Promise<void> {
-    return mergeCollectionInternal(collectionKey, collection);
-}
-/**
- * @param isFromUpdate - Whether this call originates from Onyx.update()
- * When isFromUpdate = true (called from Onyx.update()), useOnyx hook subscribers are batched to escape excessive re-renders in components
- */
-function mergeCollectionInternal<TKey extends CollectionKeyBase, TMap>(collectionKey: TKey, collection: OnyxMergeCollectionInput<TKey, TMap>, isFromUpdate = false): Promise<void> {
-    return OnyxUtils.mergeCollectionWithPatches(collectionKey, collection, undefined, isFromUpdate);
+    return OnyxUtils.mergeCollectionWithPatches(collectionKey, collection);
 }
 
 /**
@@ -504,10 +476,10 @@ function clear(keysToPreserve: OnyxKey[] = []): Promise<void> {
 
             // Notify the subscribers for each key/value group so they can receive the new values
             Object.entries(keyValuesToResetIndividually).forEach(([key, value]) => {
-                updatePromises.push(OnyxUtils.scheduleSubscriberUpdate(key, value, cache.get(key, false), undefined, false));
+                updatePromises.push(OnyxUtils.scheduleSubscriberUpdate(key, value, cache.get(key, false)));
             });
             Object.entries(keyValuesToResetAsCollection).forEach(([key, value]) => {
-                updatePromises.push(OnyxUtils.scheduleNotifyCollectionSubscribers(key, value, undefined, false));
+                updatePromises.push(OnyxUtils.scheduleNotifyCollectionSubscribers(key, value));
             });
 
             const defaultKeyValuePairs = Object.entries(
@@ -598,7 +570,7 @@ function update(data: OnyxUpdate[]): Promise<void> {
                     collectionKeys.forEach((collectionKey) => enqueueMergeOperation(collectionKey, mergedCollection[collectionKey]));
                 }
             },
-            [OnyxUtils.METHOD.SET_COLLECTION]: (k, v) => promises.push(() => setCollectionInternal(k, v as Collection<CollectionKey, unknown, unknown>, true)),
+            [OnyxUtils.METHOD.SET_COLLECTION]: (k, v) => promises.push(() => setCollection(k, v as Collection<CollectionKey, unknown, unknown>)),
             [OnyxUtils.METHOD.MULTI_SET]: (k, v) => Object.entries(v as Partial<OnyxInputKeyValueMapping>).forEach(([entryKey, entryValue]) => enqueueSetOperation(entryKey, entryValue)),
             [OnyxUtils.METHOD.CLEAR]: () => {
                 clearPromise = clear();
@@ -653,28 +625,27 @@ function update(data: OnyxUpdate[]): Promise<void> {
                     collectionKey,
                     batchedCollectionUpdates.merge as Collection<CollectionKey, unknown, unknown>,
                     batchedCollectionUpdates.mergeReplaceNullPatches,
-                    true,
                 ),
             );
         }
         if (!utils.isEmptyObject(batchedCollectionUpdates.set)) {
-            promises.push(() => multiSetInternal(batchedCollectionUpdates.set, true));
+            promises.push(() => multiSet(batchedCollectionUpdates.set));
         }
     });
 
     Object.entries(updateQueue).forEach(([key, operations]) => {
         if (operations[0] === null) {
             const batchedChanges = OnyxUtils.mergeChanges(operations).result;
-            promises.push(() => setInternal(key, batchedChanges, undefined, true));
+            promises.push(() => set(key, batchedChanges));
             return;
         }
 
         operations.forEach((operation) => {
-            promises.push(() => mergeInternal(key, operation, true));
+            promises.push(() => merge(key, operation));
         });
     });
 
-    const snapshotPromises = OnyxUtils.updateSnapshots(data, (key, changes) => mergeInternal(key, changes, true));
+    const snapshotPromises = OnyxUtils.updateSnapshots(data, merge);
 
     // We need to run the snapshot updates before the other updates so the snapshot data can be updated before the loading state in the snapshot
     const finalPromises = snapshotPromises.concat(promises);
@@ -696,13 +667,6 @@ function update(data: OnyxUpdate[]): Promise<void> {
  * @param collection Object collection keyed by individual collection member keys and values
  */
 function setCollection<TKey extends CollectionKeyBase, TMap>(collectionKey: TKey, collection: OnyxMergeCollectionInput<TKey, TMap>): Promise<void> {
-    return setCollectionInternal(collectionKey, collection);
-}
-/**
- * @param isFromUpdate - Whether this call originates from Onyx.update()
- * When isFromUpdate = true (called from Onyx.update()), useOnyx hook subscribers are batched to escape excessive re-renders in components
- */
-function setCollectionInternal<TKey extends CollectionKeyBase, TMap>(collectionKey: TKey, collection: OnyxMergeCollectionInput<TKey, TMap>, isFromUpdate = false): Promise<void> {
     let resultCollection: OnyxInputKeyValueMapping = collection;
     let resultCollectionKeys = Object.keys(resultCollection);
 
@@ -750,10 +714,10 @@ function setCollectionInternal<TKey extends CollectionKeyBase, TMap>(collectionK
 
         keyValuePairs.forEach(([key, value]) => cache.set(key, value));
 
-        const updatePromise = OnyxUtils.scheduleNotifyCollectionSubscribers(collectionKey, mutableCollection, previousCollection, isFromUpdate);
+        const updatePromise = OnyxUtils.scheduleNotifyCollectionSubscribers(collectionKey, mutableCollection, previousCollection);
 
         return Storage.multiSet(keyValuePairs)
-            .catch((error) => OnyxUtils.evictStorageAndRetry(error, setCollectionInternal, collectionKey, collection, isFromUpdate))
+            .catch((error) => OnyxUtils.evictStorageAndRetry(error, setCollection, collectionKey, collection))
             .then(() => {
                 OnyxUtils.sendActionToDevTools(OnyxUtils.METHOD.SET_COLLECTION, undefined, mutableCollection);
                 return updatePromise;

--- a/lib/OnyxMerge/index.native.ts
+++ b/lib/OnyxMerge/index.native.ts
@@ -8,7 +8,6 @@ const applyMerge: ApplyMerge = <TKey extends OnyxKey, TValue extends OnyxInput<T
     key: TKey,
     existingValue: TValue,
     validChanges: TChange[],
-    isFromUpdate = false,
 ) => {
     // If any of the changes is null, we need to discard the existing value.
     const baseValue = validChanges.includes(null as TChange) ? undefined : existingValue;
@@ -27,7 +26,7 @@ const applyMerge: ApplyMerge = <TKey extends OnyxKey, TValue extends OnyxInput<T
     OnyxUtils.logKeyChanged(OnyxUtils.METHOD.MERGE, key, mergedValue, hasChanged);
 
     // This approach prioritizes fast UI changes without waiting for data to be stored in device storage.
-    const updatePromise = OnyxUtils.broadcastUpdate(key, mergedValue as OnyxValue<TKey>, hasChanged, isFromUpdate);
+    const updatePromise = OnyxUtils.broadcastUpdate(key, mergedValue as OnyxValue<TKey>, hasChanged);
 
     // If the value has not changed, calling Storage.setItem() would be redundant and a waste of performance, so return early instead.
     if (!hasChanged) {

--- a/lib/OnyxMerge/index.ts
+++ b/lib/OnyxMerge/index.ts
@@ -8,7 +8,6 @@ const applyMerge: ApplyMerge = <TKey extends OnyxKey, TValue extends OnyxInput<T
     key: TKey,
     existingValue: TValue,
     validChanges: TChange[],
-    isFromUpdate = false,
 ) => {
     const {result: mergedValue} = OnyxUtils.mergeChanges(validChanges, existingValue);
 
@@ -19,7 +18,7 @@ const applyMerge: ApplyMerge = <TKey extends OnyxKey, TValue extends OnyxInput<T
     OnyxUtils.logKeyChanged(OnyxUtils.METHOD.MERGE, key, mergedValue, hasChanged);
 
     // This approach prioritizes fast UI changes without waiting for data to be stored in device storage.
-    const updatePromise = OnyxUtils.broadcastUpdate(key, mergedValue as OnyxValue<TKey>, hasChanged, isFromUpdate);
+    const updatePromise = OnyxUtils.broadcastUpdate(key, mergedValue as OnyxValue<TKey>, hasChanged);
 
     // If the value has not changed, calling Storage.setItem() would be redundant and a waste of performance, so return early instead.
     if (!hasChanged) {

--- a/lib/OnyxMerge/types.ts
+++ b/lib/OnyxMerge/types.ts
@@ -9,7 +9,6 @@ type ApplyMerge = <TKey extends OnyxKey, TValue extends OnyxInput<OnyxKey> | und
     key: TKey,
     existingValue: TValue,
     validChanges: TChange[],
-    isFromUpdate?: boolean,
 ) => Promise<ApplyMergeResult<TChange>>;
 
 export type {ApplyMerge, ApplyMergeResult};

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -611,7 +611,6 @@ function keysChanged<TKey extends CollectionKeyBase>(
     partialPreviousCollection: OnyxCollection<KeyValueMapping[TKey]> | undefined,
     notifyConnectSubscribers = true,
     notifyWithOnyxSubscribers = true,
-    notifyUseOnyxHookSubscribers = true,
 ): void {
     // We prepare the "cached collection" which is the entire collection + the new partial data that
     // was merged in via mergeCollection().
@@ -647,8 +646,7 @@ function keysChanged<TKey extends CollectionKeyBase>(
 
         // Regular Onyx.connect() subscriber found.
         if (typeof subscriber.callback === 'function') {
-            // Check if it's a useOnyx or a regular Onyx.connect() subscriber
-            if ((subscriber.isUseOnyxSubscriber && !notifyUseOnyxHookSubscribers) || (!subscriber.isUseOnyxSubscriber && !notifyConnectSubscribers)) {
+            if (!notifyConnectSubscribers) {
                 continue;
             }
 
@@ -807,7 +805,6 @@ function keyChanged<TKey extends OnyxKey>(
     canUpdateSubscriber: (subscriber?: Mapping<OnyxKey>) => boolean = () => true,
     notifyConnectSubscribers = true,
     notifyWithOnyxSubscribers = true,
-    notifyUseOnyxHookSubscribers = true,
 ): void {
     // Add or remove this key from the recentlyAccessedKeys lists
     if (value !== null) {
@@ -849,8 +846,7 @@ function keyChanged<TKey extends OnyxKey>(
 
         // Subscriber is a regular call to connect() and provided a callback
         if (typeof subscriber.callback === 'function') {
-            // Check if it's a useOnyx or a regular Onyx.connect() subscriber
-            if ((subscriber.isUseOnyxSubscriber && !notifyUseOnyxHookSubscribers) || (!subscriber.isUseOnyxSubscriber && !notifyConnectSubscribers)) {
+            if (!notifyConnectSubscribers) {
                 continue;
             }
             if (lastConnectionCallbackData.has(subscriber.subscriptionID) && lastConnectionCallbackData.get(subscriber.subscriptionID) === value) {
@@ -1070,10 +1066,9 @@ function scheduleSubscriberUpdate<TKey extends OnyxKey>(
     value: OnyxValue<TKey>,
     previousValue: OnyxValue<TKey>,
     canUpdateSubscriber: (subscriber?: Mapping<OnyxKey>) => boolean = () => true,
-    isFromUpdate = false,
 ): Promise<void> {
-    const promise = Promise.resolve().then(() => keyChanged(key, value, previousValue, canUpdateSubscriber, true, false, !isFromUpdate));
-    batchUpdates(() => keyChanged(key, value, previousValue, canUpdateSubscriber, false, true, isFromUpdate));
+    const promise = Promise.resolve().then(() => keyChanged(key, value, previousValue, canUpdateSubscriber, true, false));
+    batchUpdates(() => keyChanged(key, value, previousValue, canUpdateSubscriber, false, true));
     return Promise.all([maybeFlushBatchUpdates(), promise]).then(() => undefined);
 }
 
@@ -1086,10 +1081,9 @@ function scheduleNotifyCollectionSubscribers<TKey extends OnyxKey>(
     key: TKey,
     value: OnyxCollection<KeyValueMapping[TKey]>,
     previousValue?: OnyxCollection<KeyValueMapping[TKey]>,
-    isFromUpdate = false,
 ): Promise<void> {
-    const promise = Promise.resolve().then(() => keysChanged(key, value, previousValue, true, false, !isFromUpdate));
-    batchUpdates(() => keysChanged(key, value, previousValue, false, true, isFromUpdate));
+    const promise = Promise.resolve().then(() => keysChanged(key, value, previousValue, true, false));
+    batchUpdates(() => keysChanged(key, value, previousValue, false, true));
     return Promise.all([maybeFlushBatchUpdates(), promise]).then(() => undefined);
 }
 
@@ -1151,7 +1145,7 @@ function evictStorageAndRetry<TMethod extends typeof Onyx.set | typeof Onyx.mult
 /**
  * Notifies subscribers and writes current value to cache
  */
-function broadcastUpdate<TKey extends OnyxKey>(key: TKey, value: OnyxValue<TKey>, hasChanged?: boolean, isFromUpdate = false): Promise<void> {
+function broadcastUpdate<TKey extends OnyxKey>(key: TKey, value: OnyxValue<TKey>, hasChanged?: boolean): Promise<void> {
     const prevValue = cache.get(key, false) as OnyxValue<TKey>;
 
     // Update subscribers if the cached value has changed, or when the subscriber specifically requires
@@ -1162,7 +1156,7 @@ function broadcastUpdate<TKey extends OnyxKey>(key: TKey, value: OnyxValue<TKey>
         cache.addToAccessedKeys(key);
     }
 
-    return scheduleSubscriberUpdate(key, value, prevValue, (subscriber) => hasChanged || subscriber?.initWithStoredValues === false, isFromUpdate).then(() => undefined);
+    return scheduleSubscriberUpdate(key, value, prevValue, (subscriber) => hasChanged || subscriber?.initWithStoredValues === false).then(() => undefined);
 }
 
 function hasPendingMergeForKey(key: OnyxKey): boolean {
@@ -1509,7 +1503,6 @@ function mergeCollectionWithPatches<TKey extends CollectionKeyBase, TMap>(
     collectionKey: TKey,
     collection: OnyxMergeCollectionInput<TKey, TMap>,
     mergeReplaceNullPatches?: MultiMergeReplaceNullPatches,
-    isFromUpdate = false,
 ): Promise<void> {
     if (!isValidNonEmptyCollectionForMerge(collection)) {
         Logger.logInfo('mergeCollection() called with invalid or empty value. Skipping this update.');
@@ -1610,7 +1603,7 @@ function mergeCollectionWithPatches<TKey extends CollectionKeyBase, TMap>(
             // and update all subscribers
             const promiseUpdate = previousCollectionPromise.then((previousCollection) => {
                 cache.merge(finalMergedCollection);
-                return scheduleNotifyCollectionSubscribers(collectionKey, finalMergedCollection, previousCollection, isFromUpdate);
+                return scheduleNotifyCollectionSubscribers(collectionKey, finalMergedCollection, previousCollection);
             });
 
             return Promise.all(promises)

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -273,9 +273,6 @@ type BaseConnectOptions = {
      * with the same connect configurations.
      */
     reuseConnection?: boolean;
-
-    /** Indicates whether this subscriber is created from the useOnyx hook. */
-    isUseOnyxSubscriber?: boolean;
 };
 
 /** Represents the callback function used in `Onyx.connect()` method with a regular key. */

--- a/lib/useOnyx.ts
+++ b/lib/useOnyx.ts
@@ -359,7 +359,6 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
                 initWithStoredValues: options?.initWithStoredValues,
                 waitForCollectionCallback: OnyxUtils.isCollectionKey(key) as true,
                 reuseConnection: options?.reuseConnection,
-                isUseOnyxSubscriber: true,
             });
 
             checkEvictableKey();

--- a/tests/unit/useOnyxTest.ts
+++ b/tests/unit/useOnyxTest.ts
@@ -1,7 +1,5 @@
-import {act, renderHook, render} from '@testing-library/react-native';
-import React from 'react';
-import {configure as configureRNTL, resetToDefaults as resetRNTLToDefaults} from '@testing-library/react-native/build/config';
-import type {OnyxCollection, OnyxEntry, OnyxKey} from '../../lib';
+import {act, renderHook} from '@testing-library/react-native';
+import type {OnyxCollection, OnyxEntry} from '../../lib';
 import Onyx, {useOnyx} from '../../lib';
 import OnyxCache from '../../lib/OnyxCache';
 import StorageMock from '../../lib/storage';
@@ -1152,73 +1150,6 @@ describe('useOnyx', () => {
 
             expect(result1.current[0]).toBeUndefined();
             expect(logAlertFn).not.toBeCalled();
-        });
-    });
-
-    describe('batching', () => {
-        // Temporarily disable concurrent rendering to isolate and test batching behavior independently of React's concurrent features
-        beforeAll(() => {
-            configureRNTL({
-                concurrentRoot: false,
-            });
-        });
-        afterAll(() => {
-            resetRNTLToDefaults();
-        });
-
-        function TestUseOnyxComponent({onRender, onyxKey1, onyxKey2}: {onRender: jest.Mock; onyxKey1: OnyxKey; onyxKey2: OnyxKey}) {
-            const [value1] = useOnyx(onyxKey1);
-            const [value2] = useOnyx(onyxKey2);
-
-            React.useEffect(() => {
-                onRender({value1, value2});
-            });
-
-            return null;
-        }
-
-        it('re-renders once when two subscribed keys are updated in one Onyx.update', async () => {
-            const onRender = jest.fn();
-            const testKeyValues = {
-                1: {id: 1, value: '1'},
-                2: {id: 2, value: '2'},
-            };
-            const testKey2Value = {id: 10, value: '10'};
-
-            render(
-                <TestUseOnyxComponent
-                    onRender={onRender}
-                    onyxKey1={`${ONYXKEYS.COLLECTION.TEST_KEY}1`}
-                    onyxKey2={`${ONYXKEYS.COLLECTION.TEST_KEY_2}1`}
-                />,
-            );
-
-            await act(async () => waitForPromisesToResolve());
-            onRender.mockClear();
-
-            await act(async () => {
-                Onyx.update([
-                    {
-                        onyxMethod: Onyx.METHOD.MERGE_COLLECTION,
-                        key: ONYXKEYS.COLLECTION.TEST_KEY,
-                        value: {
-                            [`${ONYXKEYS.COLLECTION.TEST_KEY}1`]: testKeyValues[1],
-                            [`${ONYXKEYS.COLLECTION.TEST_KEY}2`]: testKeyValues[2],
-                        },
-                    },
-                    {
-                        onyxMethod: Onyx.METHOD.MERGE,
-                        key: `${ONYXKEYS.COLLECTION.TEST_KEY_2}1`,
-                        value: testKey2Value,
-                    },
-                ]);
-            });
-
-            await act(async () => waitForPromisesToResolve());
-
-            // We expect only one re-render after Onyx.update updates are applied
-            expect(onRender).toHaveBeenCalledTimes(1);
-            expect(onRender).toHaveBeenLastCalledWith({value1: testKeyValues[1], value2: testKey2Value});
         });
     });
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

Reverts Expensify/react-native-onyx#681 due to the deploy blocker https://github.com/Expensify/App/issues/70184 to unblock onyx lib updates

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

N/A

### Manual Tests
<!---
Each set of changes should be tested against the Expensify/App repo on all platforms to verify it does not break our staging App.
--->

N/A

### Author Checklist

- [x] I linked the correct issue in the `### Related Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.