### PR TITLE
[Structural Sharing] PR 5: Batched multiSetWithRetry notifications

### DIFF
--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -550,6 +550,16 @@ function keysChanged<TKey extends CollectionKeyBase>(
     const previousCollection = partialPreviousCollection ?? {};
     const changedMemberKeys = Object.keys(partialCollection ?? {});
 
+    // Add or remove the keys from the recentlyAccessedKeys list
+    for (const memberKey of changedMemberKeys) {
+        const value = partialCollection?.[memberKey];
+        if (value !== null && value !== undefined) {
+            cache.addLastAccessedKey(memberKey, false);
+        } else {
+            cache.removeLastAccessedKey(memberKey);
+        }
+    }
+
     // Use indexed lookup instead of scanning all subscribers.
     // We need subscribers for: (1) the collection key itself, and (2) individual changed member keys.
     const collectionSubscriberIDs = onyxKeyToSubscriptionIDs.get(collectionKey) ?? [];

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -1379,7 +1379,6 @@ function multiSetWithRetry(data: OnyxMultiSetInput, retryAttempt?: number): Prom
     // collection, `partial` holds the new values being set and `previous` holds the cached values
     // from before the set, which keysChanged() uses to skip subscribers whose value didn't change.
     const collectionBatches = new Map<string, {partial: Record<string, OnyxValue<OnyxKey>>; previous: Record<string, OnyxValue<OnyxKey>>}>();
-    const nonCollectionPairs: Array<[string, OnyxValue<OnyxKey>]> = [];
 
     for (const [key, value] of keyValuePairsToSet) {
         // When we use multiSet to set a key we want to clear the current delta changes from Onyx.merge that were queued
@@ -1403,9 +1402,11 @@ function multiSetWithRetry(data: OnyxMultiSetInput, retryAttempt?: number): Prom
             batch.partial[key] = value;
             batch.previous[key] = previousValue;
         } else {
-            // Non-collection keys are notified individually — no batching.
+            // Non-collection keys are notified inline (cache.set + keyChanged in iteration order)
+            // so re-entrant callbacks (e.g. Onyx.set inside a callback) see consistent cache
+            // and subscriber state, matching the original per-key notification semantics.
             cache.set(key, value);
-            nonCollectionPairs.push([key, value]);
+            keyChanged(key, value);
         }
     }
 
