### PR TITLE
Add stableCollectionReference to avoid rerenders

### DIFF
--- a/lib/useOnyx.ts
+++ b/lib/useOnyx.ts
@@ -236,12 +236,6 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
         if (!(isFirstConnectionRef.current && options?.initWithStoredValues === false) && !shouldGetCachedValueRef.current) {
             const cachedResult = onyxSnapshotCache.getCachedResult<UseOnyxResult<TReturnValue>>(key, cacheKey);
             if (cachedResult !== undefined) {
-                // Collections: preserve reference stability - if data is deeply equal, return same reference
-                const isCollection = OnyxUtils.isCollectionKey(key);
-                if (isCollection && resultRef.current && cachedResult !== resultRef.current && deepEqual(cachedResult, resultRef.current)) {
-                    return resultRef.current;
-                }
-
                 resultRef.current = cachedResult;
                 return cachedResult;
             }

--- a/lib/useOnyx.ts
+++ b/lib/useOnyx.ts
@@ -236,6 +236,12 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
         if (!(isFirstConnectionRef.current && options?.initWithStoredValues === false) && !shouldGetCachedValueRef.current) {
             const cachedResult = onyxSnapshotCache.getCachedResult<UseOnyxResult<TReturnValue>>(key, cacheKey);
             if (cachedResult !== undefined) {
+                // Collections: preserve reference stability - if data is deeply equal, return same reference
+                const isCollection = OnyxUtils.isCollectionKey(key);
+                if (isCollection && resultRef.current && cachedResult !== resultRef.current && deepEqual(cachedResult, resultRef.current)) {
+                    return resultRef.current;
+                }
+
                 resultRef.current = cachedResult;
                 return cachedResult;
             }


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

**Background**
When a child component using useOnyx mounts with the same key as its parent, the parent receives a new reference on the next render. This can cause an additional, unnecessary re-render even though the data is unchanged (isDeepEqual: true, isSameRef: false). I tested a similar scenario using an object (non-collection) key, and this issue did not occur (see the simple test app: 
).

**Root Cause**
getCollectionData() in OnyxCache.ts returns { ...cachedCollection }, which creates a new shallow copy on each call. This ensures React detects changes when items are added or removed, but may also replace reference in case if we add new subscribers with the same key. This can cause unnecessary rerenders in other parts of the app, triggered by unrelated events such as navigation. 

**Solution**
Added memoization to getCollectionData to avoid creating new object references when the collection hasn't changed. The method tracks dirty collections via a dirtyCollections Set and caches the last returned reference in stableCollectionReference. If the collection isn't dirty and a cached reference exists, it returns that reference; otherwise it creates a new reference, stores it, and marks the collection as clean. This ensures multiple calls for an unchanged collection return the same reference, preserving React's reference equality checks and reducing unnecessary re-renders.

**Results**
Before fix ([test app](https://github.com/Expensify/App/pull/78843), main):
- see logs pointing that ref for useOnyx changed after parent rerendered
https://github.com/user-attachments/assets/daee6b0a-35e0-470b-87ef-b66f62b93e12

After fix ([test app](https://github.com/Expensify/App/pull/78843), PR)
https://github.com/user-attachments/assets/f27014ce-6827-401b-a2c3-036eac4cd0d9

Expensify app, open report scenario (4x slowdown)
<img width="1893" height="1335" alt="Screenshot 2026-01-08 at 09 53 31" src="https://github.com/user-attachments/assets/b9a42d73-6b63-4676-bda0-c0a02c265bc6" />





### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/App/issues/77173

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
I added both perf and unit tests. I checked locally with baseline created on "main" and these are diff results. Instant access for collections stored as stable, and a bit slower when we return new reference. Main benefit is visible in real app, when we can reduce some rerenders with it.

```
OnyxCache getCollectionData one call getting collection with dirty collection (10k members) [function]: 2.0 ms → 2.7 ms
OnyxCache getCollectionData one call getting collection with stable reference (10k members) [function]: 2.0 ms → 0.0 ms
```

### Manual Tests
<!---
Each set of changes should be tested against the Expensify/App repo on all platforms to verify it does not break our staging App.
--->

I recommend performing at least the following steps:
1. Open the **Reports** tab.
2. Switch to **Expenses**.
3. Open the same report several times.
4. Modify something in the report, such as the merchant, or set it to **Hold**.
5. Navigate back to the list and verify whether it re-rendered with the latest changes.

Old issues that caused similar Onyx PRs to be reverted:
https://github.com/Expensify/App/issues/76847 ✅ 
https://github.com/Expensify/App/issues/74385 ✅ 
https://github.com/Expensify/App/issues/74405 ✅ 
https://github.com/Expensify/App/issues/74406 ✅  (I found different bug but its already on main, reported in expensify-bugs9796, https://callstack-hq.slack.com/archives/C049HHMV9SM/p1767949160869679)


### Author Checklist

- [x] I linked the correct issue in the `### Related Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/2e96e236-e9ae-459d-a71e-6b682779b9bc


</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->
https://github.com/user-attachments/assets/8be4abec-e6bb-4283-bdee-8117b760ca95
</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/924f9497-4602-4c1f-bc30-3ff999cdc2bf


</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/21341893-549a-4579-bbd7-e840ca525b56
</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/b88babdd-cefc-4bb3-ac80-82662a7ba5bf


</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
