### PR TITLE
fix: extra mount render introduced in useOnyx v3.0.59

### DIFF
--- a/lib/useOnyx.ts
+++ b/lib/useOnyx.ts
@@ -112,6 +112,10 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
     // explicit reset logic — eliminating the race condition where cleanup could clobber a boolean flag.
     const connectedKeyRef = useRef<OnyxKey | null>(null);
 
+    // Tracks whether the hook has completed its initial mount subscription.
+    // Unlike connectedKeyRef (which gets nulled by cleanup), this persists across re-subscriptions.
+    const hasMountedRef = useRef(false);
+
     // Indicates if the hook is connecting to an Onyx key.
     const isConnectingRef = useRef(false);
 
@@ -264,12 +268,19 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
         (onStoreChange: () => void) => {
             // Reset internal state so the hook properly transitions through loading
             // for the new key instead of preserving stale state from the previous one.
-            previousValueRef.current = null;
-            newValueRef.current = null;
+            // Only reset when the key has actually changed (not on initial mount).
+            if (hasMountedRef.current) {
+                previousValueRef.current = null;
+                newValueRef.current = null;
+                sourceValueRef.current = undefined;
+                resultRef.current = [undefined, {status: options?.initWithStoredValues === false ? 'loaded' : 'loading'}];
+            }
+            // Force a cache re-read on every (re)subscription so any side effects from
+            // subscribeToKey (e.g. addNullishStorageKey for skippable collection member ids)
+            // are reflected in the next getSnapshot. Resetting this flag does not change
+            // resultRef by itself, so it doesn't cause an extra mount render.
             shouldGetCachedValueRef.current = true;
-            sourceValueRef.current = undefined;
-            resultRef.current = [undefined, {status: options?.initWithStoredValues === false ? 'loaded' : 'loading'}];
-
+            hasMountedRef.current = true;
             isConnectingRef.current = true;
             onStoreChangeFnRef.current = onStoreChange;
 

--- a/tests/unit/useOnyxTest.ts
+++ b/tests/unit/useOnyxTest.ts
@@ -1339,5 +1339,76 @@ describe('useOnyx', () => {
             expect(result.current[1].status).toEqual('loaded');
             expect(renderCount).toBe(2);
         });
+
+        // Covers the `if (hasMountedRef.current)` branch — i.e. the reset that runs on key-change re-subscriptions.
+        // The reset is what makes the hook transition through 'loading' for the new key instead of leaking the
+        // previous key's value/status. These tests verify both the render count AND the loading transition,
+        // so removing the reset (regression in the other direction) is also caught.
+        it('should transition through loading and render exactly 4 times when switching from a cached key to an uncached one', async () => {
+            await Onyx.set(`${ONYXKEYS.COLLECTION.TEST_KEY}A`, 'A_value');
+
+            const renders: Array<{value: unknown; status: string}> = [];
+            const {result, rerender} = renderHook(
+                (key: string) => {
+                    const r = useOnyx(key);
+                    renders.push({value: r[0], status: r[1].status});
+                    return r;
+                },
+                {initialProps: `${ONYXKEYS.COLLECTION.TEST_KEY}A` as string},
+            );
+
+            await act(async () => waitForPromisesToResolve());
+
+            expect(result.current[0]).toEqual('A_value');
+            expect(result.current[1].status).toEqual('loaded');
+            const rendersAfterMount = renders.length;
+            expect(rendersAfterMount).toBe(1);
+
+            await act(async () => {
+                rerender(`${ONYXKEYS.COLLECTION.TEST_KEY}B`);
+            });
+            await act(async () => waitForPromisesToResolve());
+
+            expect(result.current[0]).toBeUndefined();
+            expect(result.current[1].status).toEqual('loaded');
+            // 1 mount render + 3 renders for the key switch (transient stale render, post-subscribe 'loading',
+            // callback-driven 'loaded'). The 'loading' render only happens because the subscribe-time reset
+            // clears the previous key's resultRef — removing the reset makes this assertion fail.
+            expect(renders.length).toBe(4);
+            // Verify the reset took effect: a 'loading' frame must appear after the key change.
+            const postSwitchStatuses = renders.slice(rendersAfterMount).map((r) => r.status);
+            expect(postSwitchStatuses).toContain('loading');
+            expect(postSwitchStatuses[postSwitchStatuses.length - 1]).toBe('loaded');
+        });
+
+        it('should transition through loading and render exactly 3 times when switching between two cached keys', async () => {
+            await Onyx.set(`${ONYXKEYS.COLLECTION.TEST_KEY}A`, 'A_value');
+            await Onyx.set(`${ONYXKEYS.COLLECTION.TEST_KEY}B`, 'B_value');
+
+            const renders: Array<{value: unknown; status: string}> = [];
+            const {result, rerender} = renderHook(
+                (key: string) => {
+                    const r = useOnyx(key);
+                    renders.push({value: r[0], status: r[1].status});
+                    return r;
+                },
+                {initialProps: `${ONYXKEYS.COLLECTION.TEST_KEY}A` as string},
+            );
+
+            await act(async () => waitForPromisesToResolve());
+
+            expect(result.current[0]).toEqual('A_value');
+            expect(renders.length).toBe(1);
+
+            await act(async () => {
+                rerender(`${ONYXKEYS.COLLECTION.TEST_KEY}B`);
+            });
+            await act(async () => waitForPromisesToResolve());
+
+            expect(result.current[0]).toEqual('B_value');
+            expect(result.current[1].status).toEqual('loaded');
+            // 1 mount render + 2 renders for the cached-to-cached switch.
+            expect(renders.length).toBe(3);
+        });
     });
 });

