### PR TITLE
fix: add IDB healing mechanism for backing store corruption and connection lost errors

### DIFF
--- a/lib/storage/providers/IDBKeyValProvider/createStore.ts
+++ b/lib/storage/providers/IDBKeyValProvider/createStore.ts
@@ -49,9 +49,14 @@ function createStore(dbName: string, storeName: string): UseStore {
         request.onupgradeneeded = () => request.result.createObjectStore(storeName);
         dbp = IDB.promisifyRequest(request);
 
+        const currentPromise = dbp;
         dbp.then(attachHandlers, () => {
             // Clear the cached rejected promise so the next operation retries
             // with a fresh indexedDB.open() instead of returning the same rejection.
+            // Guard: only clear if dbp hasn't been replaced by a concurrent heal/retry.
+            if (dbp !== currentPromise) {
+                return;
+            }
             dbp = undefined;
         });
         return dbp;
@@ -80,7 +85,11 @@ function createStore(dbName: string, storeName: string): UseStore {
         };
 
         dbp = IDB.promisifyRequest(request);
+        const currentPromise = dbp;
         dbp.then(attachHandlers, () => {
+            if (dbp !== currentPromise) {
+                return;
+            }
             dbp = undefined;
         });
         return dbp;
@@ -103,6 +112,9 @@ function createStore(dbName: string, storeName: string): UseStore {
     // 2. Backing store corruption (Chromium UnknownError) — close + reopen the IDB connection.
     //    Bounded by a shared heal budget (3 attempts, reset on success).
     //    Mirrors Dexie's PR1398_maxLoop pattern: https://github.com/dexie/Dexie.js/blob/master/src/functions/temp-transaction.ts
+    // Note: concurrent store() calls share the budget. Under overlapping failures each caller
+    // decrements independently, so the budget may drain faster than one-per-incident. This is
+    // acceptable — same as Dexie's approach — and the budget resets on any success.
     return (txMode, callback) =>
         executeTransaction(txMode, callback)
             .then(resetHealBudget)

--- a/lib/storage/providers/IDBKeyValProvider/createStore.ts
+++ b/lib/storage/providers/IDBKeyValProvider/createStore.ts
@@ -109,7 +109,7 @@ function createStore(dbName: string, storeName: string): UseStore {
     // Handles two recoverable error classes:
     // 1. InvalidStateError — connection closed between getDB() resolving and db.transaction().
     //    Retry once with a fresh connection.
-    // 2. Backing store corruption (Chromium UnknownError) — close + reopen the IDB connection.
+    // 2. Backing store corruption (Chromium UnknownError) — drop cached connection and reopen the IDB connection.
     //    Bounded by a shared heal budget (3 attempts, reset on success).
     //    Mirrors Dexie's PR1398_maxLoop pattern: https://github.com/dexie/Dexie.js/blob/master/src/functions/temp-transaction.ts
     // Note: concurrent store() calls share the budget. Under overlapping failures each caller
@@ -132,7 +132,7 @@ function createStore(dbName: string, storeName: string): UseStore {
 
                 if (isBackingStoreError(error) && healAttemptsRemaining > 0) {
                     healAttemptsRemaining--;
-                    Logger.logInfo('IDB heal: backing store error, attempting close + reopen', {
+                    Logger.logInfo('IDB heal: backing store error, attempting drop cached connection and reopen', {
                         dbName,
                         storeName,
                         healAttemptsRemaining,

--- a/lib/storage/providers/IDBKeyValProvider/createStore.ts
+++ b/lib/storage/providers/IDBKeyValProvider/createStore.ts
@@ -2,12 +2,25 @@ import * as IDB from 'idb-keyval';
 import type {UseStore} from 'idb-keyval';
 import * as Logger from '../../../Logger';
 
+const HEAL_ATTEMPTS_MAX = 3;
+
+/**
+ * Detects the Chromium-specific IDB backing store corruption error.
+ * Fires when LevelDB files backing IndexedDB are corrupted and Chrome's
+ * internal recovery (RepairDB -> delete -> recreate) also fails.
+ * https://github.com/Expensify/App/issues/87862
+ */
+function isBackingStoreError(error: unknown): boolean {
+    return error instanceof DOMException && error.name === 'UnknownError' && error.message.includes('Internal error opening backing store');
+}
+
 // This is a copy of the createStore function from idb-keyval, we need a custom implementation
 // because we need to create the database manually in order to ensure that the store exists before we use it.
 // If the store does not exist, idb-keyval will throw an error
 // source: https://github.com/jakearchibald/idb-keyval/blob/9d19315b4a83897df1e0193dccdc29f78466a0f3/src/index.ts#L12
 function createStore(dbName: string, storeName: string): UseStore {
     let dbp: Promise<IDBDatabase> | undefined;
+    let healAttemptsRemaining = HEAL_ATTEMPTS_MAX;
 
     const attachHandlers = (db: IDBDatabase) => {
         // Browsers may close idle IDB connections at any time, especially Safari.
@@ -36,11 +49,11 @@ function createStore(dbName: string, storeName: string): UseStore {
         request.onupgradeneeded = () => request.result.createObjectStore(storeName);
         dbp = IDB.promisifyRequest(request);
 
-        dbp.then(
-            attachHandlers,
-            // eslint-disable-next-line @typescript-eslint/no-empty-function
-            () => {},
-        );
+        dbp.then(attachHandlers, () => {
+            // Clear the cached rejected promise so the next operation retries
+            // with a fresh indexedDB.open() instead of returning the same rejection.
+            dbp = undefined;
+        });
         return dbp;
     };
 
@@ -67,8 +80,9 @@ function createStore(dbName: string, storeName: string): UseStore {
         };
 
         dbp = IDB.promisifyRequest(request);
-        // eslint-disable-next-line @typescript-eslint/no-empty-function
-        dbp.then(attachHandlers, () => {});
+        dbp.then(attachHandlers, () => {
+            dbp = undefined;
+        });
         return dbp;
     };
 
@@ -78,23 +92,45 @@ function createStore(dbName: string, storeName: string): UseStore {
             .then((db) => callback(db.transaction(storeName, txMode).objectStore(storeName)));
     }
 
-    // If the connection was closed between getDB() resolving and db.transaction() executing,
-    // the transaction throws InvalidStateError. We catch it and retry once with a fresh connection.
+    function resetHealBudget<T>(result: T): T {
+        healAttemptsRemaining = HEAL_ATTEMPTS_MAX;
+        return result;
+    }
+
+    // Handles two recoverable error classes:
+    // 1. InvalidStateError — connection closed between getDB() resolving and db.transaction().
+    //    Retry once with a fresh connection.
+    // 2. Backing store corruption (Chromium UnknownError) — close + reopen the IDB connection.
+    //    Bounded by a shared heal budget (3 attempts, reset on success).
+    //    Mirrors Dexie's PR1398_maxLoop pattern: https://github.com/dexie/Dexie.js/blob/master/src/functions/temp-transaction.ts
     return (txMode, callback) =>
-        executeTransaction(txMode, callback).catch((error) => {
-            if (error instanceof DOMException && error.name === 'InvalidStateError') {
-                Logger.logAlert('IDB InvalidStateError, retrying with fresh connection', {
-                    dbName,
-                    storeName,
-                    txMode,
-                    errorMessage: error.message,
-                });
-                dbp = undefined;
-                // Retry only once — this call is not wrapped, so if it also fails the error propagates normally.
-                return executeTransaction(txMode, callback);
-            }
-            throw error;
-        });
+        executeTransaction(txMode, callback)
+            .then(resetHealBudget)
+            .catch((error) => {
+                if (error instanceof DOMException && error.name === 'InvalidStateError') {
+                    Logger.logAlert('IDB InvalidStateError, retrying with fresh connection', {
+                        dbName,
+                        storeName,
+                        txMode,
+                        errorMessage: error.message,
+                    });
+                    dbp = undefined;
+                    return executeTransaction(txMode, callback).then(resetHealBudget);
+                }
+
+                if (isBackingStoreError(error) && healAttemptsRemaining > 0) {
+                    healAttemptsRemaining--;
+                    Logger.logInfo('IDB heal: backing store error, attempting close + reopen', {
+                        dbName,
+                        storeName,
+                        healAttemptsRemaining,
+                    });
+                    dbp = undefined;
+                    return executeTransaction(txMode, callback).then(resetHealBudget);
+                }
+
+                throw error;
+            });
 }
 
 export default createStore;

--- a/lib/storage/providers/IDBKeyValProvider/createStore.ts
+++ b/lib/storage/providers/IDBKeyValProvider/createStore.ts
@@ -33,8 +33,10 @@ function isBudgetedHealError(error: unknown): boolean {
     return isBackingStoreError(error) || isConnectionLostError(error);
 }
 
-function getBudgetedHealErrorLabel(error: unknown): 'backing store' | 'connection lost' {
-    return isBackingStoreError(error) ? 'backing store' : 'connection lost';
+function getBudgetedHealErrorLabel(error: unknown): string {
+    if (isBackingStoreError(error)) return 'backing store';
+    if (isConnectionLostError(error)) return 'connection lost';
+    return 'unknown';
 }
 
 // This is a copy of the createStore function from idb-keyval, we need a custom implementation

--- a/lib/storage/providers/IDBKeyValProvider/createStore.ts
+++ b/lib/storage/providers/IDBKeyValProvider/createStore.ts
@@ -13,6 +13,17 @@ function isBackingStoreError(error: unknown): boolean {
     return error instanceof Error && error.message.includes('Internal error opening backing store');
 }
 
+/**
+ * Detects Safari/WebKit IDB connection termination errors.
+ * Fires when Safari kills the IDB server process for backgrounded tabs.
+ * WebKit bugs: https://bugs.webkit.org/show_bug.cgi?id=197050, https://bugs.webkit.org/show_bug.cgi?id=201483
+ */
+function isConnectionLostError(error: unknown): boolean {
+    if (!(error instanceof Error)) return false;
+    const msg = error.message.toLowerCase();
+    return msg.includes('connection to indexed database server lost') || msg.includes('connection is closing');
+}
+
 // This is a copy of the createStore function from idb-keyval, we need a custom implementation
 // because we need to create the database manually in order to ensure that the store exists before we use it.
 // If the store does not exist, idb-keyval will throw an error
@@ -129,9 +140,10 @@ function createStore(dbName: string, storeName: string): UseStore {
                     return executeTransaction(txMode, callback).then(resetHealBudget);
                 }
 
-                if (isBackingStoreError(error) && healAttemptsRemaining > 0) {
+                if ((isBackingStoreError(error) || isConnectionLostError(error)) && healAttemptsRemaining > 0) {
                     healAttemptsRemaining--;
-                    Logger.logInfo('IDB heal: backing store error, attempting drop cached connection and reopen', {
+                    const errorType = isBackingStoreError(error) ? 'backing store' : 'connection lost';
+                    Logger.logInfo(`IDB heal: ${errorType} error, attempting drop cached connection and reopen`, {
                         dbName,
                         storeName,
                         healAttemptsRemaining,

--- a/lib/storage/providers/IDBKeyValProvider/createStore.ts
+++ b/lib/storage/providers/IDBKeyValProvider/createStore.ts
@@ -10,7 +10,7 @@ const HEAL_ATTEMPTS_MAX = 3;
  * internal recovery (RepairDB -> delete -> recreate) also fails.
  */
 function isBackingStoreError(error: unknown): boolean {
-    return error instanceof Error && error.message.includes('Internal error opening backing store');
+    return (error instanceof Error || error instanceof DOMException) && (error as Error).message.includes('Internal error opening backing store');
 }
 
 /**
@@ -19,13 +19,13 @@ function isBackingStoreError(error: unknown): boolean {
  * WebKit bugs: https://bugs.webkit.org/show_bug.cgi?id=197050, https://bugs.webkit.org/show_bug.cgi?id=201483
  */
 function isConnectionLostError(error: unknown): boolean {
-    if (!(error instanceof Error)) return false;
-    const msg = error.message.toLowerCase();
+    if (!(error instanceof Error || error instanceof DOMException)) return false;
+    const msg = (error as Error).message.toLowerCase();
     return msg.includes('connection to indexed database server lost') || msg.includes('connection is closing');
 }
 
 function isInvalidStateError(error: unknown): boolean {
-    return error instanceof Error && error.name === 'InvalidStateError';
+    return (error instanceof Error || error instanceof DOMException) && (error as Error).name === 'InvalidStateError';
 }
 
 /** Errors that trigger a budgeted heal-and-retry in store(). */

--- a/lib/storage/providers/IDBKeyValProvider/createStore.ts
+++ b/lib/storage/providers/IDBKeyValProvider/createStore.ts
@@ -140,7 +140,7 @@ function createStore(dbName: string, storeName: string): UseStore {
             .then(resetHealBudget)
             .catch((error) => {
                 if (isInvalidStateError(error)) {
-                    Logger.logAlert('IDB InvalidStateError — dropping cached connection and retrying', {
+                    Logger.logInfo('IDB InvalidStateError — dropping cached connection and retrying', {
                         dbName,
                         storeName,
                         txMode,
@@ -153,7 +153,7 @@ function createStore(dbName: string, storeName: string): UseStore {
                 if (isBudgetedHealError(error) && healAttemptsRemaining > 0) {
                     healAttemptsRemaining--;
                     const label = getBudgetedHealErrorLabel(error);
-                    Logger.logAlert(`IDB heal: ${label} error detected — dropping cached connection and reopening (${healAttemptsRemaining} attempts left)`, {
+                    Logger.logInfo(`IDB heal: ${label} error detected — dropping cached connection and reopening (${healAttemptsRemaining} attempts left)`, {
                         dbName,
                         storeName,
                     });

--- a/lib/storage/providers/IDBKeyValProvider/createStore.ts
+++ b/lib/storage/providers/IDBKeyValProvider/createStore.ts
@@ -8,10 +8,9 @@ const HEAL_ATTEMPTS_MAX = 3;
  * Detects the Chromium-specific IDB backing store corruption error.
  * Fires when LevelDB files backing IndexedDB are corrupted and Chrome's
  * internal recovery (RepairDB -> delete -> recreate) also fails.
- * https://github.com/Expensify/App/issues/87862
  */
 function isBackingStoreError(error: unknown): boolean {
-    return error instanceof DOMException && error.name === 'UnknownError' && error.message.includes('Internal error opening backing store');
+    return error instanceof Error && error.message.includes('Internal error opening backing store');
 }
 
 // This is a copy of the createStore function from idb-keyval, we need a custom implementation
@@ -119,7 +118,7 @@ function createStore(dbName: string, storeName: string): UseStore {
         executeTransaction(txMode, callback)
             .then(resetHealBudget)
             .catch((error) => {
-                if (error instanceof DOMException && error.name === 'InvalidStateError') {
+                if (error instanceof Error && error.name === 'InvalidStateError') {
                     Logger.logAlert('IDB InvalidStateError, retrying with fresh connection', {
                         dbName,
                         storeName,

--- a/lib/storage/providers/IDBKeyValProvider/createStore.ts
+++ b/lib/storage/providers/IDBKeyValProvider/createStore.ts
@@ -140,7 +140,7 @@ function createStore(dbName: string, storeName: string): UseStore {
             .then(resetHealBudget)
             .catch((error) => {
                 if (isInvalidStateError(error)) {
-                    Logger.logAlert('IDB InvalidStateError, retrying with fresh connection', {
+                    Logger.logAlert('IDB InvalidStateError — dropping cached connection and retrying', {
                         dbName,
                         storeName,
                         txMode,
@@ -152,15 +152,30 @@ function createStore(dbName: string, storeName: string): UseStore {
 
                 if (isBudgetedHealError(error) && healAttemptsRemaining > 0) {
                     healAttemptsRemaining--;
-                    Logger.logInfo(`IDB heal: ${getBudgetedHealErrorLabel(error)} error, attempting drop cached connection and reopen`, {
+                    const label = getBudgetedHealErrorLabel(error);
+                    Logger.logAlert(`IDB heal: ${label} error detected — dropping cached connection and reopening (${healAttemptsRemaining} attempts left)`, {
                         dbName,
                         storeName,
-                        healAttemptsRemaining,
                     });
                     dbp = undefined;
-                    return executeTransaction(txMode, callback).then(resetHealBudget);
+                    return executeTransaction(txMode, callback).then((result) => {
+                        Logger.logInfo(`IDB heal: successfully recovered after ${label} error`, {dbName, storeName});
+                        return resetHealBudget(result);
+                    });
                 }
 
+                if (isBudgetedHealError(error)) {
+                    Logger.logAlert(`IDB heal: ${getBudgetedHealErrorLabel(error)} error — heal budget exhausted, giving up`, {
+                        dbName,
+                        storeName,
+                    });
+                } else {
+                    Logger.logAlert('IDB error is not recoverable, giving up', {
+                        dbName,
+                        storeName,
+                        errorMessage: error instanceof Error ? error.message : String(error),
+                    });
+                }
                 throw error;
             });
 }

--- a/lib/storage/providers/IDBKeyValProvider/createStore.ts
+++ b/lib/storage/providers/IDBKeyValProvider/createStore.ts
@@ -24,6 +24,19 @@ function isConnectionLostError(error: unknown): boolean {
     return msg.includes('connection to indexed database server lost') || msg.includes('connection is closing');
 }
 
+function isInvalidStateError(error: unknown): boolean {
+    return error instanceof Error && error.name === 'InvalidStateError';
+}
+
+/** Errors that trigger a budgeted heal-and-retry in store(). */
+function isBudgetedHealError(error: unknown): boolean {
+    return isBackingStoreError(error) || isConnectionLostError(error);
+}
+
+function getBudgetedHealErrorLabel(error: unknown): 'backing store' | 'connection lost' {
+    return isBackingStoreError(error) ? 'backing store' : 'connection lost';
+}
+
 // This is a copy of the createStore function from idb-keyval, we need a custom implementation
 // because we need to create the database manually in order to ensure that the store exists before we use it.
 // If the store does not exist, idb-keyval will throw an error
@@ -53,23 +66,27 @@ function createStore(dbName: string, storeName: string): UseStore {
         };
     };
 
-    const getDB = () => {
-        if (dbp) return dbp;
-        const request = indexedDB.open(dbName);
-        request.onupgradeneeded = () => request.result.createObjectStore(storeName);
-        dbp = IDB.promisifyRequest(request);
-
-        const currentPromise = dbp;
-        dbp.then(attachHandlers, () => {
-            // Clear the cached rejected promise so the next operation retries
-            // with a fresh indexedDB.open() instead of returning the same rejection.
-            // Guard: only clear if dbp hasn't been replaced by a concurrent heal/retry.
+    // Cache the open promise and attach handlers + rejection cleanup.
+    // On rejection, clears dbp so the next operation retries with a fresh indexedDB.open()
+    // instead of returning the same rejected promise.
+    // Guard: only clear if dbp hasn't been replaced by a concurrent heal/retry.
+    function cacheOpenPromise(openPromise: Promise<IDBDatabase>) {
+        dbp = openPromise;
+        const currentPromise = openPromise;
+        openPromise.then(attachHandlers, () => {
             if (dbp !== currentPromise) {
                 return;
             }
             dbp = undefined;
         });
-        return dbp;
+        return openPromise;
+    }
+
+    const getDB = () => {
+        if (dbp) return dbp;
+        const request = indexedDB.open(dbName);
+        request.onupgradeneeded = () => request.result.createObjectStore(storeName);
+        return cacheOpenPromise(IDB.promisifyRequest(request));
     };
 
     // Ensures the store exists in the DB. If missing, bumps the version to trigger
@@ -94,15 +111,7 @@ function createStore(dbName: string, storeName: string): UseStore {
             updatedDatabase.createObjectStore(storeName);
         };
 
-        dbp = IDB.promisifyRequest(request);
-        const currentPromise = dbp;
-        dbp.then(attachHandlers, () => {
-            if (dbp !== currentPromise) {
-                return;
-            }
-            dbp = undefined;
-        });
-        return dbp;
+        return cacheOpenPromise(IDB.promisifyRequest(request));
     };
 
     function executeTransaction<T>(txMode: IDBTransactionMode, callback: (store: IDBObjectStore) => T | PromiseLike<T>): Promise<T> {
@@ -116,11 +125,12 @@ function createStore(dbName: string, storeName: string): UseStore {
         return result;
     }
 
-    // Handles two recoverable error classes:
+    // Handles three recoverable error classes:
     // 1. InvalidStateError — connection closed between getDB() resolving and db.transaction().
-    //    Retry once with a fresh connection.
-    // 2. Backing store corruption (Chromium UnknownError) — drop cached connection and reopen the IDB connection.
-    //    Bounded by a shared heal budget (3 attempts, reset on success).
+    //    Retry once with a fresh connection. No budget limit (transient, always worth one reopen).
+    // 2. Backing store corruption (Chromium UnknownError) — drop cached connection and reopen.
+    // 3. Connection lost (Safari UnknownError) — IDB server terminated for backgrounded tabs.
+    //    Both 2 and 3 share a heal budget (3 attempts, reset on success).
     //    Mirrors Dexie's PR1398_maxLoop pattern: https://github.com/dexie/Dexie.js/blob/master/src/functions/temp-transaction.ts
     // Note: concurrent store() calls share the budget. Under overlapping failures each caller
     // decrements independently, so the budget may drain faster than one-per-incident. This is
@@ -129,21 +139,20 @@ function createStore(dbName: string, storeName: string): UseStore {
         executeTransaction(txMode, callback)
             .then(resetHealBudget)
             .catch((error) => {
-                if (error instanceof Error && error.name === 'InvalidStateError') {
+                if (isInvalidStateError(error)) {
                     Logger.logAlert('IDB InvalidStateError, retrying with fresh connection', {
                         dbName,
                         storeName,
                         txMode,
-                        errorMessage: error.message,
+                        errorMessage: error instanceof Error ? error.message : String(error),
                     });
                     dbp = undefined;
                     return executeTransaction(txMode, callback).then(resetHealBudget);
                 }
 
-                if ((isBackingStoreError(error) || isConnectionLostError(error)) && healAttemptsRemaining > 0) {
+                if (isBudgetedHealError(error) && healAttemptsRemaining > 0) {
                     healAttemptsRemaining--;
-                    const errorType = isBackingStoreError(error) ? 'backing store' : 'connection lost';
-                    Logger.logInfo(`IDB heal: ${errorType} error, attempting drop cached connection and reopen`, {
+                    Logger.logInfo(`IDB heal: ${getBudgetedHealErrorLabel(error)} error, attempting drop cached connection and reopen`, {
                         dbName,
                         storeName,
                         healAttemptsRemaining,

--- a/tests/unit/storage/providers/createStoreTest.ts
+++ b/tests/unit/storage/providers/createStoreTest.ts
@@ -254,7 +254,7 @@ describe('createStore', () => {
             return new DOMException('Internal error opening backing store for indexedDB.open.', 'UnknownError');
         }
 
-        it('should heal mid-session by closing and reopening the connection', async () => {
+        it('should heal mid-session by dropping cached connection and reopening', async () => {
             const store = createStore(uniqueDBName(), STORE_NAME);
 
             await store('readwrite', (s) => {
@@ -275,7 +275,7 @@ describe('createStore', () => {
             const result = await store('readonly', (s) => IDB.promisifyRequest(s.get('key1')));
             expect(result).toBe('value');
             expect(callCount).toBe(2);
-            expect(logInfoSpy).toHaveBeenCalledWith('IDB heal: backing store error, attempting close + reopen', expect.objectContaining({healAttemptsRemaining: 2}));
+            expect(logInfoSpy).toHaveBeenCalledWith('IDB heal: backing store error, attempting drop cached connection and reopen', expect.objectContaining({healAttemptsRemaining: 2}));
         });
 
         it('should heal on init when indexedDB.open() rejects with UnknownError', async () => {

--- a/tests/unit/storage/providers/createStoreTest.ts
+++ b/tests/unit/storage/providers/createStoreTest.ts
@@ -365,7 +365,8 @@ describe('createStore', () => {
                     spy.mockRestore();
                     return original.apply(this, args);
                 });
-                await store('readonly', (s) => IDB.promisifyRequest(s.get('key1')));            }
+                await store('readonly', (s) => IDB.promisifyRequest(s.get('key1')));
+            }
 
             // Clean success — resets budget to 3
             jest.restoreAllMocks();
@@ -383,7 +384,8 @@ describe('createStore', () => {
                     spy.mockRestore();
                     return original.apply(this, args);
                 });
-                const result = await store('readonly', (s) => IDB.promisifyRequest(s.get('key1')));                expect(result).toBe('value');
+                const result = await store('readonly', (s) => IDB.promisifyRequest(s.get('key1')));
+                expect(result).toBe('value');
             }
         });
 

--- a/tests/unit/storage/providers/createStoreTest.ts
+++ b/tests/unit/storage/providers/createStoreTest.ts
@@ -245,4 +245,172 @@ describe('createStore', () => {
             expect(result).toBe('value');
         });
     });
+
+    describe('backing store healing', () => {
+        /**
+         * Helper: creates a DOMException matching Chromium's backing store corruption error.
+         */
+        function backingStoreError() {
+            return new DOMException('Internal error opening backing store for indexedDB.open.', 'UnknownError');
+        }
+
+        it('should heal mid-session by closing and reopening the connection', async () => {
+            const store = createStore(uniqueDBName(), STORE_NAME);
+
+            await store('readwrite', (s) => {
+                s.put('value', 'key1');
+                return IDB.promisifyRequest(s.transaction);
+            });
+
+            const original = IDBDatabase.prototype.transaction;
+            let callCount = 0;
+            jest.spyOn(IDBDatabase.prototype, 'transaction').mockImplementation(function (this: IDBDatabase, ...args) {
+                callCount++;
+                if (callCount === 1) {
+                    throw backingStoreError();
+                }
+                return original.apply(this, args);
+            });
+
+            const result = await store('readonly', (s) => IDB.promisifyRequest(s.get('key1')));
+            expect(result).toBe('value');
+            expect(callCount).toBe(2);
+            expect(logInfoSpy).toHaveBeenCalledWith('IDB heal: backing store error, attempting close + reopen', expect.objectContaining({healAttemptsRemaining: 2}));
+        });
+
+        it('should heal on init when indexedDB.open() rejects with UnknownError', async () => {
+            const dbName = uniqueDBName();
+
+            // Pre-create the DB with data
+            const setupStore = createStore(dbName, STORE_NAME);
+            await setupStore('readwrite', (s) => {
+                s.put('persisted', 'key1');
+                return IDB.promisifyRequest(s.transaction);
+            });
+
+            // Fresh store instance (simulates app restart — dbp starts undefined)
+            const store = createStore(dbName, STORE_NAME);
+
+            // Mock indexedDB.open to fail twice, then succeed.
+            // First failure: initial open in the first store() call.
+            // Second failure: the heal retry's open in that same call — propagates error.
+            // Third call (second store() invocation): succeeds, proving budget still has 1 left.
+            const realOpen = indexedDB.open.bind(indexedDB);
+            let openCallCount = 0;
+            jest.spyOn(indexedDB, 'open').mockImplementation((name: string, version?: number) => {
+                openCallCount++;
+                if (openCallCount <= 2) {
+                    const req = {} as IDBOpenDBRequest;
+                    Promise.resolve().then(() => {
+                        Object.defineProperty(req, 'error', {value: backingStoreError(), configurable: true});
+                        req.onerror?.(new Event('error') as Event & {target: IDBOpenDBRequest});
+                    });
+                    return req;
+                }
+                return realOpen(name, version);
+            });
+
+            // First call: open fails, heal retry also fails — error propagates
+            await expect(store('readonly', (s) => IDB.promisifyRequest(s.get('key1')))).rejects.toThrow('Internal error opening backing store');
+
+            // Second call: open succeeds (mock exhausted), heals
+            const result = await store('readonly', (s) => IDB.promisifyRequest(s.get('key1')));
+            expect(result).toBe('persisted');
+            expect(openCallCount).toBeGreaterThanOrEqual(3);
+        });
+
+        it('should stop healing after budget exhausts across multiple operations', async () => {
+            const store = createStore(uniqueDBName(), STORE_NAME);
+
+            // All opens fail permanently
+            jest.spyOn(indexedDB, 'open').mockImplementation(() => {
+                const req = {} as IDBOpenDBRequest;
+                Promise.resolve().then(() => {
+                    Object.defineProperty(req, 'error', {value: backingStoreError(), configurable: true});
+                    req.onerror?.(new Event('error') as Event & {target: IDBOpenDBRequest});
+                });
+                return req;
+            });
+
+            // Each call consumes 1 heal attempt (initial fails, heal retry also fails, propagates)
+            await expect(store('readonly', (s) => IDB.promisifyRequest(s.get('k')))).rejects.toThrow('Internal error opening backing store');
+            await expect(store('readonly', (s) => IDB.promisifyRequest(s.get('k')))).rejects.toThrow('Internal error opening backing store');
+            await expect(store('readonly', (s) => IDB.promisifyRequest(s.get('k')))).rejects.toThrow('Internal error opening backing store');
+
+            // Budget exhausted — 4th call should NOT attempt healing
+            logInfoSpy.mockClear();
+            await expect(store('readonly', (s) => IDB.promisifyRequest(s.get('k')))).rejects.toThrow('Internal error opening backing store');
+            expect(logInfoSpy).not.toHaveBeenCalledWith(expect.stringContaining('IDB heal'), expect.anything());
+        });
+
+        it('should reset heal budget after a successful operation', async () => {
+            const dbName = uniqueDBName();
+            const store = createStore(dbName, STORE_NAME);
+
+            await store('readwrite', (s) => {
+                s.put('value', 'key1');
+                return IDB.promisifyRequest(s.transaction);
+            });
+
+            const original = IDBDatabase.prototype.transaction;
+
+            // Drain budget to 1 remaining: fail twice, each heals successfully
+            for (let i = 0; i < 2; i++) {
+                let callCount = 0;
+                const spy = jest.spyOn(IDBDatabase.prototype, 'transaction').mockImplementation(function (this: IDBDatabase, ...args) {
+                    callCount++;
+                    if (callCount === 1) {
+                        throw backingStoreError();
+                    }
+                    spy.mockRestore();
+                    return original.apply(this, args);
+                });
+                await store('readonly', (s) => IDB.promisifyRequest(s.get('key1')));            }
+
+            // Clean success — resets budget to 3
+            jest.restoreAllMocks();
+            logInfoSpy = jest.spyOn(Logger, 'logInfo');
+            await store('readonly', (s) => IDB.promisifyRequest(s.get('key1')));
+
+            // Now fail 3 more times — all should still heal (proving budget was reset)
+            for (let i = 0; i < 3; i++) {
+                let callCount = 0;
+                const spy = jest.spyOn(IDBDatabase.prototype, 'transaction').mockImplementation(function (this: IDBDatabase, ...args) {
+                    callCount++;
+                    if (callCount === 1) {
+                        throw backingStoreError();
+                    }
+                    spy.mockRestore();
+                    return original.apply(this, args);
+                });
+                const result = await store('readonly', (s) => IDB.promisifyRequest(s.get('key1')));                expect(result).toBe('value');
+            }
+        });
+
+        it('should not attempt healing for non-backing-store errors', async () => {
+            const store = createStore(uniqueDBName(), STORE_NAME);
+
+            await store('readwrite', (s) => {
+                s.put('value', 'key1');
+                return IDB.promisifyRequest(s.transaction);
+            });
+
+            // UnknownError but different message
+            jest.spyOn(IDBDatabase.prototype, 'transaction').mockImplementation(() => {
+                throw new DOMException('Some other unknown error', 'UnknownError');
+            });
+            await expect(store('readonly', (s) => IDB.promisifyRequest(s.get('key1')))).rejects.toThrow('Some other unknown error');
+
+            jest.restoreAllMocks();
+            logInfoSpy = jest.spyOn(Logger, 'logInfo');
+
+            // QuotaExceededError
+            jest.spyOn(IDBDatabase.prototype, 'transaction').mockImplementation(() => {
+                throw new DOMException('Quota exceeded', 'QuotaExceededError');
+            });
+            await expect(store('readonly', (s) => IDB.promisifyRequest(s.get('key1')))).rejects.toThrow('Quota exceeded');
+
+            expect(logInfoSpy).not.toHaveBeenCalledWith(expect.stringContaining('IDB heal'), expect.anything());
+        });
+    });
 });

--- a/tests/unit/storage/providers/createStoreTest.ts
+++ b/tests/unit/storage/providers/createStoreTest.ts
@@ -415,4 +415,134 @@ describe('createStore', () => {
             expect(logInfoSpy).not.toHaveBeenCalledWith(expect.stringContaining('IDB heal'), expect.anything());
         });
     });
+
+    describe('connection lost healing', () => {
+        function connectionLostError() {
+            return new DOMException(
+                'Connection to Indexed Database server lost. Refresh the page to try again',
+                'UnknownError',
+            );
+        }
+
+        it('should heal by dropping cached connection and reopening', async () => {
+            const store = createStore(uniqueDBName(), STORE_NAME);
+
+            await store('readwrite', (s) => {
+                s.put('value', 'key1');
+                return IDB.promisifyRequest(s.transaction);
+            });
+
+            const original = IDBDatabase.prototype.transaction;
+            let callCount = 0;
+            jest.spyOn(IDBDatabase.prototype, 'transaction').mockImplementation(function (this: IDBDatabase, ...args) {
+                callCount++;
+                if (callCount === 1) {
+                    throw connectionLostError();
+                }
+                return original.apply(this, args);
+            });
+
+            const result = await store('readonly', (s) => IDB.promisifyRequest(s.get('key1')));
+            expect(result).toBe('value');
+            expect(callCount).toBe(2);
+            expect(logInfoSpy).toHaveBeenCalledWith(
+                'IDB heal: connection lost error, attempting drop cached connection and reopen',
+                expect.objectContaining({healAttemptsRemaining: expect.any(Number)}),
+            );
+        });
+
+        it('should stop healing after budget exhausts', async () => {
+            const store = createStore(uniqueDBName(), STORE_NAME);
+
+            // All transaction calls fail permanently with connection lost.
+            // The heal path clears dbp and calls indexedDB.open() again — mock that to
+            // also fail so fake-indexeddb doesn't deadlock waiting for the old connection
+            // to close (same pattern as the backing store budget exhaustion test).
+            jest.spyOn(IDBDatabase.prototype, 'transaction').mockImplementation(() => {
+                throw connectionLostError();
+            });
+            jest.spyOn(indexedDB, 'open').mockImplementation(() => {
+                const req = {} as IDBOpenDBRequest;
+                Promise.resolve().then(() => {
+                    Object.defineProperty(req, 'error', {value: connectionLostError(), configurable: true});
+                    req.onerror?.(new Event('error') as Event & {target: IDBOpenDBRequest});
+                });
+                return req;
+            });
+
+            // Each call drains 1 heal attempt (initial fails, heal retry also fails)
+            await expect(store('readonly', (s) => IDB.promisifyRequest(s.get('k')))).rejects.toThrow('Connection to Indexed Database server lost');
+            await expect(store('readonly', (s) => IDB.promisifyRequest(s.get('k')))).rejects.toThrow('Connection to Indexed Database server lost');
+            await expect(store('readonly', (s) => IDB.promisifyRequest(s.get('k')))).rejects.toThrow('Connection to Indexed Database server lost');
+
+            // Budget exhausted — 4th call should NOT attempt healing
+            logInfoSpy.mockClear();
+            await expect(store('readonly', (s) => IDB.promisifyRequest(s.get('k')))).rejects.toThrow('Connection to Indexed Database server lost');
+            expect(logInfoSpy).not.toHaveBeenCalledWith(expect.stringContaining('IDB heal'), expect.anything());
+        });
+
+        it('should also heal "connection is closing" variant', async () => {
+            const store = createStore(uniqueDBName(), STORE_NAME);
+
+            await store('readwrite', (s) => {
+                s.put('value', 'key1');
+                return IDB.promisifyRequest(s.transaction);
+            });
+
+            const original = IDBDatabase.prototype.transaction;
+            let callCount = 0;
+            jest.spyOn(IDBDatabase.prototype, 'transaction').mockImplementation(function (this: IDBDatabase, ...args) {
+                callCount++;
+                if (callCount === 1) {
+                    throw new DOMException('Connection is closing.', 'UnknownError');
+                }
+                return original.apply(this, args);
+            });
+
+            const result = await store('readonly', (s) => IDB.promisifyRequest(s.get('key1')));
+            expect(result).toBe('value');
+            expect(callCount).toBe(2);
+        });
+
+        it('should share heal budget with backing store errors', async () => {
+            const store = createStore(uniqueDBName(), STORE_NAME);
+
+            // All transaction calls fail permanently, alternating error types.
+            // The heal path clears dbp and calls indexedDB.open() again — mock that to
+            // also fail so fake-indexeddb doesn't deadlock waiting for the old connection
+            // to close.
+            const txErrors = [
+                new DOMException('Internal error opening backing store for indexedDB.open.', 'UnknownError'),
+                connectionLostError(),
+                new DOMException('Internal error opening backing store for indexedDB.open.', 'UnknownError'),
+            ];
+            let txErrorIndex = 0;
+            jest.spyOn(IDBDatabase.prototype, 'transaction').mockImplementation(() => {
+                const err = txErrors[Math.min(txErrorIndex, txErrors.length - 1)];
+                txErrorIndex++;
+                throw err;
+            });
+            jest.spyOn(indexedDB, 'open').mockImplementation(() => {
+                const req = {} as IDBOpenDBRequest;
+                Promise.resolve().then(() => {
+                    Object.defineProperty(req, 'error', {
+                        value: new DOMException('Internal error opening backing store for indexedDB.open.', 'UnknownError'),
+                        configurable: true,
+                    });
+                    req.onerror?.(new Event('error') as Event & {target: IDBOpenDBRequest});
+                });
+                return req;
+            });
+
+            // 3 calls drain the budget (each call: fail + heal retry fail = 1 budget)
+            await expect(store('readonly', (s) => IDB.promisifyRequest(s.get('k')))).rejects.toThrow();
+            await expect(store('readonly', (s) => IDB.promisifyRequest(s.get('k')))).rejects.toThrow();
+            await expect(store('readonly', (s) => IDB.promisifyRequest(s.get('k')))).rejects.toThrow();
+
+            // Budget exhausted — no more healing for either error type
+            logInfoSpy.mockClear();
+            await expect(store('readonly', (s) => IDB.promisifyRequest(s.get('k')))).rejects.toThrow();
+            expect(logInfoSpy).not.toHaveBeenCalledWith(expect.stringContaining('IDB heal'), expect.anything());
+        });
+    });
 });

--- a/tests/unit/storage/providers/createStoreTest.ts
+++ b/tests/unit/storage/providers/createStoreTest.ts
@@ -418,10 +418,7 @@ describe('createStore', () => {
 
     describe('connection lost healing', () => {
         function connectionLostError() {
-            return new DOMException(
-                'Connection to Indexed Database server lost. Refresh the page to try again',
-                'UnknownError',
-            );
+            return new DOMException('Connection to Indexed Database server lost. Refresh the page to try again', 'UnknownError');
         }
 
         it('should heal by dropping cached connection and reopening', async () => {

--- a/tests/unit/storage/providers/createStoreTest.ts
+++ b/tests/unit/storage/providers/createStoreTest.ts
@@ -96,7 +96,8 @@ describe('createStore', () => {
 
             await expect(store('readonly', (s) => IDB.promisifyRequest(s.get('key1')))).rejects.toThrow(DOMException);
             expect(callCount).toBe(1);
-            expect(logAlertSpy).not.toHaveBeenCalled();
+            expect(logAlertSpy).toHaveBeenCalledWith('IDB error is not recoverable, giving up', expect.objectContaining({errorMessage: 'Not found'}));
+            expect(logAlertSpy).not.toHaveBeenCalledWith(expect.stringContaining('dropping cached connection'), expect.anything());
         });
 
         it('should not retry on non-DOMException errors', async () => {
@@ -115,7 +116,8 @@ describe('createStore', () => {
 
             await expect(store('readonly', (s) => IDB.promisifyRequest(s.get('key1')))).rejects.toThrow(TypeError);
             expect(callCount).toBe(1);
-            expect(logAlertSpy).not.toHaveBeenCalled();
+            expect(logAlertSpy).toHaveBeenCalledWith('IDB error is not recoverable, giving up', expect.objectContaining({errorMessage: 'Something went wrong'}));
+            expect(logAlertSpy).not.toHaveBeenCalledWith(expect.stringContaining('dropping cached connection'), expect.anything());
         });
 
         it('should preserve data integrity after a successful retry', async () => {
@@ -174,7 +176,7 @@ describe('createStore', () => {
                 return IDB.promisifyRequest(s.transaction);
             });
 
-            expect(logAlertSpy).toHaveBeenCalledWith('IDB InvalidStateError, retrying with fresh connection', {
+            expect(logAlertSpy).toHaveBeenCalledWith('IDB InvalidStateError — dropping cached connection and retrying', {
                 dbName,
                 storeName: STORE_NAME,
                 txMode: 'readwrite',
@@ -275,7 +277,8 @@ describe('createStore', () => {
             const result = await store('readonly', (s) => IDB.promisifyRequest(s.get('key1')));
             expect(result).toBe('value');
             expect(callCount).toBe(2);
-            expect(logInfoSpy).toHaveBeenCalledWith('IDB heal: backing store error, attempting drop cached connection and reopen', expect.objectContaining({healAttemptsRemaining: 2}));
+            expect(logAlertSpy).toHaveBeenCalledWith('IDB heal: backing store error detected — dropping cached connection and reopening (2 attempts left)', expect.objectContaining({dbName: expect.any(String)}));
+            expect(logInfoSpy).toHaveBeenCalledWith('IDB heal: successfully recovered after backing store error', expect.objectContaining({dbName: expect.any(String)}));
         });
 
         it('should heal on init when indexedDB.open() rejects with UnknownError', async () => {
@@ -337,10 +340,11 @@ describe('createStore', () => {
             await expect(store('readonly', (s) => IDB.promisifyRequest(s.get('k')))).rejects.toThrow('Internal error opening backing store');
             await expect(store('readonly', (s) => IDB.promisifyRequest(s.get('k')))).rejects.toThrow('Internal error opening backing store');
 
-            // Budget exhausted — 4th call should NOT attempt healing
-            logInfoSpy.mockClear();
+            // Budget exhausted — 4th call should NOT attempt healing, but should log budget exhausted
+            logAlertSpy.mockClear();
             await expect(store('readonly', (s) => IDB.promisifyRequest(s.get('k')))).rejects.toThrow('Internal error opening backing store');
-            expect(logInfoSpy).not.toHaveBeenCalledWith(expect.stringContaining('IDB heal'), expect.anything());
+            expect(logAlertSpy).toHaveBeenCalledWith(expect.stringContaining('heal budget exhausted'), expect.anything());
+            expect(logAlertSpy).not.toHaveBeenCalledWith(expect.stringContaining('dropping cached connection and reopening'), expect.anything());
         });
 
         it('should reset heal budget after a successful operation', async () => {
@@ -404,7 +408,7 @@ describe('createStore', () => {
             await expect(store('readonly', (s) => IDB.promisifyRequest(s.get('key1')))).rejects.toThrow('Some other unknown error');
 
             jest.restoreAllMocks();
-            logInfoSpy = jest.spyOn(Logger, 'logInfo');
+            logAlertSpy = jest.spyOn(Logger, 'logAlert');
 
             // QuotaExceededError
             jest.spyOn(IDBDatabase.prototype, 'transaction').mockImplementation(() => {
@@ -412,7 +416,8 @@ describe('createStore', () => {
             });
             await expect(store('readonly', (s) => IDB.promisifyRequest(s.get('key1')))).rejects.toThrow('Quota exceeded');
 
-            expect(logInfoSpy).not.toHaveBeenCalledWith(expect.stringContaining('IDB heal'), expect.anything());
+            expect(logAlertSpy).not.toHaveBeenCalledWith(expect.stringContaining('dropping cached connection and reopening'), expect.anything());
+            expect(logAlertSpy).toHaveBeenCalledWith('IDB error is not recoverable, giving up', expect.objectContaining({errorMessage: 'Quota exceeded'}));
         });
     });
 
@@ -442,9 +447,13 @@ describe('createStore', () => {
             const result = await store('readonly', (s) => IDB.promisifyRequest(s.get('key1')));
             expect(result).toBe('value');
             expect(callCount).toBe(2);
+            expect(logAlertSpy).toHaveBeenCalledWith(
+                expect.stringContaining('connection lost error detected — dropping cached connection and reopening'),
+                expect.objectContaining({dbName: expect.any(String)}),
+            );
             expect(logInfoSpy).toHaveBeenCalledWith(
-                'IDB heal: connection lost error, attempting drop cached connection and reopen',
-                expect.objectContaining({healAttemptsRemaining: expect.any(Number)}),
+                'IDB heal: successfully recovered after connection lost error',
+                expect.objectContaining({dbName: expect.any(String)}),
             );
         });
 
@@ -472,10 +481,11 @@ describe('createStore', () => {
             await expect(store('readonly', (s) => IDB.promisifyRequest(s.get('k')))).rejects.toThrow('Connection to Indexed Database server lost');
             await expect(store('readonly', (s) => IDB.promisifyRequest(s.get('k')))).rejects.toThrow('Connection to Indexed Database server lost');
 
-            // Budget exhausted — 4th call should NOT attempt healing
-            logInfoSpy.mockClear();
+            // Budget exhausted — 4th call should NOT attempt healing, but should log budget exhausted
+            logAlertSpy.mockClear();
             await expect(store('readonly', (s) => IDB.promisifyRequest(s.get('k')))).rejects.toThrow('Connection to Indexed Database server lost');
-            expect(logInfoSpy).not.toHaveBeenCalledWith(expect.stringContaining('IDB heal'), expect.anything());
+            expect(logAlertSpy).toHaveBeenCalledWith(expect.stringContaining('heal budget exhausted'), expect.anything());
+            expect(logAlertSpy).not.toHaveBeenCalledWith(expect.stringContaining('dropping cached connection and reopening'), expect.anything());
         });
 
         it('should also heal "connection is closing" variant', async () => {
@@ -537,9 +547,10 @@ describe('createStore', () => {
             await expect(store('readonly', (s) => IDB.promisifyRequest(s.get('k')))).rejects.toThrow();
 
             // Budget exhausted — no more healing for either error type
-            logInfoSpy.mockClear();
+            logAlertSpy.mockClear();
             await expect(store('readonly', (s) => IDB.promisifyRequest(s.get('k')))).rejects.toThrow();
-            expect(logInfoSpy).not.toHaveBeenCalledWith(expect.stringContaining('IDB heal'), expect.anything());
+            expect(logAlertSpy).toHaveBeenCalledWith(expect.stringContaining('heal budget exhausted'), expect.anything());
+            expect(logAlertSpy).not.toHaveBeenCalledWith(expect.stringContaining('dropping cached connection and reopening'), expect.anything());
         });
     });
 });

--- a/tests/unit/storage/providers/createStoreTest.ts
+++ b/tests/unit/storage/providers/createStoreTest.ts
@@ -77,7 +77,7 @@ describe('createStore', () => {
             });
 
             await expect(store('readonly', (s) => IDB.promisifyRequest(s.get('key1')))).rejects.toThrow(DOMException);
-            expect(logAlertSpy).toHaveBeenCalledTimes(1);
+            expect(logInfoSpy).toHaveBeenCalledWith(expect.stringContaining('IDB InvalidStateError'), expect.anything());
         });
 
         it('should not retry on non-InvalidStateError DOMException', async () => {
@@ -176,7 +176,7 @@ describe('createStore', () => {
                 return IDB.promisifyRequest(s.transaction);
             });
 
-            expect(logAlertSpy).toHaveBeenCalledWith('IDB InvalidStateError — dropping cached connection and retrying', {
+            expect(logInfoSpy).toHaveBeenCalledWith('IDB InvalidStateError — dropping cached connection and retrying', {
                 dbName,
                 storeName: STORE_NAME,
                 txMode: 'readwrite',
@@ -277,7 +277,7 @@ describe('createStore', () => {
             const result = await store('readonly', (s) => IDB.promisifyRequest(s.get('key1')));
             expect(result).toBe('value');
             expect(callCount).toBe(2);
-            expect(logAlertSpy).toHaveBeenCalledWith(
+            expect(logInfoSpy).toHaveBeenCalledWith(
                 'IDB heal: backing store error detected — dropping cached connection and reopening (2 attempts left)',
                 expect.objectContaining({dbName: expect.any(String)}),
             );
@@ -450,7 +450,7 @@ describe('createStore', () => {
             const result = await store('readonly', (s) => IDB.promisifyRequest(s.get('key1')));
             expect(result).toBe('value');
             expect(callCount).toBe(2);
-            expect(logAlertSpy).toHaveBeenCalledWith(
+            expect(logInfoSpy).toHaveBeenCalledWith(
                 expect.stringContaining('connection lost error detected — dropping cached connection and reopening'),
                 expect.objectContaining({dbName: expect.any(String)}),
             );

--- a/tests/unit/storage/providers/createStoreTest.ts
+++ b/tests/unit/storage/providers/createStoreTest.ts
@@ -277,7 +277,10 @@ describe('createStore', () => {
             const result = await store('readonly', (s) => IDB.promisifyRequest(s.get('key1')));
             expect(result).toBe('value');
             expect(callCount).toBe(2);
-            expect(logAlertSpy).toHaveBeenCalledWith('IDB heal: backing store error detected — dropping cached connection and reopening (2 attempts left)', expect.objectContaining({dbName: expect.any(String)}));
+            expect(logAlertSpy).toHaveBeenCalledWith(
+                'IDB heal: backing store error detected — dropping cached connection and reopening (2 attempts left)',
+                expect.objectContaining({dbName: expect.any(String)}),
+            );
             expect(logInfoSpy).toHaveBeenCalledWith('IDB heal: successfully recovered after backing store error', expect.objectContaining({dbName: expect.any(String)}));
         });
 
@@ -451,10 +454,7 @@ describe('createStore', () => {
                 expect.stringContaining('connection lost error detected — dropping cached connection and reopening'),
                 expect.objectContaining({dbName: expect.any(String)}),
             );
-            expect(logInfoSpy).toHaveBeenCalledWith(
-                'IDB heal: successfully recovered after connection lost error',
-                expect.objectContaining({dbName: expect.any(String)}),
-            );
+            expect(logInfoSpy).toHaveBeenCalledWith('IDB heal: successfully recovered after connection lost error', expect.objectContaining({dbName: expect.any(String)}));
         });
 
         it('should stop healing after budget exhausts', async () => {


### PR DESCRIPTION
### Details

Adds an IDB healing mechanism in `createStore.ts` — the IDB connection manager for `IDBKeyValProvider` — addressing two sibling storage error classes:

1. **Chromium backing store corruption** — `UnknownError: Internal error opening backing store for indexedDB.open.` — 884K errors/month, 26.3% of all storage errors, Chrome/Edge only ([investigation](https://github.com/Expensify/App/issues/87862#issuecomment-4307001225), [solution design](https://github.com/Expensify/App/issues/90636))
2. **Safari connection lost** — `UnknownError: Connection to Indexed Database server lost.` — 637K errors/month, 19% of all storage errors, 100% WebKit ([investigation](https://github.com/Expensify/App/issues/87864#issuecomment-4428339647), [solution](https://github.com/Expensify/App/issues/87864#issuecomment-4445851498))

Both errors share the same structural problem: a stale cached `dbp` is never cleared, so all retries reuse the dead/corrupt connection. This is a Dexie-style heal pattern ([`PR1398_maxLoop`](https://github.com/dexie/Dexie.js/blob/master/src/functions/temp-transaction.ts)).

**What it does:**

- `isBackingStoreError()` — detects Chromium LevelDB corruption (`'Internal error opening backing store'`)
- `isConnectionLostError()` — detects Safari/WebKit connection termination (`'connection to indexed database server lost'`, `'connection is closing'`). [WebKit #197050](https://bugs.webkit.org/show_bug.cgi?id=197050), [#201483](https://bugs.webkit.org/show_bug.cgi?id=201483)
- Shared `healAttemptsRemaining` counter (3 attempts, reset on every successful IDB operation)
- On backing store or connection lost error + budget > 0: decrement counter, drop cached `dbp`, retry `executeTransaction` once (forces a fresh `indexedDB.open()`)
- Guard against stale rejection handlers clearing a newer `dbp` (capture reference, only clear if unchanged)
- Clear `dbp` on rejection in `getDB()` and `verifyStoreExists` (fixes pre-existing bug where a cached rejected promise caused infinite failures)
- Full diagnostic logging via `Logger.logAlert`/`logInfo` at every step: error detection, heal attempt, successful recovery, budget exhaustion, and non-recoverable errors

**What it does NOT do (by design per [#90636](https://github.com/Expensify/App/issues/90636)):**

- No `deleteDatabase()` — [proven to also fail](https://github.com/Expensify/App/issues/87862#issuecomment-4297398578) when LevelDB files are corrupt
- No `MemoryOnlyProvider` degradation — cache already absorbs all writes during the session
- No user-visible UI — session serves correctly from cache
- No changes to `storage/index.ts` or `OnyxUtils.ts` — those are separate issues ([#90632](https://github.com/Expensify/App/issues/90632), [#90633](https://github.com/Expensify/App/issues/90633))

### Linked E/App PR

https://github.com/Expensify/App/pull/91085

### Related Issues

https://github.com/Expensify/App/issues/90636
https://github.com/Expensify/App/issues/87862
https://github.com/Expensify/App/issues/87864

### Automated Tests

19 tests in `tests/unit/storage/providers/createStoreTest.ts`:

**InvalidStateError retry (5):** retry + succeed, retry + propagate, non-InvalidState DOMException skipped, non-DOMException skipped, data integrity after retry

**Diagnostic logging (1):** logInfo with all diagnostic fields on retry

**Onclose/onversionchange handlers (4):** log + recover for each

**Backing store healing (5):** mid-session heal, init-time heal, budget exhaustion, budget reset, error classification (wrong message / QuotaExceeded bypass)

**Connection lost healing (4):** heal + reopen, budget exhaustion, "connection is closing" variant, shared budget with backing store

All tests pass.

### Manual Tests

Each test injects a monkey-patch via the browser console to simulate the error class, then triggers an Onyx write (e.g. navigate to a different chat). No code changes needed.

**Test 1 — Backing store error (Chromium path):**
1. Open the app in Chrome, log in, navigate to any chat
2. Paste in DevTools console:
   ```js
   const _origTx = IDBDatabase.prototype.transaction;
   let _fired = false;
   IDBDatabase.prototype.transaction = function(...args) {
     if (!_fired) {
       _fired = true;
       IDBDatabase.prototype.transaction = _origTx;
       throw new DOMException('Internal error opening backing store', 'UnknownError');
     }
     return _origTx.apply(this, args);
   };
   ```
3. Navigate to a different chat (triggers Onyx write)
4. Expected log sequence:
   - `[Onyx] IDB heal: backing store error detected — dropping cached connection and reopening (2 attempts left)`
   - `[Onyx] IDB heal: successfully recovered after backing store error`
5. ✅ App recovers — navigation works, no white screen, subsequent operations succeed

**Test 2 — Connection lost (Safari path):**
1. Same setup as Test 1
2. Paste in DevTools console:
   ```js
   const _origTx = IDBDatabase.prototype.transaction;
   let _fired = false;
   IDBDatabase.prototype.transaction = function(...args) {
     if (!_fired) {
       _fired = true;
       IDBDatabase.prototype.transaction = _origTx;
       throw new DOMException('Connection to Indexed Database server lost', 'UnknownError');
     }
     return _origTx.apply(this, args);
   };
   ```
3. Navigate to a different chat
4. Expected log sequence:
   - `[Onyx] IDB heal: connection lost error detected — dropping cached connection and reopening (2 attempts left)`
   - `[Onyx] IDB heal: successfully recovered after connection lost error`
5. ✅ App recovers seamlessly

**Test 3 — Budget exhaustion (permanent failure, then gives up):**
1. Same setup as Test 1
2. Paste in DevTools console:
   ```js
   const _origTx = IDBDatabase.prototype.transaction;
   IDBDatabase.prototype.transaction = function(...args) {
     throw new DOMException('Internal error opening backing store', 'UnknownError');
   };
   ```
3. Navigate to 4 different chats in sequence (each navigation triggers an Onyx write that exercises the heal path). After each navigation, wait for the error logs to appear before navigating again.
4. Expected log sequence across the 4 navigations:
   - Navigation 1: `[Onyx] IDB heal: backing store error detected — dropping cached connection and reopening (2 attempts left)` (heal retry also fails — error propagates)
   - Navigation 2: `[Onyx] IDB heal: backing store error detected — dropping cached connection and reopening (1 attempts left)` (heal retry also fails)
   - Navigation 3: `[Onyx] IDB heal: backing store error detected — dropping cached connection and reopening (0 attempts left)` (heal retry also fails)
   - Navigation 4: `[Onyx] IDB heal: backing store error — heal budget exhausted, giving up` (no heal attempted)
5. ✅ App continues from cache — may show degraded behavior but should not crash or white-screen
6. To restore: paste `IDBDatabase.prototype.transaction = _origTx;` or refresh the page

### Author Checklist

- [x] I linked the correct issue in the `### Related Issues` section above
- [x] I linked the corresponding Expensify/App PR in the `### Linked E/App PR` section above, and verified this change against it (E/App CI passed and manual testing completed)
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos

> This PR modifies only the IDB connection manager (`createStore.ts`) — a web-only storage internals file with no UI changes. Screenshots/videos of manual test console output will be attached after integration testing via [E/App PR #91085](https://github.com/Expensify/App/pull/91085).

<details>
<summary>Android: Native</summary>

N/A — IDB is web-only, no native changes.

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- To be added after manual testing -->

</details>

<details>
<summary>iOS: Native</summary>

N/A — IDB is web-only, no native changes.

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- To be added after manual testing -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- To be added after manual testing -->
**Healed (simulated error):**

https://github.com/user-attachments/assets/e42fc3c0-38ca-416a-882e-89f907b77270


Killed connection (simulated error):

https://github.com/user-attachments/assets/f154bdae-4968-4152-9fc8-034dc95a6566


**Exhausted (simulated error):**

https://github.com/user-attachments/assets/6021d445-b871-43e8-b844-47c8ef8d73aa



Healed (simulated on Safari):

https://github.com/user-attachments/assets/6f2375fc-78b9-48be-b90e-d904ac939805


Killed connection (simulated on Safari):

https://github.com/user-attachments/assets/f7e6df4a-5b22-4415-aee1-fbaaae442567


Exhausted (simulated on Safari):

https://github.com/user-attachments/assets/38578b0f-6553-4183-8066-0bbc0fa07c66


**Healed offline (simulated on Chrome):**

https://github.com/user-attachments/assets/3106976c-e980-498c-a70e-8e8ca7c1ccda



</details>


