### PR TITLE
fix: re-check cache after storage read in get() to handle concurrent writes

### DIFF
--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -290,6 +290,12 @@ function get<TKey extends OnyxKey, TValue extends OnyxValue<TKey>>(key: TKey): P
                 }
             }
 
+            // Prefer cache over stale storage if a concurrent write populated it during the read.
+            const cachedValue = cache.get(key) as TValue;
+            if (cachedValue !== undefined) {
+                return cachedValue;
+            }
+
             if (val === undefined) {
                 cache.addNullishStorageKey(key);
                 return undefined;

--- a/tests/unit/onyxTest.ts
+++ b/tests/unit/onyxTest.ts
@@ -3477,3 +3477,56 @@ describe('RAM-only keys should not read from storage', () => {
         Onyx.disconnect(connection);
     });
 });
+
+describe('get() should prefer cache over stale storage', () => {
+    let cache: typeof OnyxCache;
+
+    beforeEach(() => {
+        Object.assign(OnyxUtils.getDeferredInitTask(), createDeferredTask());
+        cache = require('../../lib/OnyxCache').default;
+        Onyx.init({keys: ONYX_KEYS});
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+        return Onyx.clear();
+    });
+
+    it('should preserve data from Onyx.update when a concurrent Onyx.merge fires before cache is written', async () => {
+        const member1 = `${ONYX_KEYS.COLLECTION.TEST_KEY}1`;
+        const member2 = `${ONYX_KEYS.COLLECTION.TEST_KEY}2`;
+
+        // Delay getItem for member1 to simulate slow Native storage (returns null before the write lands)
+        const getItemMock = StorageMock.getItem as jest.Mock;
+        const originalGetItem = getItemMock.getMockImplementation()!;
+        getItemMock.mockImplementation((key: OnyxKey) => {
+            if (key === member1) {
+                return new Promise<undefined>((resolve) => {
+                    setTimeout(() => resolve(undefined), 50);
+                });
+            }
+            return originalGetItem(key);
+        });
+
+        // 2+ collection keys get batched into mergeCollectionWithPatches (deferred cache write)
+        const updatePromise = Onyx.update([
+            {onyxMethod: Onyx.METHOD.MERGE, key: member1, value: {isOptimistic: true, name: 'first'}},
+            {onyxMethod: Onyx.METHOD.MERGE, key: member2, value: {isOptimistic: true, name: 'second'}},
+        ]);
+
+        // Concurrent merge fires before cache write — its get() hits the delayed storage mock
+        const mergePromise = Onyx.merge(member1, {lastVisitTime: '2025-01-01'});
+
+        await act(async () => {
+            await updatePromise;
+            await mergePromise;
+            await new Promise<void>((resolve) => {
+                setTimeout(resolve, 100);
+            });
+        });
+
+        const value = cache.get(member1);
+        expect(value).toHaveProperty('isOptimistic', true);
+        expect(value).toHaveProperty('lastVisitTime', '2025-01-01');
+    });
+});


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

`mergeCollectionWithPatches` is the only Onyx write operation that defers its cache write to an async `.then()` chain. All other operations (`setWithRetry`, `applyMerge`, `multiSetWithRetry`) update cache synchronously. When `Onyx.update()` batches 2+ collection keys into `mergeCollectionWithPatches`, a concurrent `Onyx.merge()` on the same key can call `get()` before the cache write completes. `get()` falls back to `Storage.getItem()`, which returns null on Native (SQLite is slower than the deferred cache write). The merge then overwrites cache with the stale result, destroying fields set by the original update.

This affects any optimistic data written via `Onyx.update()` that shares a collection prefix with other keys in the same update batch. In the App, it manifests as `isOptimisticReport: true` being destroyed from report metadata when `updateLastVisitTime` fires concurrently.

The fix adds a cache re-check in `get()` after the async storage read resolves. If a concurrent operation populated the cache while storage was in-flight, the fresher cache value is used instead of the stale storage result.

Web is unaffected because IndexedDB completes the storage write before the `getItem` resolves, so storage returns the correct value. The race window exists on both platforms but only causes data loss on Native.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
$ https://github.com/Expensify/App/issues/83779

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

Added a test in `onyxTest.ts` that reproduces the race condition by mocking `Storage.getItem` with a 50ms delay for the target key (simulating slow Native SQLite). The test calls `Onyx.update` with 2+ collection keys followed by a concurrent `Onyx.merge` on the same key. Without the fix, the merged result loses the original fields. With the fix, both fields are preserved.

### Manual Tests
<!---
Each set of changes should be tested against the Expensify/App repo on all platforms to verify it does not break our staging App.
--->

Prerequisite: Turn on "Simulate failing network requests"
 
1. Open Expensify App
2. Go to Inbox and tap FAB
3. Tap Create Expense enter amount
4. On confirmation Page choose a user you never chatted or send an expense before
5. Create the Expense, and The chat creation/expense submission should be failed.
6. Tap the create chat error clear button
7. Verify that the User is redirected to the concierge chat

### Author Checklist

- [x] I linked the correct issue in the `### Related Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/5ff8acd6-3323-4df7-a7cb-5adb5cabc53b

</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/user-attachments/assets/b0c5e94c-5ece-45e2-97bf-d0d3b4ef4401

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/9748e676-e75d-41d1-a996-792fcae24aca

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/a829a27e-f222-485a-b2a0-d7960c33c2cf

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/6727b0e2-dd69-45cf-9ae9-bf07923d16c6

</details>