### PR TITLE
[HOLD] feat: add retry backoff for connection errors in retryOperation

### DIFF
--- a/API-INTERNAL.md
+++ b/API-INTERNAL.md
@@ -78,6 +78,14 @@ If the requested key is a collection, it will return an object with all the coll
 <dt><a href="#remove">remove()</a></dt>
 <dd><p>Remove a key from Onyx and update the subscribers</p>
 </dd>
+<dt><a href="#wait">wait()</a></dt>
+<dd><p>Returns a promise that resolves after the given number of milliseconds.</p>
+</dd>
+<dt><a href="#getRetryDelay">getRetryDelay()</a></dt>
+<dd><p>Calculates exponential backoff delay with jitter for a given retry attempt.
+Formula: baseDelay * 2^attempt ± jitter
+Attempt 0: ~100ms, Attempt 1: ~200ms, ..., Attempt 4: ~1600ms</p>
+</dd>
 <dt><a href="#retryOperation">retryOperation()</a></dt>
 <dd><p>Handles storage operation failures based on the error type:</p>
 <ul>
@@ -336,6 +344,20 @@ Gets the data for a given an array of matching keys, combines them into an objec
 
 ## remove()
 Remove a key from Onyx and update the subscribers
+
+**Kind**: global function  
+<a name="wait"></a>
+
+## wait()
+Returns a promise that resolves after the given number of milliseconds.
+
+**Kind**: global function  
+<a name="getRetryDelay"></a>
+
+## getRetryDelay()
+Calculates exponential backoff delay with jitter for a given retry attempt.
+Formula: baseDelay * 2^attempt ± jitter
+Attempt 0: ~100ms, Attempt 1: ~200ms, ..., Attempt 4: ~1600ms
 
 **Kind**: global function  
 <a name="retryOperation"></a>

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -838,8 +838,15 @@ function retryOperation<TMethod extends RetriableOnyxOperation>(error: Error, on
     }
 
     if (!isStorageCapacityError) {
+        const delay = getRetryDelay(currentRetryAttempt);
+        const isConnectionError = CONNECTION_ERRORS.some((connError) => errorName?.includes(connError) || errorMessage?.includes(connError));
+
+        if (isConnectionError) {
+            Logger.logInfo(`Connection error detected, retrying with backoff (${delay}ms). Error: ${error}. onyxMethod: ${onyxMethod.name}. retryAttempt: ${nextRetryAttempt}/${MAX_STORAGE_OPERATION_RETRY_ATTEMPTS}`);
+        }
+
         // @ts-expect-error No overload matches this call.
-        return onyxMethod(defaultParams, nextRetryAttempt);
+        return wait(delay).then(() => onyxMethod(defaultParams, nextRetryAttempt));
     }
 
     // Find the least recently accessed evictable key that we can remove

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -849,14 +849,13 @@ function retryOperation<TMethod extends RetriableOnyxOperation>(error: Error, on
             Logger.logInfo(`Connection error detected, retrying with backoff (${delay}ms). Error: ${error}. onyxMethod: ${onyxMethod.name}. retryAttempt: ${nextRetryAttempt}/${MAX_STORAGE_OPERATION_RETRY_ATTEMPTS}`);
         }
 
-        return wait(delay).then(() =>
-            // @ts-expect-error No overload matches this call.
-            onyxMethod(defaultParams, nextRetryAttempt).then(() => {
-                if (isConnectionError) {
-                    Logger.logInfo(`Connection error recovered after backoff on attempt ${nextRetryAttempt}/${MAX_STORAGE_OPERATION_RETRY_ATTEMPTS}. onyxMethod: ${onyxMethod.name}.`);
-                }
-            }),
-        );
+        // @ts-expect-error No overload matches this call.
+        return wait(delay).then(() => Promise.resolve(onyxMethod(defaultParams, nextRetryAttempt)).then(() => {
+            if (!isConnectionError) {
+                return;
+            }
+            Logger.logInfo(`Connection error recovered after backoff on attempt ${nextRetryAttempt}/${MAX_STORAGE_OPERATION_RETRY_ATTEMPTS}. onyxMethod: ${onyxMethod.name}.`);
+        }));
     }
 
     // Find the least recently accessed evictable key that we can remove

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -64,6 +64,24 @@ const STORAGE_ERRORS = [...IDB_STORAGE_ERRORS, ...SQLITE_STORAGE_ERRORS];
 // Max number of retries for failed storage operations
 const MAX_STORAGE_OPERATION_RETRY_ATTEMPTS = 5;
 