--- a/tests/unit/useOnyxTest.ts
+++ b/tests/unit/useOnyxTest.ts
@@ -1271,4 +1271,73 @@ describe('useOnyx', () => {
             expect(result.current[1].status).toEqual('loaded');
         });
     });
+
+    // Regression coverage for Expensify/App#87850 ("[Onyx] Fix extra mount render introduced in useOnyx v3.0.59").
+    // The bug: `subscribe` unconditionally reset `resultRef.current` to a fresh tuple, including on initial mount.
+    // `useSyncExternalStore` then observed a different snapshot reference post-subscribe and scheduled an extra
+    // render per `useOnyx` hook. The fix guards the reset behind `hasMountedRef` so it only runs on re-subscription.
+    describe('initial mount render count', () => {
+        it('should render only once when the key has a value already in Onyx cache', async () => {
+            await Onyx.set(ONYXKEYS.TEST_KEY, 'cached_value');
+
+            let renderCount = 0;
+            const {result} = renderHook(() => {
+                renderCount++;
+                return useOnyx(ONYXKEYS.TEST_KEY);
+            });
+
+            await act(async () => waitForPromisesToResolve());
+
+            expect(result.current[0]).toEqual('cached_value');
+            expect(result.current[1].status).toEqual('loaded');
+            // A single render — no extra render caused by subscribe resetting state on initial mount.
+            expect(renderCount).toBe(1);
+        });
+
+        it('should render exactly twice (loading → loaded) when the key is not cached', async () => {
+            let renderCount = 0;
+            const {result} = renderHook(() => {
+                renderCount++;
+                return useOnyx(ONYXKEYS.TEST_KEY);
+            });
+
+            await act(async () => waitForPromisesToResolve());
+
+            expect(result.current[0]).toBeUndefined();
+            expect(result.current[1].status).toEqual('loaded');
+            // Exactly two renders: initial 'loading' + transition to 'loaded' after the connection callback fires.
+            // If the regression returns, a third render sneaks in from the subscribe-time state reset.
+            expect(renderCount).toBe(2);
+        });
+
+        it('should render exactly twice when the key value is only present in storage', async () => {
+            await StorageMock.setItem(ONYXKEYS.TEST_KEY, 'storage_value');
+
+            let renderCount = 0;
+            const {result} = renderHook(() => {
+                renderCount++;
+                return useOnyx(ONYXKEYS.TEST_KEY);
+            });
+
+            await act(async () => waitForPromisesToResolve());
+
+            expect(result.current[0]).toEqual('storage_value');
+            expect(result.current[1].status).toEqual('loaded');
+            expect(renderCount).toBe(2);
+        });
+
+        it('should render exactly twice for a non-cached collection member key', async () => {
+            let renderCount = 0;
+            const {result} = renderHook(() => {
+                renderCount++;
+                return useOnyx(`${ONYXKEYS.COLLECTION.TEST_KEY}1`);
+            });
+
+            await act(async () => waitForPromisesToResolve());
+
+            expect(result.current[0]).toBeUndefined();
+            expect(result.current[1].status).toEqual('loaded');
+            expect(renderCount).toBe(2);
+        });
+    });
 });


### PR DESCRIPTION


<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Onyx v3.0.59 added a state-reset block inside useOnyx's subscribe callback to fix stale data on key changes. The reset, however, ran unconditionally - including on the very first subscription. That mutated resultRef.current to a fresh tuple after useSyncExternalStore had already rendered once with the initial resultRef.useSyncExternalStore then observed a different snapshot reference post-subscribe and scheduled an extra render per useOnyx hook on initial mount.
This regression was caught by the Reassure performance suite during the Onyx v3.0.59 bump in Expensify/App and tracked as Expensify/App#87850. A temporary patch (patches/react-native-onyx+3.0.59.patch) was applied in App PR #87738 to unblock the bump; this Onyx PR upstreams the real fix so the patch can be removed.
### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
$ https://github.com/Expensify/App/issues/87850

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Manual Tests
<!---
Each set of changes should be tested against the Expensify/App repo on all platforms to verify it does not break our staging App.
--->
1. Open app
2. Create expense 
3. Verify that expense correctly created
4. Open expense chat verify that reports are correctly rendered 

### Author Checklist

- [x] I linked the correct issue in the `### Related Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>