### PR TITLE
Remove unconditional null pruning from Onyx write operations

### DIFF
--- a/lib/OnyxCache.ts
+++ b/lib/OnyxCache.ts
@@ -226,7 +226,6 @@ class OnyxCache {
 
         this.storageMap = {
             ...utils.fastMerge(this.storageMap, data, {
-                shouldRemoveNestedNulls: true,
                 objectRemovalMode: 'replace',
             }).result,
         };

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -1018,7 +1018,6 @@ function hasPendingMergeForKey(key: OnyxKey): boolean {
  */
 function prepareKeyValuePairsForStorage(
     data: Record<OnyxKey, OnyxInput<OnyxKey>>,
-    shouldRemoveNestedNulls?: boolean,
     replaceNullPatches?: MultiMergeReplaceNullPatches,
     isProcessingCollectionUpdate?: boolean,
 ): StorageKeyValuePair[] {
@@ -1030,10 +1029,8 @@ function prepareKeyValuePairsForStorage(
             continue;
         }
 
-        const valueWithoutNestedNullValues = shouldRemoveNestedNulls ?? true ? utils.removeNestedNullValues(value) : value;
-
-        if (valueWithoutNestedNullValues !== undefined) {
-            pairs.push([key, valueWithoutNestedNullValues, replaceNullPatches?.[key]]);
+        if (value !== undefined) {
+            pairs.push([key, value, replaceNullPatches?.[key]]);
         }
     }
 
@@ -1085,7 +1082,7 @@ function mergeInternal<TValue extends OnyxInput<OnyxKey> | undefined, TChange ex
         // Object values are then merged one after the other
         return changes.reduce<FastMergeResult<TChange>>(
             (modifiedData, change) => {
-                const options: FastMergeOptions = mode === 'merge' ? {shouldRemoveNestedNulls: true, objectRemovalMode: 'replace'} : {objectRemovalMode: 'mark'};
+                const options: FastMergeOptions = mode === 'merge' ? {objectRemovalMode: 'replace'} : {objectRemovalMode: 'mark'};
                 const {result, replaceNullPatches} = utils.fastMerge(modifiedData.result, change, options);
 
                 // eslint-disable-next-line no-param-reassign
@@ -1117,9 +1114,7 @@ function initializeWithDefaultKeyStates(): Promise<void> {
     return Storage.multiGet(keysToFetch).then((pairs) => {
         const existingDataAsObject = Object.fromEntries(pairs) as Record<string, unknown>;
 
-        const merged = utils.fastMerge(existingDataAsObject, defaultKeyStates, {
-            shouldRemoveNestedNulls: true,
-        }).result;
+        const merged = utils.fastMerge(existingDataAsObject, defaultKeyStates).result;
         cache.merge(merged ?? {});
 
         for (const [key, value] of Object.entries(merged ?? {})) keyChanged(key, value);
@@ -1393,13 +1388,12 @@ function setWithRetry<TKey extends OnyxKey>({key, value, options}: SetParams<TKe
         return Promise.resolve();
     }
 
-    const valueWithoutNestedNullValues = utils.removeNestedNullValues(value) as OnyxValue<TKey>;
-    const hasChanged = options?.skipCacheCheck ? true : cache.hasValueChanged(key, valueWithoutNestedNullValues);
+    const hasChanged = options?.skipCacheCheck ? true : cache.hasValueChanged(key, value);
 
     OnyxUtils.logKeyChanged(OnyxUtils.METHOD.SET, key, value, hasChanged);
 
     // This approach prioritizes fast UI changes without waiting for data to be stored in device storage.
-    const updatePromise = OnyxUtils.broadcastUpdate(key, valueWithoutNestedNullValues, hasChanged);
+    const updatePromise = OnyxUtils.broadcastUpdate(key, value, hasChanged);
 
     // If the value has not changed and this isn't a retry attempt, calling Storage.setItem() would be redundant and a waste of performance, so return early instead.
     if (!hasChanged && !retryAttempt) {
@@ -1408,14 +1402,14 @@ function setWithRetry<TKey extends OnyxKey>({key, value, options}: SetParams<TKe
 
     // If a key is a RAM-only key or a member of RAM-only collection, we skip the step that modifies the storage
     if (isRamOnlyKey(key)) {
-        OnyxUtils.sendActionToDevTools(OnyxUtils.METHOD.SET, key, valueWithoutNestedNullValues);
+        OnyxUtils.sendActionToDevTools(OnyxUtils.METHOD.SET, key, value);
         return updatePromise;
     }
 
-    return Storage.setItem(key, valueWithoutNestedNullValues)
-        .catch((error) => OnyxUtils.retryOperation(error, setWithRetry, {key, value: valueWithoutNestedNullValues, options}, retryAttempt))
+    return Storage.setItem(key, value)
+        .catch((error) => OnyxUtils.retryOperation(error, setWithRetry, {key, value, options}, retryAttempt))
         .then(() => {
-            OnyxUtils.sendActionToDevTools(OnyxUtils.METHOD.SET, key, valueWithoutNestedNullValues);
+            OnyxUtils.sendActionToDevTools(OnyxUtils.METHOD.SET, key, value);
             return updatePromise;
         });
 }
@@ -1448,7 +1442,7 @@ function multiSetWithRetry(data: OnyxMultiSetInput, retryAttempt?: number): Prom
         }, {});
     }
 
-    const keyValuePairsToSet = OnyxUtils.prepareKeyValuePairsForStorage(newData, true);
+    const keyValuePairsToSet = OnyxUtils.prepareKeyValuePairsForStorage(newData);
 
     const updatePromises = keyValuePairsToSet.map(([key, value]) => {
         // When we use multiSet to set a key we want to clear the current delta changes from Onyx.merge that were queued
@@ -1530,7 +1524,7 @@ function setCollectionWithRetry<TKey extends CollectionKeyBase>({collectionKey, 
             mutableCollection[key] = null;
         }
 
-        const keyValuePairs = OnyxUtils.prepareKeyValuePairsForStorage(mutableCollection, true, undefined, true);
+        const keyValuePairs = OnyxUtils.prepareKeyValuePairsForStorage(mutableCollection, undefined, true);
         const previousCollection = OnyxUtils.getCachedCollection(collectionKey);
 
         for (const [key, value] of keyValuePairs) cache.set(key, value);
@@ -1636,14 +1630,8 @@ function mergeCollectionWithPatches<TKey extends CollectionKeyBase>(
                 newCollection[key] = resultCollection[key];
             }
 
-            // When (multi-)merging the values with the existing values in storage,
-            // we don't want to remove nested null values from the data that we pass to the storage layer,
-            // because the storage layer uses them to remove nested keys from storage natively.
-            const keyValuePairsForExistingCollection = prepareKeyValuePairsForStorage(existingKeyCollection, false, mergeReplaceNullPatches);
-
-            // We can safely remove nested null values when using (multi-)set,
-            // because we will simply overwrite the existing values in storage.
-            const keyValuePairsForNewCollection = prepareKeyValuePairsForStorage(newCollection, true);
+            const keyValuePairsForExistingCollection = prepareKeyValuePairsForStorage(existingKeyCollection, mergeReplaceNullPatches);
+            const keyValuePairsForNewCollection = prepareKeyValuePairsForStorage(newCollection);
 
             const promises = [];
 
@@ -1732,7 +1720,7 @@ function partialSetCollection<TKey extends CollectionKeyBase>({collectionKey, co
         const mutableCollection: OnyxInputKeyValueMapping = {...resultCollection};
         const existingKeys = resultCollectionKeys.filter((key) => persistedKeys.has(key));
         const previousCollection = getCachedCollection(collectionKey, existingKeys);
-        const keyValuePairs = prepareKeyValuePairsForStorage(mutableCollection, true, undefined, true);
+        const keyValuePairs = prepareKeyValuePairsForStorage(mutableCollection, undefined, true);
 
         for (const [key, value] of keyValuePairs) cache.set(key, value);
 

--- a/lib/storage/providers/IDBKeyValProvider/index.ts
+++ b/lib/storage/providers/IDBKeyValProvider/index.ts
@@ -62,7 +62,6 @@ const provider: StorageProvider<UseStore | undefined> = {
                         store.delete(key);
                     } else {
                         const newValue = utils.fastMerge(values[index] as Record<string, unknown>, value as Record<string, unknown>, {
-                            shouldRemoveNestedNulls: true,
                             objectRemovalMode: 'replace',
                         }).result;
 

--- a/lib/storage/providers/MemoryOnlyProvider.ts
+++ b/lib/storage/providers/MemoryOnlyProvider.ts
@@ -82,14 +82,12 @@ const provider: StorageProvider<Store> = {
 
     /**
      * Multiple merging of existing and new values in a batch
-     * This function also removes all nested null values from an object.
      */
     multiMerge(pairs) {
         for (const [key, value] of pairs) {
             const existingValue = provider.store[key] as Record<string, unknown>;
 
             const newValue = utils.fastMerge(existingValue, value as Record<string, unknown>, {
-                shouldRemoveNestedNulls: true,
                 objectRemovalMode: 'replace',
             }).result;
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,4 +1,4 @@
-import type {OnyxInput, OnyxKey} from './types';
+import type {OnyxKey} from './types';
 
 type EmptyObject = Record<string, never>;
 type EmptyValue = EmptyObject | null | undefined;
@@ -13,9 +13,6 @@ type EmptyValue = EmptyObject | null | undefined;
 type FastMergeReplaceNullPatch = [string[], unknown];
 
 type FastMergeOptions = {
-    /** If true, null object values will be removed. */
-    shouldRemoveNestedNulls?: boolean;
-
     /**
      * If set to "mark", we will mark objects that are set to null instead of simply removing them,
      * so that we can batch changes together, without losing information about the object removal.
@@ -40,9 +37,7 @@ type FastMergeResult<TValue> = {
 const ONYX_INTERNALS__REPLACE_OBJECT_MARK = 'ONYX_INTERNALS__REPLACE_OBJECT_MARK';
 
 /**
- * Merges two objects and removes null values if "shouldRemoveNestedNulls" is set to true
- *
- * We generally want to remove null values from objects written to disk and cache, because it decreases the amount of data stored in memory and on disk.
+ * Merges two objects.
  */
 function fastMerge<TValue>(target: TValue, source: TValue, options?: FastMergeOptions, metadata?: FastMergeMetadata, basePath: string[] = []): FastMergeResult<TValue> {
     if (!metadata) {
@@ -60,7 +55,6 @@ function fastMerge<TValue>(target: TValue, source: TValue, options?: FastMergeOp
     }
 
     const optionsWithDefaults: FastMergeOptions = {
-        shouldRemoveNestedNulls: options?.shouldRemoveNestedNulls ?? false,
         objectRemovalMode: options?.objectRemovalMode ?? 'none',
     };
 
@@ -91,18 +85,11 @@ function mergeObject<TObject extends Record<string, unknown>>(
 
     // First we want to copy over all keys from the target into the destination object,
     // in case "target" is a mergable object.
-    // If "shouldRemoveNestedNulls" is true, we want to remove null values from the merged object
-    // and therefore we need to omit keys where either the source or target value is null.
     if (targetObject) {
         for (const key of Object.keys(targetObject)) {
             const targetProperty = targetObject?.[key];
-            const sourceProperty = source?.[key];
 
-            // If "shouldRemoveNestedNulls" is true, we want to remove (nested) null values from the merged object.
-            // If either the source or target value is null, we want to omit the key from the merged object.
-            const shouldOmitNullishProperty = options.shouldRemoveNestedNulls && (targetProperty === null || sourceProperty === null);
-
-            if (targetProperty === undefined || shouldOmitNullishProperty) {
+            if (targetProperty === undefined) {
                 continue;
             }
 
@@ -115,11 +102,7 @@ function mergeObject<TObject extends Record<string, unknown>>(
         let targetProperty = targetObject?.[key];
         const sourceProperty = source?.[key] as Record<string, unknown>;
 
-        // If "shouldRemoveNestedNulls" is true, we want to remove (nested) null values from the merged object.
-        // If the source value is null, we want to omit the key from the merged object.
-        const shouldOmitNullishProperty = options.shouldRemoveNestedNulls && sourceProperty === null;
-
-        if (sourceProperty === undefined || shouldOmitNullishProperty) {
+        if (sourceProperty === undefined) {
             continue;
         }
 
@@ -168,37 +151,6 @@ function isEmptyObject<T>(obj: T | EmptyValue): obj is EmptyValue {
 function isMergeableObject<TObject extends Record<string, unknown>>(value: unknown): value is TObject {
     const isNonNullObject = value != null ? typeof value === 'object' : false;
     return isNonNullObject && !(value instanceof RegExp) && !(value instanceof Date) && !Array.isArray(value);
-}
-
-/** Deep removes the nested null values from the given value. */
-function removeNestedNullValues<TValue extends OnyxInput<OnyxKey> | null>(value: TValue): TValue {
-    if (value === null || value === undefined || typeof value !== 'object') {
-        return value;
-    }
-
-    if (Array.isArray(value)) {
-        return [...value] as TValue;
-    }
-
-    const result: Record<string, unknown> = {};
-
-    // eslint-disable-next-line no-restricted-syntax, guard-for-in
-    for (const key in value) {
-        const propertyValue = value[key];
-
-        if (propertyValue === null || propertyValue === undefined) {
-            continue;
-        }
-
-        if (typeof propertyValue === 'object' && !Array.isArray(propertyValue)) {
-            const valueWithoutNestedNulls = removeNestedNullValues(propertyValue);
-            result[key] = valueWithoutNestedNulls;
-        } else {
-            result[key] = propertyValue;
-        }
-    }
-
-    return result as TValue;
 }
 
 /** Formats the action name by uppercasing and adding the key if provided. */
@@ -284,7 +236,6 @@ export default {
     fastMerge,
     isEmptyObject,
     formatActionName,
-    removeNestedNullValues,
     checkCompatibilityWithExistingValue,
     pick,
     omit,

--- a/tests/perf-test/utils.perf-test.ts
+++ b/tests/perf-test/utils.perf-test.ts
@@ -23,30 +23,13 @@ describe('utils', () => {
         test('one call', async () => {
             const target = getRandomReportActions(collectionKey, 1000);
             const source = getRandomReportActions(collectionKey, 500);
-            await measureFunction(() =>
-                utils.fastMerge(target, source, {
-                    shouldRemoveNestedNulls: true,
-                }),
-            );
+            await measureFunction(() => utils.fastMerge(target, source));
         });
     });
 
     describe('formatActionName', () => {
         test('one call', async () => {
             await measureFunction(() => utils.formatActionName(Onyx.METHOD.SET, ONYXKEYS.COLLECTION.TEST_KEY));
-        });
-    });
-
-    describe('removeNestedNullValues', () => {
-        test('one call', async () => {
-            const reportAction = createRandomReportAction(0);
-            reportAction.actorAccountID = null;
-            reportAction.person.push(null);
-            reportAction.message[0].style = null;
-            reportAction.originalMessage.whisperedTo = null;
-            reportAction.lastModified = null;
-
-            await measureFunction(() => utils.removeNestedNullValues(reportAction));
         });
     });
 

--- a/tests/unit/fastMergeTest.ts
+++ b/tests/unit/fastMergeTest.ts
@@ -27,15 +27,6 @@ const testObjectWithNullishValues: DeepObject = {
     },
 };
 
-const testObjectWithNullValuesRemoved: DeepObject = {
-    b: {
-        c: {
-            h: 'h',
-        },
-        d: {},
-    },
-};
-
 const testMergeChanges: DeepObject[] = [
     {
         b: {
@@ -78,24 +69,7 @@ describe('fastMerge', () => {
     });
 
     describe('objects', () => {
-        it('should merge an object with another object and remove nested null values', () => {
-            const result = utils.fastMerge(testObject, testObjectWithNullishValues, {shouldRemoveNestedNulls: true});
-
-            expect(result.result).toEqual({
-                a: 'a',
-                b: {
-                    c: {
-                        h: 'h',
-                    },
-                    d: {
-                        f: 'f',
-                    },
-                    g: 'g',
-                },
-            });
-        });
-
-        it('should merge an object with another object and not remove nested null values', () => {
+        it('should merge an object with another object and keep nested null values', () => {
             const result = utils.fastMerge(testObject, testObjectWithNullishValues);
 
             expect(result.result).toEqual({
@@ -111,20 +85,6 @@ describe('fastMerge', () => {
                     g: 'g',
                 },
             });
-        });
-
-        it('should merge an object with an empty object and remove deeply nested null values', () => {
-            const result = utils.fastMerge({}, testObjectWithNullishValues, {
-                shouldRemoveNestedNulls: true,
-            });
-
-            expect(result.result).toEqual(testObjectWithNullValuesRemoved);
-        });
-
-        it('should remove null values by merging two identical objects with fastMerge', () => {
-            const result = utils.removeNestedNullValues(testObjectWithNullishValues);
-
-            expect(result).toEqual(testObjectWithNullValuesRemoved);
         });
 
         it('should replace Date objects', () => {
@@ -143,7 +103,6 @@ describe('fastMerge', () => {
 
         it('should add the "ONYX_INTERNALS__REPLACE_OBJECT_MARK" flag to the merged object when the change is set to null and "objectRemovalMode" is set to "mark"', () => {
             const result = utils.fastMerge(testMergeChanges[1], testMergeChanges[0], {
-                shouldRemoveNestedNulls: true,
                 objectRemovalMode: 'mark',
             });
 
@@ -172,7 +131,6 @@ describe('fastMerge', () => {
                     },
                 },
                 {
-                    shouldRemoveNestedNulls: true,
                     objectRemovalMode: 'replace',
                 },
             );

--- a/tests/unit/onyxCacheTest.tsx
+++ b/tests/unit/onyxCacheTest.tsx
@@ -352,13 +352,13 @@ describe('Onyx', () => {
                 expect(() => cache.merge({})).not.toThrow();
             });
 
-            it('Should remove `null` values when merging', () => {
+            it('Should keep `null` values when merging', () => {
                 cache.set('mockKey', {ID: 5});
                 cache.set('mockNullKey', null);
 
                 cache.merge({mockKey: null});
 
-                expect(cache.get('mockKey')).toEqual(undefined);
+                expect(cache.get('mockKey')).toEqual(null);
                 expect(cache.get('mockNullKey')).toEqual(undefined);
             });
         });

--- a/tests/unit/onyxTest.ts
+++ b/tests/unit/onyxTest.ts
@@ -327,7 +327,7 @@ describe('Onyx', () => {
         });
     });
 
-    it('should remove keys that are set to null when merging', () => {
+    it('should preserve null values when merging', () => {
         let testKeyValue: unknown;
 
         connection = Onyx.connect({
@@ -368,7 +368,9 @@ describe('Onyx', () => {
                 expect(testKeyValue).toEqual({
                     test1: {
                         test2: 'test2',
-                        test3: {},
+                        test3: {
+                            test4: null,
+                        },
                     },
                 });
 
@@ -379,12 +381,12 @@ describe('Onyx', () => {
                 });
             })
             .then(() => {
-                expect(testKeyValue).toEqual({test1: {test2: 'test2'}});
+                expect(testKeyValue).toEqual({test1: {test2: 'test2', test3: null}});
 
                 return Onyx.merge(ONYX_KEYS.TEST_KEY, {test1: null});
             })
             .then(() => {
-                expect(testKeyValue).toEqual({});
+                expect(testKeyValue).toEqual({test1: null});
             });
     });
 
@@ -1343,7 +1345,7 @@ describe('Onyx', () => {
             });
     });
 
-    it("should not set null values in Onyx.merge, when the key doesn't exist yet", () => {
+    it("should preserve null values in Onyx.merge, when the key doesn't exist yet", () => {
         let testKeyValue: unknown;
 
         connection = Onyx.connect({
@@ -1365,6 +1367,7 @@ describe('Onyx', () => {
                 waypoints: {
                     1: 'Home',
                     2: 'Work',
+                    3: null,
                 },
             });
         });
@@ -1402,7 +1405,7 @@ describe('Onyx', () => {
             });
     });
 
-    it('mergeCollection should omit nested null values', () => {
+    it('mergeCollection should preserve nested null values', () => {
         let result: OnyxCollection<unknown>;
 
         const routineRoute = `${ONYX_KEYS.COLLECTION.TEST_KEY}routine`;
@@ -1443,6 +1446,7 @@ describe('Onyx', () => {
                     waypoints: {
                         1: 'Home',
                         2: 'Beach',
+                        3: null,
                     },
                 },
             });
@@ -2616,7 +2620,7 @@ describe('Onyx', () => {
             });
         });
 
-        it('should remove a deeply nested null when merging an existing key', () => {
+        it('should preserve a deeply nested null when merging an existing key', () => {
             let result: unknown;
 
             connection = Onyx.connect({
@@ -2650,6 +2654,7 @@ describe('Onyx', () => {
                         waypoints: {
                             1: 'Home',
                             2: 'Work',
+                            3: null,
                         },
                     });
                 });


### PR DESCRIPTION
Deletes removeNestedNullValues() entirely and strips shouldRemoveNestedNulls from fastMerge() and all call sites. Payloads are now written to storage as-is, recovering multiple seconds of JS thread time per session on heavy accounts without meaningful storage impact.

<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
GH_LINK

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Manual Tests
<!---
Each set of changes should be tested against the Expensify/App repo on all platforms to verify it does not break our staging App.
--->

### Author Checklist

- [ ] I linked the correct issue in the `### Related Issues` section above
- [ ] I wrote clear testing steps that cover the changes made in this PR
    - [ ] I added steps for local testing in the `Tests` section
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android / native
    - [ ] Android / Chrome
    - [ ] iOS / native
    - [ ] iOS / Safari
    - [ ] MacOS / Chrome / Safari
    - [ ] MacOS / Desktop
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [ ] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [ ] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [ ] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [ ] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [ ] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [ ] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [ ] I verified that if a function's arguments changed that all usages have also been updated correctly
- [ ] If a new component is created I verified that:
    - [ ] A similar component doesn't exist in the codebase
    - [ ] All props are defined accurately and each prop has a `/** comment above it */`
    - [ ] The file is named correctly
    - [ ] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [ ] The only data being stored in the state is data necessary for rendering and nothing else
    - [ ] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [ ] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [ ] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [ ] All JSX used for rendering exists in the render method
    - [ ] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [ ] If any new file was added I verified that:
    - [ ] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [ ] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