@@ -1413,11 +1414,6 @@ function multiSetWithRetry(data: OnyxMultiSetInput, retryAttempt?: number): Prom
     // keysChanged() internally decide which individual member subscribers need notification.
     for (const [collectionKey, batch] of collectionBatches) {
         keysChanged(collectionKey as CollectionKeyBase, batch.partial, batch.previous);
-    }
-
-    // Non-collection keys go through the regular per-key notification path.
-    for (const [key, value] of nonCollectionPairs) {
-        keyChanged(key, value);
     }
 
     const keyValuePairsToStore = keyValuePairsToSet.filter((keyValuePair) => {

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -588,12 +588,20 @@ function keysChanged<TKey extends CollectionKeyBase>(
                 continue;
             }
 
-            // Not using waitForCollectionCallback — notify per changed key
+            // Not using waitForCollectionCallback — notify per changed key.
+            // Re-check the subscription on each iteration because the callback may
+            // synchronously disconnect itself (removing it from callbackToStateMapping),
+            // in which case we must stop firing further callbacks for this subscriber.
             for (const dataKey of changedMemberKeys) {
+                const currentSubscriber = callbackToStateMapping[subID];
+                if (!currentSubscriber || typeof currentSubscriber.callback !== 'function') {
+                    break;
+                }
                 if (cachedCollection[dataKey] === previousCollection[dataKey]) {
                     continue;
                 }
-                subscriber.callback(cachedCollection[dataKey], dataKey);
+                const currentSubscriberCallback = currentSubscriber.callback as DefaultConnectCallback<TKey>;
+                currentSubscriberCallback(cachedCollection[dataKey], dataKey as TKey);
             }
         } catch (error) {
             Logger.logAlert(`[OnyxUtils.keysChanged] Subscriber callback threw an error for key '${collectionKey}': ${error}`);

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -1368,6 +1368,10 @@ function multiSetWithRetry(data: OnyxMultiSetInput, retryAttempt?: number): Prom
 
     const keyValuePairsToSet = OnyxUtils.prepareKeyValuePairsForStorage(newData, true);
 
+    // Group keys by collection for batched notification
+    const collectionBatches = new Map<string, {partial: Record<string, OnyxValue<OnyxKey>>; previous: Record<string, OnyxValue<OnyxKey>>}>();
+    const nonCollectionPairs: Array<[string, OnyxValue<OnyxKey>]> = [];
+
     for (const [key, value] of keyValuePairsToSet) {
         // When we use multiSet to set a key we want to clear the current delta changes from Onyx.merge that were queued
         // before the value was set. If Onyx.merge is currently reading the old value from storage, it will then not apply the changes.
@@ -1375,8 +1379,32 @@ function multiSetWithRetry(data: OnyxMultiSetInput, retryAttempt?: number): Prom
             delete OnyxUtils.getMergeQueue()[key];
         }
 
-        // Update cache and optimistically inform subscribers
-        cache.set(key, value);
+        const collectionKey = OnyxKeys.getCollectionKey(key);
+        if (collectionKey && OnyxKeys.isCollectionMemberKey(collectionKey, key)) {
+            // Capture the previous value before updating cache
+            const previousValue = cache.get(key);
+            cache.set(key, value);
+
+            let batch = collectionBatches.get(collectionKey);
+            if (!batch) {
+                batch = {partial: {}, previous: {}};
+                collectionBatches.set(collectionKey, batch);
+            }
+            batch.partial[key] = value;
+            batch.previous[key] = previousValue;
+        } else {
+            cache.set(key, value);
+            nonCollectionPairs.push([key, value]);
+        }
+    }
+
+    // Notify collection subscribers once per collection (batched)
+    for (const [collectionKey, batch] of collectionBatches) {
+        keysChanged(collectionKey as CollectionKeyBase, batch.partial, batch.previous);
+    }
+
+    // Notify non-collection key subscribers individually
+    for (const [key, value] of nonCollectionPairs) {
         keyChanged(key, value);
     }
 

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -1368,7 +1368,10 @@ function multiSetWithRetry(data: OnyxMultiSetInput, retryAttempt?: number): Prom
 
     const keyValuePairsToSet = OnyxUtils.prepareKeyValuePairsForStorage(newData, true);
 
-    // Group keys by collection for batched notification
+    // Group collection members by their parent collection key so each collection can be notified
+    // via a single batched keysChanged() call instead of one keyChanged() per member. For each
+    // collection, `partial` holds the new values being set and `previous` holds the cached values
+    // from before the set, which keysChanged() uses to skip subscribers whose value didn't change.
     const collectionBatches = new Map<string, {partial: Record<string, OnyxValue<OnyxKey>>; previous: Record<string, OnyxValue<OnyxKey>>}>();
     const nonCollectionPairs: Array<[string, OnyxValue<OnyxKey>]> = [];
 
@@ -1381,7 +1384,8 @@ function multiSetWithRetry(data: OnyxMultiSetInput, retryAttempt?: number): Prom
 
         const collectionKey = OnyxKeys.getCollectionKey(key);
         if (collectionKey && OnyxKeys.isCollectionMemberKey(collectionKey, key)) {
-            // Capture the previous value before updating cache
+            // Capture the previous cached value BEFORE calling cache.set() so keysChanged()
+            // can diff old vs new per-member.
             const previousValue = cache.get(key);
             cache.set(key, value);
 
@@ -1393,17 +1397,19 @@ function multiSetWithRetry(data: OnyxMultiSetInput, retryAttempt?: number): Prom
             batch.partial[key] = value;
             batch.previous[key] = previousValue;
         } else {
+            // Non-collection keys are notified individually — no batching.
             cache.set(key, value);
             nonCollectionPairs.push([key, value]);
         }
     }
 