+// Connection/state errors where the DB needs time to recover — backoff helps, eviction does not
+const IDB_CONNECTION_ERRORS = [
+    'internal error opening backing store', // Chrome/Edge: corrupted IDB state
+    'connection to indexed database server lost', // Safari: IDB connection dropped
+    'the database connection is closing', // Cross-browser: DB closing during write
+] as const;
+
+const SQLITE_CONNECTION_ERRORS = [
+    'disk i/o error', // Native: filesystem/device stress
+    'database is locked', // Native: concurrent access contention
+] as const;
+
+const CONNECTION_ERRORS = [...IDB_CONNECTION_ERRORS, ...SQLITE_CONNECTION_ERRORS];
+
+// Retry backoff configuration
+const RETRY_BASE_DELAY_MS = 100;
+const RETRY_JITTER_FACTOR = 0.25;
+
 type OnyxMethod = ValueOf<typeof METHOD>;
 
 // Key/value store of Onyx key and arrays of values to merge
@@ -761,6 +779,26 @@ function remove<TKey extends OnyxKey>(key: TKey, isProcessingCollectionUpdate?: 
     }
 
     return Storage.removeItem(key).then(() => undefined);
+}
+
+/**
+ * Returns a promise that resolves after the given number of milliseconds.
+ */
+function wait(ms: number): Promise<void> {
+    return new Promise((resolve) => {
+        setTimeout(resolve, ms);
+    });
+}
+
+/**
+ * Calculates exponential backoff delay with jitter for a given retry attempt.
+ * Formula: baseDelay * 2^attempt ± jitter
+ * Attempt 0: ~100ms, Attempt 1: ~200ms, ..., Attempt 4: ~1600ms
+ */
+function getRetryDelay(attempt: number): number {
+    const baseDelay = RETRY_BASE_DELAY_MS * 2 ** attempt;
+    const jitter = baseDelay * RETRY_JITTER_FACTOR * (2 * Math.random() - 1);
+    return Math.round(baseDelay + jitter);
 }
 
 function reportStorageQuota(error?: Error): Promise<void> {

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -846,16 +846,20 @@ function retryOperation<TMethod extends RetriableOnyxOperation>(error: Error, on
         const delay = getRetryDelay(currentRetryAttempt);
 
         if (isConnectionError) {
-            Logger.logInfo(`Connection error detected, retrying with backoff (${delay}ms). Error: ${error}. onyxMethod: ${onyxMethod.name}. retryAttempt: ${nextRetryAttempt}/${MAX_STORAGE_OPERATION_RETRY_ATTEMPTS}`);
+            Logger.logInfo(
+                `Connection error detected, retrying with backoff (${delay}ms). Error: ${error}. onyxMethod: ${onyxMethod.name}. retryAttempt: ${nextRetryAttempt}/${MAX_STORAGE_OPERATION_RETRY_ATTEMPTS}`,
+            );
         }
 
         // @ts-expect-error No overload matches this call.
-        return wait(delay).then(() => Promise.resolve(onyxMethod(defaultParams, nextRetryAttempt)).then(() => {
-            if (!isConnectionError) {
-                return;
-            }
-            Logger.logInfo(`Connection error recovered after backoff on attempt ${nextRetryAttempt}/${MAX_STORAGE_OPERATION_RETRY_ATTEMPTS}. onyxMethod: ${onyxMethod.name}.`);
-        }));
+        return wait(delay).then(() =>
+            Promise.resolve(onyxMethod(defaultParams, nextRetryAttempt)).then(() => {
+                if (!isConnectionError) {
+                    return;
+                }
+                Logger.logInfo(`Connection error recovered after backoff on attempt ${nextRetryAttempt}/${MAX_STORAGE_OPERATION_RETRY_ATTEMPTS}. onyxMethod: ${onyxMethod.name}.`);
+            }),
+        );
     }
 
     // Find the least recently accessed evictable key that we can remove

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -798,7 +798,7 @@ function wait(ms: number): Promise<void> {
 function getRetryDelay(attempt: number): number {
     const baseDelay = RETRY_BASE_DELAY_MS * 2 ** attempt;
     const jitter = baseDelay * RETRY_JITTER_FACTOR * (2 * Math.random() - 1);
-    return Math.round(baseDelay + jitter);
+    return Math.max(0, Math.round(baseDelay + jitter));
 }
 
 function reportStorageQuota(error?: Error): Promise<void> {

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -851,8 +851,8 @@ function retryOperation<TMethod extends RetriableOnyxOperation>(error: Error, on
             );
         }
 
-        // @ts-expect-error No overload matches this call.
         return wait(delay).then(() =>
+            // @ts-expect-error No overload matches this call.
             Promise.resolve(onyxMethod(defaultParams, nextRetryAttempt)).then(() => {
                 if (!isConnectionError) {
                     return;

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -831,22 +831,32 @@ function retryOperation<TMethod extends RetriableOnyxOperation>(error: Error, on
     const errorMessage = error?.message?.toLowerCase?.();
     const errorName = error?.name?.toLowerCase?.();
     const isStorageCapacityError = STORAGE_ERRORS.some((storageError) => errorName?.includes(storageError) || errorMessage?.includes(storageError));
+    const isConnectionError = CONNECTION_ERRORS.some((connError) => errorName?.includes(connError) || errorMessage?.includes(connError));
 
     if (nextRetryAttempt > MAX_STORAGE_OPERATION_RETRY_ATTEMPTS) {
-        Logger.logAlert(`Storage operation failed after 5 retries. Error: ${error}. onyxMethod: ${onyxMethod.name}.`);
+        if (isConnectionError) {
+            Logger.logAlert(`Connection error exhausted all retries with backoff. Error: ${error}. onyxMethod: ${onyxMethod.name}.`);
+        } else {
+            Logger.logAlert(`Storage operation failed after 5 retries. Error: ${error}. onyxMethod: ${onyxMethod.name}.`);
+        }
         return Promise.resolve();
     }
 
     if (!isStorageCapacityError) {
         const delay = getRetryDelay(currentRetryAttempt);
-        const isConnectionError = CONNECTION_ERRORS.some((connError) => errorName?.includes(connError) || errorMessage?.includes(connError));
 
         if (isConnectionError) {
             Logger.logInfo(`Connection error detected, retrying with backoff (${delay}ms). Error: ${error}. onyxMethod: ${onyxMethod.name}. retryAttempt: ${nextRetryAttempt}/${MAX_STORAGE_OPERATION_RETRY_ATTEMPTS}`);
         }
 
-        // @ts-expect-error No overload matches this call.
-        return wait(delay).then(() => onyxMethod(defaultParams, nextRetryAttempt));
+        return wait(delay).then(() =>
+            // @ts-expect-error No overload matches this call.
+            onyxMethod(defaultParams, nextRetryAttempt).then(() => {
+                if (isConnectionError) {
+                    Logger.logInfo(`Connection error recovered after backoff on attempt ${nextRetryAttempt}/${MAX_STORAGE_OPERATION_RETRY_ATTEMPTS}. onyxMethod: ${onyxMethod.name}.`);
+                }
+            }),
+        );
     }
 
     // Find the least recently accessed evictable key that we can remove

--- a/tests/unit/onyxUtilsTest.ts
+++ b/tests/unit/onyxUtilsTest.ts
@@ -578,6 +578,40 @@ describe('OnyxUtils', () => {
             }
         });
 
+        it('should log recovery when connection error succeeds after backoff', async () => {
+            jest.useFakeTimers();
+            try {
+                const logInfoSpy = jest.spyOn(Logger, 'logInfo');
+                const connectionError = new Error('Connection to Indexed Database server lost. Refresh the page to try again');
+                StorageMock.setItem = jest.fn(StorageMock.setItem).mockRejectedValueOnce(connectionError).mockImplementation(StorageMock.setItem);
+
+                const setPromise = Onyx.set(ONYXKEYS.TEST_KEY, {test: 'data'});
+                await jest.runAllTimersAsync();
+                await setPromise;
+
+                expect(logInfoSpy).toHaveBeenCalledWith(expect.stringContaining('Connection error recovered after backoff on attempt'));
+            } finally {
+                jest.useRealTimers();
+            }
+        });
+
+        it('should log connection-specific exhaustion message when all retries fail', async () => {
+            jest.useFakeTimers();
+            try {
+                const logAlertSpy = jest.spyOn(Logger, 'logAlert');
+                const connectionError = new Error('Connection to Indexed Database server lost. Refresh the page to try again');
+                StorageMock.setItem = jest.fn().mockRejectedValue(connectionError);
+
+                const setPromise = Onyx.set(ONYXKEYS.TEST_KEY, {test: 'data'});
+                await jest.runAllTimersAsync();
+                await setPromise;
+
+                expect(logAlertSpy).toHaveBeenCalledWith(expect.stringContaining('Connection error exhausted all retries with backoff'));
+            } finally {
+                jest.useRealTimers();
+            }
+        });
+
         it('should NOT apply backoff delay for capacity errors (immediate retry with eviction)', async () => {
             const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
             StorageMock.setItem = jest.fn().mockRejectedValue(diskFullError);

--- a/tests/unit/onyxUtilsTest.ts
+++ b/tests/unit/onyxUtilsTest.ts
@@ -538,9 +538,7 @@ describe('OnyxUtils', () => {
                 await setPromise;
 
                 // Filter setTimeout calls to only those from our wait() helper (delay > 0)
-                const backoffDelays = setTimeoutSpy.mock.calls
-                    .map((call) => call[1])
-                    .filter((delay): delay is number => typeof delay === 'number' && delay > 0);
+                const backoffDelays = setTimeoutSpy.mock.calls.map((call) => call[1]).filter((delay): delay is number => typeof delay === 'number' && delay > 0);
 
                 // Should have 5 backoff delays (one before each of the 5 retries, attempts 0-4)
                 // The 6th call to retryOperation (attempt 5) hits the MAX check and resolves without waiting
@@ -619,9 +617,7 @@ describe('OnyxUtils', () => {
             await Onyx.set(ONYXKEYS.TEST_KEY, {test: 'data'});
 
             // Capacity errors should not trigger any backoff delays (delay > 0)
-            const backoffDelays = setTimeoutSpy.mock.calls
-                .map((call) => call[1])
-                .filter((delay): delay is number => typeof delay === 'number' && delay > 0);
+            const backoffDelays = setTimeoutSpy.mock.calls.map((call) => call[1]).filter((delay): delay is number => typeof delay === 'number' && delay > 0);
 
             expect(backoffDelays).toHaveLength(0);
             setTimeoutSpy.mockRestore();

--- a/tests/unit/onyxUtilsTest.ts
+++ b/tests/unit/onyxUtilsTest.ts
@@ -432,21 +432,35 @@ describe('OnyxUtils', () => {
         const diskFullError = new Error('database or disk is full');
 
         it('should retry only one time if the operation is firstly failed and then passed', async () => {
-            StorageMock.setItem = jest.fn(StorageMock.setItem).mockRejectedValueOnce(genericError).mockImplementation(StorageMock.setItem);
+            jest.useFakeTimers();
+            try {
+                StorageMock.setItem = jest.fn(StorageMock.setItem).mockRejectedValueOnce(genericError).mockImplementation(StorageMock.setItem);
 
-            await Onyx.set(ONYXKEYS.TEST_KEY, {test: 'data'});
+                const setPromise = Onyx.set(ONYXKEYS.TEST_KEY, {test: 'data'});
+                await jest.runAllTimersAsync();
+                await setPromise;
 
-            // Should be called once, since Storage.setItem if failed only once
-            expect(retryOperationSpy).toHaveBeenCalledTimes(1);
+                // Should be called once, since Storage.setItem failed only once
+                expect(retryOperationSpy).toHaveBeenCalledTimes(1);
+            } finally {
+                jest.useRealTimers();
+            }
         });
 
         it('should stop retrying after MAX_STORAGE_OPERATION_RETRY_ATTEMPTS retries for failing operation', async () => {
-            StorageMock.setItem = jest.fn().mockRejectedValue(genericError);
+            jest.useFakeTimers();
+            try {
+                StorageMock.setItem = jest.fn().mockRejectedValue(genericError);
 
-            await Onyx.set(ONYXKEYS.TEST_KEY, {test: 'data'});
+                const setPromise = Onyx.set(ONYXKEYS.TEST_KEY, {test: 'data'});
+                await jest.runAllTimersAsync();
+                await setPromise;
 
-            // Should be called 6 times: initial attempt + 5 retries (MAX_STORAGE_OPERATION_RETRY_ATTEMPTS)
-            expect(retryOperationSpy).toHaveBeenCalledTimes(6);
+                // Should be called 6 times: initial attempt + 5 retries (MAX_STORAGE_OPERATION_RETRY_ATTEMPTS)
+                expect(retryOperationSpy).toHaveBeenCalledTimes(6);
+            } finally {
+                jest.useRealTimers();
+            }
         });
 
         it("should throw error for if operation failed with \"Failed to execute 'put' on 'IDBObjectStore': invalid data\" error", async () => {
@@ -511,6 +525,72 @@ describe('OnyxUtils', () => {
 
             await OnyxUtils.remove(evictableKey);
             expect(OnyxCache.getKeyForEviction()).toBeUndefined();
+        });
+
+        it('should apply exponential backoff delay for non-capacity errors', async () => {
+            jest.useFakeTimers();
+            try {
+                const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+                StorageMock.setItem = jest.fn().mockRejectedValue(genericError);
+
+                const setPromise = Onyx.set(ONYXKEYS.TEST_KEY, {test: 'data'});
+                await jest.runAllTimersAsync();
+                await setPromise;
+
+                // Filter setTimeout calls to only those from our wait() helper (delay > 0)
+                const backoffDelays = setTimeoutSpy.mock.calls
+                    .map((call) => call[1])
+                    .filter((delay): delay is number => typeof delay === 'number' && delay > 0);
+
+                // Should have 5 backoff delays (one before each of the 5 retries, attempts 0-4)
+                // The 6th call to retryOperation (attempt 5) hits the MAX check and resolves without waiting
+                expect(backoffDelays).toHaveLength(5);
+
+                // Verify exponential growth pattern: each delay should be roughly double the previous
+                // With ±25% jitter, delay[n+1] / delay[n] should be between ~1.2 and ~3.3
+                for (let i = 1; i < backoffDelays.length; i++) {
+                    const ratio = backoffDelays[i] / backoffDelays[i - 1];
+                    expect(ratio).toBeGreaterThan(1.0);
+                    expect(ratio).toBeLessThan(4.0);
+                }
+
+                setTimeoutSpy.mockRestore();
+            } finally {
+                jest.useRealTimers();
+            }
+        });
+
+        it('should log connection error with backoff delay info', async () => {
+            jest.useFakeTimers();
+            try {
+                const logInfoSpy = jest.spyOn(Logger, 'logInfo');
+                const connectionError = new Error('Connection to Indexed Database server lost. Refresh the page to try again');
+                StorageMock.setItem = jest.fn(StorageMock.setItem).mockRejectedValueOnce(connectionError).mockImplementation(StorageMock.setItem);
+
+                const setPromise = Onyx.set(ONYXKEYS.TEST_KEY, {test: 'data'});
+                await jest.runAllTimersAsync();
+                await setPromise;
+
+                expect(logInfoSpy).toHaveBeenCalledWith(expect.stringContaining('Connection error detected, retrying with backoff'));
+                expect(logInfoSpy).toHaveBeenCalledWith(expect.stringContaining('Connection to Indexed Database server lost'));
+            } finally {
+                jest.useRealTimers();
+            }
+        });
+
+        it('should NOT apply backoff delay for capacity errors (immediate retry with eviction)', async () => {
+            const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+            StorageMock.setItem = jest.fn().mockRejectedValue(diskFullError);
+
+            await Onyx.set(ONYXKEYS.TEST_KEY, {test: 'data'});
+
+            // Capacity errors should not trigger any backoff delays (delay > 0)
+            const backoffDelays = setTimeoutSpy.mock.calls
+                .map((call) => call[1])
+                .filter((delay): delay is number => typeof delay === 'number' && delay > 0);
+
+            expect(backoffDelays).toHaveLength(0);
+            setTimeoutSpy.mockRestore();
         });
     });
 


### PR DESCRIPTION
### Details

Add exponential backoff with jitter to `OnyxUtils.retryOperation` for non-capacity storage errors, framed as an instrumented experiment to determine the right mitigation strategy.

**Context:** Connection-class errors — Chromium backing store failures (26.3%), WebKit connection drops (19.0%), and closing-database errors (6.4%) — account for 51.7% of all storage failures ([investigation](https://github.com/Expensify/App/issues/85252#issuecomment-4224034362)). Analysis of 7-day production logs via VictoriaLogs shows:

- **0% recovery rate** across 5 immediate retries — all attempts complete within the same millisecond
- **100% retry exhaustion** — 67,404 out of ~67,400 initial failures exhaust all retries
- **Users continue writing successfully** to other keys in the same session (e.g. one user: 8,920 exhaustions alongside 28,206 successful Onyx ops)
- **IDB enters a degraded state** rather than failing completely — successful writes interleaved with failures in the same request

We have no data on whether introducing a delay (100ms-1600ms) would allow recovery. This PR adds backoff as a low-risk experiment to collect that data.

**Changes:**

- `lib/OnyxUtils.ts`: Added `CONNECTION_ERRORS` constants (IDB + SQLite), backoff config (`RETRY_BASE_DELAY_MS=100`, `RETRY_JITTER_FACTOR=0.25`), `wait()`/`getRetryDelay()` helpers, wired backoff into non-capacity error branch of `retryOperation`
- Backoff schedule: `100ms → 200ms → 400ms → 800ms → 1600ms` (±25% jitter, ~3.1s total max)
- Capacity errors (QuotaExceeded, disk full) keep immediate retry with eviction — unchanged
- **Observability for experiment measurement:**
  - Connection errors log retry attempts with delay duration (`Connection error detected, retrying with backoff`)
  - Successful recovery after backoff is logged with attempt number (`Connection error recovered after backoff on attempt N/5`)
  - Connection error exhaustion gets a distinct log message from generic failures (`Connection error exhausted all retries with backoff`)

**Measurement plan ([discussion](https://github.com/Expensify/App/issues/87782#issuecomment-4354716399)):**

- **Recovery rate**: recovered / detected — core metric, baseline is 0%
- **Recovery distribution by attempt**: which delay tier recoveries happen on most
- **Timeline**: 1 week production data (~67k failures/week volume)
- **Rollback if**: recovery stays ~0%, any regression in Onyx op success rate, or unexpected latency
- **Success if**: recovery rate meaningfully above 0% → tune constants

**Next steps based on production data:**

- If recovery rate at 100-1600ms delays improves → tune constants
- If recovery rate remains ~0% → pivot to fail-fast (fewer retries + error propagation) or reconnection strategy (close/reopen IDB before retry)

### Related Issues

https://github.com/Expensify/App/issues/87782

### Automated Tests

Updated 2 existing retry tests to use fake timers (backoff delays require timer advancement). Added 5 new tests:

- `should apply exponential backoff delay for non-capacity errors` — verifies delay count and exponential growth pattern
- `should log connection error with backoff delay info` — verifies connection-specific log message
- `should log recovery when connection error succeeds after backoff` — verifies recovery log fires on successful retry
- `should log connection-specific exhaustion message when all retries fail` — verifies distinct exhaustion log for connection errors
- `should NOT apply backoff delay for capacity errors (immediate retry with eviction)` — verifies capacity errors remain immediate

All 439 tests pass.

### Manual Tests

1. Verify `npm run typecheck` passes
2. Verify `npm run lint` passes
3. Verify `npm test` passes (439/439)
4. Integrate with Expensify/App and verify storage operations still work correctly on all platforms

### Author Checklist

- [x] I linked the correct issue in the `### Related Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
  - [x] I added steps for local testing in the `Tests` section
  - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
  - [x] Android / native
  - [x] Android / Chrome
  - [x] iOS / native
  - [x] iOS / Safari
  - [x] MacOS / Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
  - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
  - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
  - [x] I verified that comments were added to code that is not self explanatory
  - [x] I verified that any new or modified comments were clear, correct English, and explained why the code was doing something instead of only explaining what the code was doing.
  - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named index.js. All platform-specific files are named for the platform the code supports as outlined in the README.
  - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

N/A — library-level change, no UI

</details>

<details>
<summary>Android: mWeb Chrome</summary>

N/A — library-level change, no UI

</details>

<details>
<summary>iOS: Native</summary>

N/A — library-level change, no UI

</details>

<details>
<summary>iOS: mWeb Safari</summary>

N/A — library-level change, no UI

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

N/A — library-level change, no UI

</details>