-    // Notify collection subscribers once per collection (batched)
+    // One keysChanged() per collection — fires each collection-level subscriber once and lets
+    // keysChanged() internally decide which individual member subscribers need notification.
     for (const [collectionKey, batch] of collectionBatches) {
         keysChanged(collectionKey as CollectionKeyBase, batch.partial, batch.previous);
     }
 
-    // Notify non-collection key subscribers individually
+    // Non-collection keys go through the regular per-key notification path.
     for (const [key, value] of nonCollectionPairs) {
         keyChanged(key, value);
     }

--- a/tests/unit/onyxUtilsTest.ts
+++ b/tests/unit/onyxUtilsTest.ts
@@ -266,6 +266,175 @@ describe('OnyxUtils', () => {
         });
     });
 
+    describe('multiSetWithRetry', () => {
+        it('should fire collection-level callback only once per collection even with multiple members', async () => {
+            const collectionCallback = jest.fn();
+            const connection = Onyx.connect({
+                key: ONYXKEYS.COLLECTION.TEST_KEY,
+                callback: collectionCallback,
+                waitForCollectionCallback: true,
+                initWithStoredValues: false,
+            });
+
+            await waitForPromisesToResolve();
+            collectionCallback.mockClear();
+
+            // multiSet with 3 members of the same collection
+            await Onyx.multiSet({
+                [`${ONYXKEYS.COLLECTION.TEST_KEY}1`]: {id: 1},
+                [`${ONYXKEYS.COLLECTION.TEST_KEY}2`]: {id: 2},
+                [`${ONYXKEYS.COLLECTION.TEST_KEY}3`]: {id: 3},
+            });
+
+            // Should be called only ONCE with the batched collection (not 3 times)
+            expect(collectionCallback).toHaveBeenCalledTimes(1);
+            const [collection] = collectionCallback.mock.calls[0];
+            expect(collection[`${ONYXKEYS.COLLECTION.TEST_KEY}1`]).toEqual({id: 1});
+            expect(collection[`${ONYXKEYS.COLLECTION.TEST_KEY}2`]).toEqual({id: 2});
+            expect(collection[`${ONYXKEYS.COLLECTION.TEST_KEY}3`]).toEqual({id: 3});
+
+            Onyx.disconnect(connection);
+        });
+
+        it('should fire individual member-key subscribers once per key', async () => {
+            const spy1 = jest.fn();
+            const spy2 = jest.fn();
+            const spy3 = jest.fn();
+
+            const conn1 = Onyx.connect({key: `${ONYXKEYS.COLLECTION.TEST_KEY}1`, callback: spy1, initWithStoredValues: false});
+            const conn2 = Onyx.connect({key: `${ONYXKEYS.COLLECTION.TEST_KEY}2`, callback: spy2, initWithStoredValues: false});
+            const conn3 = Onyx.connect({key: `${ONYXKEYS.COLLECTION.TEST_KEY}3`, callback: spy3, initWithStoredValues: false});
+            await waitForPromisesToResolve();
+            spy1.mockClear();
+            spy2.mockClear();
+            spy3.mockClear();
+
+            await Onyx.multiSet({
+                [`${ONYXKEYS.COLLECTION.TEST_KEY}1`]: {id: 1},
+                [`${ONYXKEYS.COLLECTION.TEST_KEY}2`]: {id: 2},
+                [`${ONYXKEYS.COLLECTION.TEST_KEY}3`]: {id: 3},
+            });
+
+            expect(spy1).toHaveBeenCalledTimes(1);
+            expect(spy1).toHaveBeenCalledWith({id: 1}, `${ONYXKEYS.COLLECTION.TEST_KEY}1`);
+            expect(spy2).toHaveBeenCalledTimes(1);
+            expect(spy2).toHaveBeenCalledWith({id: 2}, `${ONYXKEYS.COLLECTION.TEST_KEY}2`);
+            expect(spy3).toHaveBeenCalledTimes(1);
+            expect(spy3).toHaveBeenCalledWith({id: 3}, `${ONYXKEYS.COLLECTION.TEST_KEY}3`);
+
+            Onyx.disconnect(conn1);
+            Onyx.disconnect(conn2);
+            Onyx.disconnect(conn3);
+        });
+
+        it('should notify non-collection keys individually alongside batched collection updates', async () => {
+            const collectionCallback = jest.fn();
+            const singleKeyCallback = jest.fn();
+
+            const connCollection = Onyx.connect({
+                key: ONYXKEYS.COLLECTION.TEST_KEY,
+                callback: collectionCallback,
+                waitForCollectionCallback: true,
+                initWithStoredValues: false,
+            });
+            const connSingle = Onyx.connect({
+                key: ONYXKEYS.TEST_KEY,
+                callback: singleKeyCallback,
+                initWithStoredValues: false,
+            });
+            await waitForPromisesToResolve();
+            collectionCallback.mockClear();
+            singleKeyCallback.mockClear();
+
+            // Mix of collection members and a non-collection key
+            await Onyx.multiSet({
+                [`${ONYXKEYS.COLLECTION.TEST_KEY}1`]: {id: 1},
+                [`${ONYXKEYS.COLLECTION.TEST_KEY}2`]: {id: 2},
+                [ONYXKEYS.TEST_KEY]: 'standalone',
+            });
+
+            // Collection callback fires once (batched)
+            expect(collectionCallback).toHaveBeenCalledTimes(1);
+            // Non-collection key callback fires once
+            expect(singleKeyCallback).toHaveBeenCalledTimes(1);
+            expect(singleKeyCallback).toHaveBeenCalledWith('standalone', ONYXKEYS.TEST_KEY);
+
+            Onyx.disconnect(connCollection);
+            Onyx.disconnect(connSingle);
+        });
+
+        it('should batch notifications per-collection when members span multiple collections', async () => {
+            const testCallback = jest.fn();
+            const routesCallback = jest.fn();
+
+            const connTest = Onyx.connect({
+                key: ONYXKEYS.COLLECTION.TEST_KEY,
+                callback: testCallback,
+                waitForCollectionCallback: true,
+                initWithStoredValues: false,
+            });
+            const connRoutes = Onyx.connect({
+                key: ONYXKEYS.COLLECTION.ROUTES,
+                callback: routesCallback,
+                waitForCollectionCallback: true,
+                initWithStoredValues: false,
+            });
+            await waitForPromisesToResolve();
+            testCallback.mockClear();
+            routesCallback.mockClear();
+
+            // multiSet with members of two different collections
+            await Onyx.multiSet({
+                [`${ONYXKEYS.COLLECTION.TEST_KEY}1`]: {id: 1},
+                [`${ONYXKEYS.COLLECTION.TEST_KEY}2`]: {id: 2},
+                [`${ONYXKEYS.COLLECTION.ROUTES}A`]: {name: 'A'},
+                [`${ONYXKEYS.COLLECTION.ROUTES}B`]: {name: 'B'},
+            });
+
+            // Each collection callback fires once
+            expect(testCallback).toHaveBeenCalledTimes(1);
+            expect(routesCallback).toHaveBeenCalledTimes(1);
+
+            Onyx.disconnect(connTest);
+            Onyx.disconnect(connRoutes);
+        });
+
+        it('should pass previous values to keysChanged so unchanged members skip notification', async () => {
+            // Set initial data
+            const initial1 = {id: 1, name: 'A'};
+            const initial2 = {id: 2, name: 'B'};
+            await Onyx.multiSet({
+                [`${ONYXKEYS.COLLECTION.TEST_KEY}1`]: initial1,
+                [`${ONYXKEYS.COLLECTION.TEST_KEY}2`]: initial2,
+            });
+
+            const spy1 = jest.fn();
+            const spy2 = jest.fn();
+            const conn1 = Onyx.connect({key: `${ONYXKEYS.COLLECTION.TEST_KEY}1`, callback: spy1, initWithStoredValues: false});
+            const conn2 = Onyx.connect({key: `${ONYXKEYS.COLLECTION.TEST_KEY}2`, callback: spy2, initWithStoredValues: false});
+            await waitForPromisesToResolve();
+            spy1.mockClear();
+            spy2.mockClear();
+
+            // multiSet: change key 1, keep key 2 with same content (but new reference)
+            await Onyx.multiSet({
+                [`${ONYXKEYS.COLLECTION.TEST_KEY}1`]: {id: 1, name: 'A-updated'},
+                [`${ONYXKEYS.COLLECTION.TEST_KEY}2`]: initial2,
+            });
+
+            // Key 1 subscriber fires (value changed)
+            expect(spy1).toHaveBeenCalledTimes(1);
+            expect(spy1).toHaveBeenCalledWith({id: 1, name: 'A-updated'}, `${ONYXKEYS.COLLECTION.TEST_KEY}1`);
+
+            // Key 2 keeps the same reference (passed as-is in multiSet) — subscriber should not fire
+            // because keysChanged sees the same reference as previousCollection[key]
+            expect(spy2).not.toHaveBeenCalled();
+
+            Onyx.disconnect(conn1);
+            Onyx.disconnect(conn2);
+        });
+    });
+
     describe('keysChanged', () => {
         beforeEach(() => {
             Onyx.clear();

--- a/tests/unit/onyxUtilsTest.ts
+++ b/tests/unit/onyxUtilsTest.ts
@@ -433,6 +433,40 @@ describe('OnyxUtils', () => {
             Onyx.disconnect(conn1);
             Onyx.disconnect(conn2);
         });
+
+        it('should stop firing callbacks for a collection subscriber that disconnects itself mid-batch', async () => {
+            // A collection subscriber (waitForCollectionCallback=false) disconnects itself when
+            // it receives the first member. Subsequent changed members in the same batch must NOT
+            // trigger further callbacks for this subscriber.
+            const callback = jest.fn();
+            let connection: ReturnType<typeof Onyx.connect>;
+
+            callback.mockImplementation(() => {
+                if (!connection) {
+                    return;
+                }
+
+                Onyx.disconnect(connection);
+            });
+
+            connection = Onyx.connect({
+                key: ONYXKEYS.COLLECTION.TEST_KEY,
+                callback,
+                waitForCollectionCallback: false,
+                initWithStoredValues: false,
+            });
+            await waitForPromisesToResolve();
+            callback.mockClear();
+
+            await Onyx.multiSet({
+                [`${ONYXKEYS.COLLECTION.TEST_KEY}1`]: {id: 1},
+                [`${ONYXKEYS.COLLECTION.TEST_KEY}2`]: {id: 2},
+                [`${ONYXKEYS.COLLECTION.TEST_KEY}3`]: {id: 3},
+            });
+
+            // Despite 3 changed members, callback should fire at most once before disconnect stops it
+            expect(callback).toHaveBeenCalledTimes(1);
+        });
     });
 
     describe('keysChanged', () => {

--- a/tests/unit/onyxUtilsTest.ts
+++ b/tests/unit/onyxUtilsTest.ts
@@ -74,6 +74,7 @@ const testMergeChanges: GenericDeepRecord[] = [
 
 const ONYXKEYS = {
     TEST_KEY: 'test',
+    TEST_KEY_2: 'test2',
     COLLECTION: {
         TEST_KEY: 'test_',
         TEST_LEVEL_KEY: 'test_level_',
@@ -466,6 +467,54 @@ describe('OnyxUtils', () => {
 
             // Despite 3 changed members, callback should fire at most once before disconnect stops it
             expect(callback).toHaveBeenCalledTimes(1);
+        });
+
+        it('should keep cache and subscriber state consistent when a non-collection callback writes to another payload key', async () => {
+            // A subscriber for keyA synchronously calls Onyx.set() on keyB during its callback.
+            // After multiSet completes, the cache must reflect the multiSet's value for keyB
+            // (multiSet wins), and the keyB subscriber's last seen value must equal the cache.
+            await Onyx.multiSet({[ONYXKEYS.TEST_KEY]: 'initialA', [ONYXKEYS.TEST_KEY_2]: 'initialB'});
+
+            const callbackA = jest.fn((value: unknown) => {
+                if (value !== 'newA') {
+                    return;
+                }
+
+                // While processing the new value of keyA, write to keyB.
+                // keyB is later in the same multiSet payload — multiSet should win.
+                Onyx.set(ONYXKEYS.TEST_KEY_2, 'callbackB');
+            });
+            const callbackB = jest.fn();
+
+            const connA = Onyx.connect({
+                key: ONYXKEYS.TEST_KEY,
+                callback: callbackA,
+                initWithStoredValues: false,
+            });
+            const connB = Onyx.connect({
+                key: ONYXKEYS.TEST_KEY_2,
+                callback: callbackB,
+                initWithStoredValues: false,
+            });
+            await waitForPromisesToResolve();
+            callbackA.mockClear();
+            callbackB.mockClear();
+
+            await Onyx.multiSet({
+                [ONYXKEYS.TEST_KEY]: 'newA',
+                [ONYXKEYS.TEST_KEY_2]: 'multiSetB',
+            });
+
+            // Cache reflects multiSet's payload value for keyB (the multiSet's later cache.set wins)
+            expect(OnyxCache.get(ONYXKEYS.TEST_KEY_2)).toBe('multiSetB');
+
+            expect(callbackB.mock.calls.length).toBe(2);
+            expect(callbackB.mock.calls.at(0)?.[0]).toBe('callbackB');
+            // keyB subscriber's last received value matches the cache (no stale callback)
+            expect(callbackB.mock.calls.at(1)?.[0]).toBe('multiSetB');
+
+            Onyx.disconnect(connA);
+            Onyx.disconnect(connB);
         });
     });
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

Fifth PR of https://github.com/Expensify/App/issues/86181

> Group collection members by their parent collection key and call `keysChanged()` once per collection instead of `keyChanged()` per individual key. Non-collection keys still get individual notifications.

E/App PR: https://github.com/Expensify/App/pull/88734

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/App/issues/86181

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

Unit tests were added.

### Manual Tests
<!---
Each set of changes should be tested against the Expensify/App repo on all platforms to verify it does not break our staging App.
--->

Use https://github.com/Expensify/App/pull/88734 for testing:

1. Login with an account.
2. Go to Inbox tab, scroll the chat list a bit, assert the items are there as expected.
3. Go to a chat, send a message and react it, assert it works.
4. Go to Spend tab, scroll the chat list a bit, assert the items are there as expected.
5. Navigate to a expense details, assert it works.
6. Go to Settings -> Troubleshoot, use `Import Onyx state` to import any onyx state file you have. Assert the state was imported without issues.
7. Go to Inbox tab, scroll the chat list a bit, assert the items are there as expected.
8. Refresh the page/app, assert it works and data is still there.
9. Go to Settings -> Troubleshoot and clear cache, assert it works.
10. Go to Inbox tab again, scroll the chat list a bit, assert the items are there as expected.
11. Sign out and login again with same account, assert it works.

### Author Checklist

- [x] I linked the correct issue in the `### Related Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>


https://github.com/user-attachments/assets/0dc6ae32-25a7-4580-a29b-bcc775894f6a

