### PR TITLE
Remove initWithStoredValues from Onyx

### DIFF
--- a/API-INTERNAL.md
+++ b/API-INTERNAL.md
@@ -299,10 +299,6 @@ When a collection of keys change, search for any callbacks matching the collecti
 When a key change happens, search for any callbacks matching the key or collection key and trigger those callbacks
 
 **Kind**: global function  
-**Example**  
-```js
-keyChanged(key, value, subscriber => subscriber.initWithStoredValues === false)
-```
 <a name="sendDataToConnection"></a>
 
 ## sendDataToConnection()

--- a/lib/OnyxConnectionManager.ts
+++ b/lib/OnyxConnectionManager.ts
@@ -115,7 +115,7 @@ class OnyxConnectionManager {
      * according to their purpose and effect they produce in the Onyx connection.
      */
     private generateConnectionID<TKey extends OnyxKey>(connectOptions: ConnectOptions<TKey>): string {
-        const {key, initWithStoredValues, reuseConnection, waitForCollectionCallback} = connectOptions;
+        const {key, reuseConnection, waitForCollectionCallback} = connectOptions;
 
         // The current session ID is appended to the connection ID so we can have different connections
         // after an `Onyx.clear()` operation.
@@ -123,18 +123,13 @@ class OnyxConnectionManager {
 
         // We will generate a unique ID in any of the following situations:
         // - `reuseConnection` is `false`. That means the subscriber explicitly wants the connection to not be reused.
-        // - `initWithStoredValues` is `false`. This flag changes the subscription flow when set to `false`, so the connection can't be reused.
         // - `key` is a collection key AND `waitForCollectionCallback` is `undefined/false`. This combination needs a new connection at every subscription
         //   in order to send all the collection entries, so the connection can't be reused.
-        if (
-            reuseConnection === false ||
-            initWithStoredValues === false ||
-            (OnyxKeys.isCollectionKey(key) && (waitForCollectionCallback === undefined || waitForCollectionCallback === false))
-        ) {
+        if (reuseConnection === false || (OnyxKeys.isCollectionKey(key) && (waitForCollectionCallback === undefined || waitForCollectionCallback === false))) {
             suffix += `,uniqueID=${Str.guid()}`;
         }
 
-        return `onyxKey=${key},initWithStoredValues=${initWithStoredValues ?? true},waitForCollectionCallback=${waitForCollectionCallback ?? false}${suffix}`;
+        return `onyxKey=${key},waitForCollectionCallback=${waitForCollectionCallback ?? false}${suffix}`;
     }
 
     /**

--- a/lib/OnyxSnapshotCache.ts
+++ b/lib/OnyxSnapshotCache.ts
@@ -58,17 +58,13 @@ class OnyxSnapshotCache {
      * according to their purpose and effect they produce in the useOnyx hook behavior:
      *
      * - `selector`: Different selectors produce different results, so each selector needs its own cache entry
-     * - `initWithStoredValues`: This flag changes the initial loading behavior and affects the returned fetch status
      *
      * Other options like `reuseConnection` don't affect the data transformation
      * or timing behavior of getSnapshot, so they're excluded from the cache key for better cache hit rates.
      */
-    registerConsumer<TKey extends OnyxKey, TReturnValue>(options: Pick<UseOnyxOptions<TKey, TReturnValue>, 'selector' | 'initWithStoredValues'>): string {
+    registerConsumer<TKey extends OnyxKey, TReturnValue>(options: Pick<UseOnyxOptions<TKey, TReturnValue>, 'selector'>): string {
         const selectorID = options?.selector ? this.getSelectorID(options.selector) : 'no_selector';
-
-        // Create options hash without expensive JSON.stringify
-        const initWithStoredValues = options?.initWithStoredValues ?? true;
-        const cacheKey = `${selectorID}_${initWithStoredValues}`;
+        const cacheKey = `${selectorID}`;
 
         // Increment reference count for this cache key
         const currentCount = this.cacheKeyRefCounts.get(cacheKey) || 0;

--- a/lib/OnyxSnapshotCache.ts
+++ b/lib/OnyxSnapshotCache.ts
@@ -64,7 +64,7 @@ class OnyxSnapshotCache {
      */
     registerConsumer<TKey extends OnyxKey, TReturnValue>(options: Pick<UseOnyxOptions<TKey, TReturnValue>, 'selector'>): string {
         const selectorID = options?.selector ? this.getSelectorID(options.selector) : 'no_selector';
-        const cacheKey = `${selectorID}`;
+        const cacheKey = String(selectorID);
 
         // Increment reference count for this cache key
         const currentCount = this.cacheKeyRefCounts.get(cacheKey) || 0;

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -613,9 +613,6 @@ function keysChanged<TKey extends CollectionKeyBase>(
 
 /**
  * When a key change happens, search for any callbacks matching the key or collection key and trigger those callbacks
- *
- * @example
- * keyChanged(key, value, subscriber => subscriber.initWithStoredValues === false)
  */
 function keyChanged<TKey extends OnyxKey>(
     key: TKey,
@@ -820,13 +817,11 @@ function retryOperation<TMethod extends RetriableOnyxOperation>(error: Error, on
  * Notifies subscribers and writes current value to cache
  */
 function broadcastUpdate<TKey extends OnyxKey>(key: TKey, value: OnyxValue<TKey>, hasChanged?: boolean): void {
-    // Update subscribers if the cached value has changed, or when the subscriber specifically requires
-    // all updates regardless of value changes (indicated by initWithStoredValues set to false).
     if (hasChanged) {
         cache.set(key, value);
     }
 
-    keyChanged(key, value, (subscriber) => hasChanged || subscriber?.initWithStoredValues === false);
+    keyChanged(key, value, () => !!hasChanged);
 }
 
 function hasPendingMergeForKey(key: OnyxKey): boolean {
@@ -1069,10 +1064,6 @@ function subscribeToKey<TKey extends OnyxKey>(connectOptions: ConnectOptions<TKe
     // to avoid having to loop through all the Subscribers all the time (even when just one connection belongs to one key),
     // We create a mapping from key to lists of subscriptionIDs to access the specific list of subscriptionIDs.
     storeKeyBySubscriptions(mapping.key, callbackToStateMapping[subscriptionID].subscriptionID);
-
-    if (mapping.initWithStoredValues === false) {
-        return subscriptionID;
-    }
 
     // Commit connection only after init passes
     deferredInitTask.promise

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -817,11 +817,12 @@ function retryOperation<TMethod extends RetriableOnyxOperation>(error: Error, on
  * Notifies subscribers and writes current value to cache
  */
 function broadcastUpdate<TKey extends OnyxKey>(key: TKey, value: OnyxValue<TKey>, hasChanged?: boolean): void {
-    if (hasChanged) {
-        cache.set(key, value);
+    if (!hasChanged) {
+        return;
     }
 
-    keyChanged(key, value, () => !!hasChanged);
+    cache.set(key, value);
+    keyChanged(key, value);
 }
 
 function hasPendingMergeForKey(key: OnyxKey): boolean {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -212,9 +212,6 @@ type Collection<TKey extends CollectionKeyBase, TValue> = Record<`${TKey}${strin
 /** Represents the base options used in `Onyx.connect()` method. */
 // NOTE: Any changes to this type like adding or removing options must be accounted in OnyxConnectionManager's `generateConnectionID()` method!
 type BaseConnectOptions = {
-    /** If set to `false`, then the initial data will be only sent to the callback function if it changes. */
-    initWithStoredValues?: boolean;
-
     /**
      * If set to `false`, the connection won't be reused between other subscribers that are listening to the same Onyx key
      * with the same connect configurations.

--- a/lib/useOnyx.ts
+++ b/lib/useOnyx.ts
@@ -14,12 +14,6 @@ type UseOnyxSelector<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>> = (da
 
 type UseOnyxOptions<TKey extends OnyxKey, TReturnValue> = {
     /**
-     * If set to `false`, then no data will be prefilled into the component.
-     * @deprecated This param is going to be removed soon. Use RAM-only keys instead.
-     */
-    initWithStoredValues?: boolean;
-
-    /**
      * If set to `false`, the connection won't be reused between other subscribers that are listening to the same Onyx key
      * with the same connect configurations.
      */
@@ -97,11 +91,10 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
 
     // Stores the previously result returned by the hook, containing the data from cache and the fetch status.
     // We initialize it to `undefined` and `loading` fetch status to simulate the initial result when the hook is loading from the cache.
-    // However, if `initWithStoredValues` is `false` we set the fetch status to `loaded` since we want to signal that data is ready.
     const resultRef = useRef<UseOnyxResult<TReturnValue>>([
         undefined,
         {
-            status: options?.initWithStoredValues === false ? 'loaded' : 'loading',
+            status: 'loading',
         },
     ]);
 
@@ -133,9 +126,8 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
         () =>
             onyxSnapshotCache.registerConsumer({
                 selector: options?.selector,
-                initWithStoredValues: options?.initWithStoredValues,
             }),
-        [options?.selector, options?.initWithStoredValues],
+        [options?.selector],
     );
 
     useEffect(() => () => onyxSnapshotCache.deregisterConsumer(key, cacheKey), [key, cacheKey]);
@@ -174,24 +166,14 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
 
     const getSnapshot = useCallback(() => {
         // Check if we have any cache for this Onyx key
-        // Don't use cache for first connection with initWithStoredValues: false
-        // Also don't use cache during active data updates (when shouldGetCachedValueRef is true)
+        // Don't use cache during active data updates (when shouldGetCachedValueRef is true)
         const isFirstConnection = connectedKeyRef.current !== key;
-        if (!(isFirstConnection && options?.initWithStoredValues === false) && !shouldGetCachedValueRef.current) {
+        if (!shouldGetCachedValueRef.current) {
             const cachedResult = onyxSnapshotCache.getCachedResult<UseOnyxResult<TReturnValue>>(key, cacheKey);
             if (cachedResult !== undefined) {
                 resultRef.current = cachedResult;
                 return cachedResult;
             }
-        }
-
-        // We return the initial result right away during the first connection if `initWithStoredValues` is set to `false`.
-        if (isFirstConnection && options?.initWithStoredValues === false) {
-            const result = resultRef.current;
-
-            // Store result in snapshot cache
-            onyxSnapshotCache.setCachedResult<UseOnyxResult<TReturnValue>>(key, cacheKey, result);
-            return result;
         }
 
         // We get the value from cache while the first connection to Onyx is being made or if the key has changed,
@@ -255,7 +237,7 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
         }
 
         return resultRef.current;
-    }, [options?.initWithStoredValues, key, memoizedSelector, cacheKey]);
+    }, [key, memoizedSelector, cacheKey]);
 
     const subscribe = useCallback(
         (onStoreChange: () => void) => {
@@ -266,7 +248,7 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
                 previousValueRef.current = null;
                 newValueRef.current = null;
                 sourceValueRef.current = undefined;
-                resultRef.current = [undefined, {status: options?.initWithStoredValues === false ? 'loaded' : 'loading'}];
+                resultRef.current = [undefined, {status: 'loading'}];
             }
             // Force a cache re-read on every (re)subscription so any side effects from
             // subscribeToKey (e.g. addNullishStorageKey for skippable collection member ids)
@@ -299,7 +281,6 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
                     // Finally, we signal that the store changed, making `getSnapshot()` be called again.
                     onStoreChange();
                 },
-                initWithStoredValues: options?.initWithStoredValues,
                 waitForCollectionCallback: OnyxKeys.isCollectionKey(key) as true,
                 reuseConnection: options?.reuseConnection,
             });
@@ -315,7 +296,7 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
                 onStoreChangeFnRef.current = null;
             };
         },
-        [key, options?.initWithStoredValues, options?.reuseConnection],
+        [key, options?.reuseConnection],
     );
 
     const result = useSyncExternalStore<UseOnyxResult<TReturnValue>>(subscribe, getSnapshot);

--- a/tests/perf-test/OnyxSnapshotCache.perf-test.ts
+++ b/tests/perf-test/OnyxSnapshotCache.perf-test.ts
@@ -37,12 +37,10 @@ const complexSelector: UseOnyxSelector<OnyxKey, ComplexSelectorResult> = (data) 
 
 const selectorOptions: UseOnyxOptions<string, number | undefined> = {
     selector: simpleSelector,
-    initWithStoredValues: true,
 };
 
 const complexSelectorOptions: UseOnyxOptions<string, ComplexSelectorResult> = {
     selector: complexSelector,
-    initWithStoredValues: true,
 };
 
 // Mock results

--- a/tests/perf-test/OnyxUtils.perf-test.ts
+++ b/tests/perf-test/OnyxUtils.perf-test.ts
@@ -310,7 +310,7 @@ describe('OnyxUtils', () => {
                 beforeEach: async () => {
                     await Onyx.multiSet(mockedReportActionsMap);
                     for (const key of mockedReportActionsKeys) {
-                        const id = OnyxUtils.subscribeToKey({key, callback: jest.fn(), initWithStoredValues: false});
+                        const id = OnyxUtils.subscribeToKey({key, callback: jest.fn()});
                         subscriptionMap.set(key, id);
                     }
                 },
@@ -340,7 +340,7 @@ describe('OnyxUtils', () => {
                 beforeEach: async () => {
                     await Onyx.set(key, previousReportAction);
                     for (let i = 0; i < 10000; i++) {
-                        const id = OnyxUtils.subscribeToKey({key, callback: jest.fn(), initWithStoredValues: false});
+                        const id = OnyxUtils.subscribeToKey({key, callback: jest.fn()});
                         subscriptionIDs.add(id);
                     }
                 },
@@ -372,7 +372,7 @@ describe('OnyxUtils', () => {
                 {
                     beforeEach: async () => {
                         await Onyx.multiSet(mockedReportActionsMap);
-                        subscriptionID = OnyxUtils.subscribeToKey({key: collectionKey, callback: jest.fn(), initWithStoredValues: false});
+                        subscriptionID = OnyxUtils.subscribeToKey({key: collectionKey, callback: jest.fn()});
                     },
                     afterEach: async () => {
                         if (subscriptionID) {
@@ -402,7 +402,6 @@ describe('OnyxUtils', () => {
                     subscriptionID = OnyxUtils.subscribeToKey({
                         key: collectionKey,
                         callback: jest.fn(),
-                        initWithStoredValues: false,
                     });
 
                     OnyxUtils.getCollectionDataAndSendAsObject(mockedReportActionsKeys, {
@@ -650,7 +649,6 @@ describe('OnyxUtils', () => {
                 beforeEach: async () => {
                     subscriptionID = OnyxUtils.subscribeToKey({
                         key,
-                        initWithStoredValues: false,
                     });
                 },
                 afterEach: clearOnyxAfterEachMeasure,
@@ -692,7 +690,6 @@ describe('OnyxUtils', () => {
                 beforeEach: async () => {
                     subscriptionID = OnyxUtils.subscribeToKey({
                         key,
-                        initWithStoredValues: false,
                     });
                 },
                 afterEach: async () => {
@@ -713,7 +710,6 @@ describe('OnyxUtils', () => {
                 beforeEach: async () => {
                     subscriptionID = OnyxUtils.subscribeToKey({
                         key,
-                        initWithStoredValues: false,
                     });
                     OnyxUtils.storeKeyBySubscriptions(key, subscriptionID);
                 },

--- a/tests/perf-test/useOnyx.perf-test.tsx
+++ b/tests/perf-test/useOnyx.perf-test.tsx
@@ -196,31 +196,6 @@ describe('useOnyx', () => {
         });
     });
 
-    describe('initWithStoredValues', () => {
-        /**
-         * Expected renders: 1.
-         */
-        test('connecting with initWithStoredValues set to false', async () => {
-            const key = ONYXKEYS.TEST_KEY;
-            await measureRenders(
-                <UseOnyxWrapper
-                    onyxKey={key}
-                    onyxOptions={{initWithStoredValues: false}}
-                />,
-                {
-                    beforeEach: async () => {
-                        await StorageMock.setItem(key, 'test');
-                    },
-                    scenario: async () => {
-                        await screen.findByText(dataMatcher(key, undefined));
-                        await screen.findByText(metadataStatusMatcher(key, 'loaded'));
-                    },
-                    afterEach: clearOnyxAfterEachMeasure,
-                },
-            );
-        });
-    });
-
     describe('multiple calls', () => {
         /**
          * Expected renders: 2.

--- a/tests/unit/OnyxConnectionManagerTest.ts
+++ b/tests/unit/OnyxConnectionManagerTest.ts
@@ -39,23 +39,20 @@ describe('OnyxConnectionManager', () => {
     describe('generateConnectionID', () => {
         it('should generate a stable connection ID', async () => {
             const connectionID = generateConnectionID({key: ONYXKEYS.TEST_KEY});
-            expect(connectionID).toEqual(`onyxKey=${ONYXKEYS.TEST_KEY},initWithStoredValues=true,waitForCollectionCallback=false,sessionID=${getSessionID()}`);
+            expect(connectionID).toEqual(`onyxKey=${ONYXKEYS.TEST_KEY},waitForCollectionCallback=false,sessionID=${getSessionID()}`);
         });
 
         it("should generate a stable connection ID regardless of the order which the option's properties were passed", async () => {
-            const connectionID = generateConnectionID({key: ONYXKEYS.TEST_KEY, waitForCollectionCallback: true, initWithStoredValues: true});
-            expect(connectionID).toEqual(`onyxKey=${ONYXKEYS.TEST_KEY},initWithStoredValues=true,waitForCollectionCallback=true,sessionID=${getSessionID()}`);
+            const connectionID = generateConnectionID({key: ONYXKEYS.TEST_KEY, waitForCollectionCallback: true});
+            expect(connectionID).toEqual(`onyxKey=${ONYXKEYS.TEST_KEY},waitForCollectionCallback=true,sessionID=${getSessionID()}`);
         });
 
         it('should generate unique connection IDs if certain options are passed', async () => {
             const connectionID1 = generateConnectionID({key: ONYXKEYS.TEST_KEY, reuseConnection: false});
             const connectionID2 = generateConnectionID({key: ONYXKEYS.TEST_KEY, reuseConnection: false});
-            expect(connectionID1.startsWith(`onyxKey=${ONYXKEYS.TEST_KEY},initWithStoredValues=true,waitForCollectionCallback=false,sessionID=${getSessionID()},uniqueID=`)).toBeTruthy();
-            expect(connectionID2.startsWith(`onyxKey=${ONYXKEYS.TEST_KEY},initWithStoredValues=true,waitForCollectionCallback=false,sessionID=${getSessionID()},uniqueID=`)).toBeTruthy();
+            expect(connectionID1.startsWith(`onyxKey=${ONYXKEYS.TEST_KEY},waitForCollectionCallback=false,sessionID=${getSessionID()},uniqueID=`)).toBeTruthy();
+            expect(connectionID2.startsWith(`onyxKey=${ONYXKEYS.TEST_KEY},waitForCollectionCallback=false,sessionID=${getSessionID()},uniqueID=`)).toBeTruthy();
             expect(connectionID1).not.toEqual(connectionID2);
-
-            const connectionID3 = generateConnectionID({key: ONYXKEYS.TEST_KEY, initWithStoredValues: false});
-            expect(connectionID3.startsWith(`onyxKey=${ONYXKEYS.TEST_KEY},initWithStoredValues=false,waitForCollectionCallback=false,sessionID=${getSessionID()},uniqueID=`)).toBeTruthy();
         });
 
         it('should generate an unique connection ID if the session ID is changed', async () => {
@@ -220,43 +217,6 @@ describe('OnyxConnectionManager', () => {
             expect(connectionsMap.size).toEqual(2);
             expect(connectionsMap.has(connection1.id)).toBeTruthy();
             expect(connectionsMap.has(connection2.id)).toBeTruthy();
-        });
-
-        it('should create a separate connection to the same key when setting initWithStoredValues to false', async () => {
-            await StorageMock.setItem(ONYXKEYS.TEST_KEY, 'test');
-
-            const callback1 = jest.fn();
-            const connection1 = connectionManager.connect({key: ONYXKEYS.TEST_KEY, initWithStoredValues: false, callback: callback1});
-
-            await act(async () => waitForPromisesToResolve());
-
-            expect(callback1).not.toHaveBeenCalled();
-            expect(connectionsMap.size).toEqual(1);
-            expect(connectionsMap.has(connection1.id)).toBeTruthy();
-
-            await Onyx.set(ONYXKEYS.TEST_KEY, 'test2');
-
-            expect(callback1).toHaveBeenCalledTimes(1);
-            expect(callback1).toHaveBeenCalledWith('test2', ONYXKEYS.TEST_KEY);
-
-            const callback2 = jest.fn();
-            const connection2 = connectionManager.connect({key: ONYXKEYS.TEST_KEY, initWithStoredValues: false, callback: callback2});
-
-            await act(async () => waitForPromisesToResolve());
-
-            expect(callback2).not.toHaveBeenCalled();
-            expect(connectionsMap.size).toEqual(2);
-            expect(connectionsMap.has(connection2.id)).toBeTruthy();
-
-            await Onyx.set(ONYXKEYS.TEST_KEY, 'test3');
-
-            expect(callback2).toHaveBeenCalledTimes(1);
-            expect(callback2).toHaveBeenCalledWith('test3', ONYXKEYS.TEST_KEY);
-
-            connectionManager.disconnect(connection1);
-            connectionManager.disconnect(connection2);
-
-            expect(connectionsMap.size).toEqual(0);
         });
 
         it("should create a separate connection to the same key when it's a collection one and waitForCollectionCallback is undefined/false", async () => {

--- a/tests/unit/OnyxSnapshotCacheTest.ts
+++ b/tests/unit/OnyxSnapshotCacheTest.ts
@@ -38,22 +38,20 @@ describe('OnyxSnapshotCache', () => {
             };
             const optionsWithSelector: UseOnyxOptions<OnyxKey, string> = {
                 selector,
-                initWithStoredValues: true,
             };
-            const optionsWithoutSelector: UseOnyxOptions<OnyxKey, string> = {
-                initWithStoredValues: false,
-            };
+            const optionsWithoutSelector: UseOnyxOptions<OnyxKey, string> = {};
             const keyWithSelector = cache.registerConsumer(optionsWithSelector);
             const keyWithoutSelector = cache.registerConsumer(optionsWithoutSelector);
             const keyWithUndefined = cache.registerConsumer({});
 
             // Different option combinations should produce different cache keys
-            expect(keyWithSelector).toContain('0_'); // Should contain selector ID
+            expect(keyWithSelector).toContain('0'); // Should contain selector ID
             expect(keyWithoutSelector).toContain('no_selector'); // Should indicate no selector
             expect(keyWithUndefined).toContain('no_selector'); // Should indicate no selector
 
-            // All keys should be unique
-            expect(new Set([keyWithSelector, keyWithoutSelector, keyWithUndefined]).size).toBe(3);
+            // Selector key is unique; the two no-selector keys are equal
+            expect(keyWithSelector).not.toEqual(keyWithoutSelector);
+            expect(keyWithoutSelector).toEqual(keyWithUndefined);
         });
 
         it('should store and retrieve cached results', () => {

--- a/tests/unit/OnyxSnapshotCacheTest.ts
+++ b/tests/unit/OnyxSnapshotCacheTest.ts
@@ -44,14 +44,10 @@ describe('OnyxSnapshotCache', () => {
             const keyWithoutSelector = cache.registerConsumer(optionsWithoutSelector);
             const keyWithUndefined = cache.registerConsumer({});
 
-            // Different option combinations should produce different cache keys
-            expect(keyWithSelector).toContain('0'); // Should contain selector ID
-            expect(keyWithoutSelector).toContain('no_selector'); // Should indicate no selector
-            expect(keyWithUndefined).toContain('no_selector'); // Should indicate no selector
-
-            // Selector key is unique; the two no-selector keys are equal
-            expect(keyWithSelector).not.toEqual(keyWithoutSelector);
-            expect(keyWithoutSelector).toEqual(keyWithUndefined);
+            // Selector cache keys are the selector ID as a string; no-selector consumers share the same key
+            expect(keyWithSelector).toBe('0');
+            expect(keyWithoutSelector).toBe('no_selector');
+            expect(keyWithUndefined).toBe('no_selector');
         });
 
         it('should store and retrieve cached results', () => {

--- a/tests/unit/onyxClearNativeStorageTest.ts
+++ b/tests/unit/onyxClearNativeStorageTest.ts
@@ -34,7 +34,6 @@ describe('Set data while storage is clearing', () => {
         });
         connection = Onyx.connect({
             key: ONYX_KEYS.DEFAULT_KEY,
-            initWithStoredValues: false,
             callback: (val) => (onyxValue = val),
         });
         return waitForPromisesToResolve();
@@ -86,7 +85,6 @@ describe('Set data while storage is clearing', () => {
         let regularKeyOnyxValue: unknown;
         Onyx.connect({
             key: ONYX_KEYS.REGULAR_KEY,
-            initWithStoredValues: false,
             callback: (val) => (regularKeyOnyxValue = val),
         });
         Onyx.set(ONYX_KEYS.REGULAR_KEY, SET_VALUE).then(() => {

--- a/tests/unit/onyxClearWebStorageTest.ts
+++ b/tests/unit/onyxClearWebStorageTest.ts
@@ -36,7 +36,6 @@ describe('Set data while storage is clearing', () => {
         });
         connection = Onyx.connect({
             key: ONYX_KEYS.DEFAULT_KEY,
-            initWithStoredValues: false,
             callback: (val) => (onyxValue = val),
         });
         return waitForPromisesToResolve();
@@ -90,7 +89,6 @@ describe('Set data while storage is clearing', () => {
         let regularKeyOnyxValue: unknown;
         Onyx.connect({
             key: ONYX_KEYS.REGULAR_KEY,
-            initWithStoredValues: false,
             callback: (val) => (regularKeyOnyxValue = val),
         });
         Onyx.set(ONYX_KEYS.REGULAR_KEY, SET_VALUE).then(() => {

--- a/tests/unit/onyxTest.ts
+++ b/tests/unit/onyxTest.ts
@@ -92,7 +92,6 @@ describe('Onyx', () => {
 
         connection = Onyx.connect({
             key: ONYX_KEYS.TEST_KEY,
-            initWithStoredValues: false,
             callback: (value) => {
                 testKeyValue = value;
             },
@@ -109,7 +108,6 @@ describe('Onyx', () => {
 
         connection = Onyx.connect({
             key: ONYX_KEYS.TEST_KEY,
-            initWithStoredValues: false,
             callback: (value) => {
                 testKeyValue = value;
             },
@@ -132,7 +130,6 @@ describe('Onyx', () => {
             key: ONYX_KEYS.TEST_KEY,
             callback: mockCallback,
             // True is the default, just setting it here to be explicit
-            initWithStoredValues: true,
         });
 
         return Onyx.set(ONYX_KEYS.TEST_KEY, 'test').then(() => {
@@ -145,7 +142,6 @@ describe('Onyx', () => {
 
         connection = Onyx.connect({
             key: ONYX_KEYS.TEST_KEY,
-            initWithStoredValues: false,
             callback: (value) => {
                 testKeyValue = value;
             },
@@ -166,7 +162,6 @@ describe('Onyx', () => {
 
         connection = Onyx.connect({
             key: ONYX_KEYS.TEST_KEY,
-            initWithStoredValues: false,
             callback: (value) => {
                 testKeyValue = value;
             },
@@ -187,7 +182,6 @@ describe('Onyx', () => {
 
         connection = Onyx.connect({
             key: ONYX_KEYS.TEST_KEY,
-            initWithStoredValues: false,
             callback: (value) => {
                 testKeyValue = value;
             },
@@ -204,7 +198,6 @@ describe('Onyx', () => {
 
         connection = Onyx.connect({
             key: ONYX_KEYS.TEST_KEY,
-            initWithStoredValues: false,
             callback: (value) => {
                 testKeyValue = value;
             },
@@ -222,7 +215,6 @@ describe('Onyx', () => {
 
         connection = Onyx.connect({
             key: ONYX_KEYS.COLLECTION.TEST_KEY,
-            initWithStoredValues: false,
             waitForCollectionCallback: true,
             callback: (value) => {
                 testKeyValue = value;
@@ -240,7 +232,6 @@ describe('Onyx', () => {
 
         connection = Onyx.connect({
             key: ONYX_KEYS.TEST_KEY,
-            initWithStoredValues: false,
             callback: (value) => {
                 testKeyValue = value;
             },
@@ -256,7 +247,6 @@ describe('Onyx', () => {
         let testKeyValue: unknown;
         connection = Onyx.connect({
             key: ONYX_KEYS.TEST_KEY,
-            initWithStoredValues: false,
             callback: (value) => {
                 testKeyValue = value;
             },
@@ -324,7 +314,6 @@ describe('Onyx', () => {
         let testKeyValue: unknown;
         connection = Onyx.connect({
             key: ONYX_KEYS.TEST_KEY,
-            initWithStoredValues: false,
             callback: (value) => {
                 testKeyValue = value;
             },
@@ -348,7 +337,6 @@ describe('Onyx', () => {
         let testKeyValue: unknown;
         connection = Onyx.connect({
             key: ONYX_KEYS.TEST_KEY,
-            initWithStoredValues: false,
             callback: (value) => {
                 testKeyValue = value;
             },
@@ -369,7 +357,6 @@ describe('Onyx', () => {
         let testKeyValue: unknown;
         connection = Onyx.connect({
             key: ONYX_KEYS.TEST_KEY,
-            initWithStoredValues: false,
             callback: (value) => {
                 testKeyValue = value;
             },
@@ -385,7 +372,6 @@ describe('Onyx', () => {
         let testKeyValue: unknown;
         connection = Onyx.connect({
             key: ONYX_KEYS.TEST_KEY,
-            initWithStoredValues: false,
             callback: (value) => {
                 testKeyValue = value;
             },
@@ -402,7 +388,6 @@ describe('Onyx', () => {
 
         connection = Onyx.connect({
             key: ONYX_KEYS.TEST_KEY,
-            initWithStoredValues: false,
             callback: (value) => {
                 testKeyValue = value;
             },
@@ -463,7 +448,6 @@ describe('Onyx', () => {
 
         connection = Onyx.connect({
             key: ONYX_KEYS.TEST_KEY,
-            initWithStoredValues: false,
             callback: (value) => {
                 testKeyValue = value;
             },
@@ -511,7 +495,6 @@ describe('Onyx', () => {
         let testKeyValue: unknown;
         connection = Onyx.connect({
             key: ONYX_KEYS.TEST_KEY,
-            initWithStoredValues: false,
             callback: (value) => {
                 testKeyValue = value;
             },
@@ -520,7 +503,6 @@ describe('Onyx', () => {
         let otherTestKeyValue: unknown;
         connection = Onyx.connect({
             key: ONYX_KEYS.OTHER_TEST,
-            initWithStoredValues: false,
             callback: (value) => {
                 otherTestKeyValue = value;
             },
@@ -570,7 +552,6 @@ describe('Onyx', () => {
 
         connection = Onyx.connect({
             key: ONYX_KEYS.TEST_KEY,
-            initWithStoredValues: false,
             callback: (value) => {
                 testKeyValue = value;
             },
@@ -617,7 +598,6 @@ describe('Onyx', () => {
 
         connection = Onyx.connect({
             key: ONYX_KEYS.COLLECTION.TEST_KEY,
-            initWithStoredValues: false,
             callback: (value) => (result = value),
             waitForCollectionCallback: true,
         });
@@ -652,7 +632,6 @@ describe('Onyx', () => {
         let testKeyValue: unknown;
         connection = Onyx.connect({
             key: ONYX_KEYS.TEST_KEY,
-            initWithStoredValues: false,
             callback: (value) => {
                 testKeyValue = value;
             },
@@ -668,7 +647,6 @@ describe('Onyx', () => {
         let testKeyValue: unknown;
         connection = Onyx.connect({
             key: ONYX_KEYS.COLLECTION.TEST_KEY,
-            initWithStoredValues: false,
             callback: (value) => {
                 testKeyValue = value;
             },
@@ -680,14 +658,17 @@ describe('Onyx', () => {
         });
     });
 
-    it('should properly set and merge when using mergeCollection', () => {
+    it('should properly set and merge when using mergeCollection', async () => {
         const valuesReceived: Record<string, unknown> = {};
-        const mockCallback = jest.fn((data) => (valuesReceived[data.ID] = data.value));
+        const mockCallback = jest.fn();
         connection = Onyx.connect({
             key: ONYX_KEYS.COLLECTION.TEST_KEY,
-            initWithStoredValues: false,
             callback: mockCallback,
         });
+        await waitForPromisesToResolve();
+
+        mockCallback.mockReset();
+        mockCallback.mockImplementation((data) => (valuesReceived[data.ID] = data.value));
 
         // The first time we call mergeCollection we'll be doing a multiSet internally
         return Onyx.mergeCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
@@ -749,7 +730,6 @@ describe('Onyx', () => {
         const valuesReceived: Record<string, unknown> = {};
         connection = Onyx.connect({
             key: ONYX_KEYS.COLLECTION.TEST_KEY,
-            initWithStoredValues: false,
             callback: (data, key) => (valuesReceived[key] = data),
         });
 
@@ -762,7 +742,6 @@ describe('Onyx', () => {
         const valuesReceived: Record<string, unknown> = {};
         connection = Onyx.connect({
             key: ONYX_KEYS.COLLECTION.TEST_KEY,
-            initWithStoredValues: false,
             callback: (data, key) => (valuesReceived[key] = data),
         });
 
@@ -887,7 +866,6 @@ describe('Onyx', () => {
         let testKeyValue: unknown;
         connection = Onyx.connect({
             key: ONYX_KEYS.TEST_KEY,
-            initWithStoredValues: false,
             callback: (value) => {
                 testKeyValue = value;
             },
@@ -896,7 +874,6 @@ describe('Onyx', () => {
         let otherTestKeyValue: unknown;
         connection = Onyx.connect({
             key: ONYX_KEYS.OTHER_TEST,
-            initWithStoredValues: false,
             callback: (value) => {
                 otherTestKeyValue = value;
             },
@@ -936,15 +913,17 @@ describe('Onyx', () => {
 
     it('should use update data object to merge a collection of keys', () => {
         const valuesReceived: Record<string, unknown> = {};
-        const mockCallback = jest.fn((data) => (valuesReceived[data.ID] = data.value));
+        const mockCallback = jest.fn();
         connection = Onyx.connect({
             key: ONYX_KEYS.COLLECTION.TEST_KEY,
-            initWithStoredValues: false,
             callback: mockCallback,
         });
 
         return waitForPromisesToResolve()
             .then(() => {
+                mockCallback.mockReset();
+                mockCallback.mockImplementation((data) => (valuesReceived[data.ID] = data.value));
+
                 // Given the initial Onyx state: {test_1: {existingData: 'test',}, test_2: {existingData: 'test',}}
                 Onyx.multiSet({
                     test_1: {
@@ -1012,7 +991,6 @@ describe('Onyx', () => {
         const valuesReceived: Record<string, unknown> = {};
         connection = Onyx.connect({
             key: ONYX_KEYS.COLLECTION.TEST_KEY,
-            initWithStoredValues: false,
             callback: (data, key) => (valuesReceived[key] = data),
         });
 
@@ -1228,47 +1206,6 @@ describe('Onyx', () => {
         );
     });
 
-    it('should update subscriber if the value in the cache has not changed at all but initWithStoredValues === false', () => {
-        const mockCallback = jest.fn();
-        const collectionUpdate = {
-            testPolicy_1: {ID: 234, value: 'one'},
-        };
-
-        // Given an Onyx.connect call with waitForCollectionCallback=true
-        connection = Onyx.connect({
-            key: ONYX_KEYS.COLLECTION.TEST_POLICY,
-            waitForCollectionCallback: true,
-            callback: mockCallback,
-            initWithStoredValues: false,
-        });
-        return (
-            waitForPromisesToResolve()
-                // When merge is called with an updated collection
-                .then(() => Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_POLICY}${1}`, collectionUpdate.testPolicy_1))
-                .then(() => {
-                    // Then we expect the callback to have called once. 0 times the initial connect call + 1 time for the merge()
-                    expect(mockCallback).toHaveBeenCalledTimes(1);
-
-                    // And the value for the second call should be collectionUpdate
-                    expect(mockCallback).toHaveBeenNthCalledWith(1, collectionUpdate, ONYX_KEYS.COLLECTION.TEST_POLICY, {testPolicy_1: collectionUpdate.testPolicy_1});
-                })
-
-                // When merge is called again with the same collection not modified
-                .then(() => Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_POLICY}${1}`, collectionUpdate.testPolicy_1))
-                .then(() => {
-                    // Then we should expect another invocation of the callback because initWithStoredValues = false
-                    expect(mockCallback).toHaveBeenCalledTimes(2);
-                })
-
-                // When merge is called again with an object of equivalent value but not the same reference
-                .then(() => Onyx.merge(`${ONYX_KEYS.COLLECTION.TEST_POLICY}${1}`, lodashClone(collectionUpdate.testPolicy_1)))
-                .then(() => {
-                    // Then we should expect another invocation of the callback because initWithStoredValues = false
-                    expect(mockCallback).toHaveBeenCalledTimes(3);
-                })
-        );
-    });
-
     it('should return a promise that completes when all update() operations are done', () => {
         const connections: Connection[] = [];
 
@@ -1308,7 +1245,6 @@ describe('Onyx', () => {
 
         connection = Onyx.connect({
             key: ONYX_KEYS.TEST_KEY,
-            initWithStoredValues: false,
             callback: (value) => {
                 testKeyValue = value;
             },
@@ -1339,7 +1275,6 @@ describe('Onyx', () => {
 
         connection = Onyx.connect({
             key: ONYX_KEYS.TEST_KEY,
-            initWithStoredValues: false,
             callback: (value) => {
                 testKeyValue = value;
             },
@@ -1366,7 +1301,6 @@ describe('Onyx', () => {
 
         connection = Onyx.connect({
             key: ONYX_KEYS.TEST_KEY,
-            initWithStoredValues: false,
             callback: (value) => {
                 testKeyValue = value;
             },
@@ -1392,7 +1326,6 @@ describe('Onyx', () => {
 
         connection = Onyx.connect({
             key: ONYX_KEYS.TEST_KEY,
-            initWithStoredValues: false,
             callback: (value) => {
                 testKeyValue = value;
             },
@@ -1418,7 +1351,6 @@ describe('Onyx', () => {
 
         connection = Onyx.connect({
             key: ONYX_KEYS.TEST_KEY,
-            initWithStoredValues: false,
             callback: (value) => {
                 testKeyValue = value;
             },
@@ -1444,7 +1376,6 @@ describe('Onyx', () => {
 
         connection = Onyx.connect({
             key: ONYX_KEYS.TEST_KEY,
-            initWithStoredValues: false,
             callback: (value) => {
                 testKeyValue = value;
             },
@@ -1480,7 +1411,6 @@ describe('Onyx', () => {
 
         connection = Onyx.connect({
             key: ONYX_KEYS.COLLECTION.TEST_KEY,
-            initWithStoredValues: false,
             callback: (value) => (result = value),
             waitForCollectionCallback: true,
         });
@@ -1837,7 +1767,6 @@ describe('Onyx', () => {
 
             connection = Onyx.connect({
                 key: ONYX_KEYS.TEST_KEY,
-                initWithStoredValues: false,
                 callback: (value) => {
                     testKeyValue = value;
                 },
@@ -2271,7 +2200,6 @@ describe('Onyx', () => {
 
             connection = Onyx.connect({
                 key: ONYX_KEYS.COLLECTION.ROUTES,
-                initWithStoredValues: false,
                 callback: (value) => {
                     routesCollection = value;
                 },
@@ -2311,7 +2239,6 @@ describe('Onyx', () => {
 
             connection = Onyx.connect({
                 key: ONYX_KEYS.COLLECTION.ROUTES,
-                initWithStoredValues: false,
                 callback: (value) => {
                     routesCollection = value;
                 },
@@ -2690,7 +2617,6 @@ describe('Onyx', () => {
 
             connection = Onyx.connect({
                 key: ONYX_KEYS.TEST_KEY,
-                initWithStoredValues: false,
                 callback: (value) => (result = value),
             });
 
@@ -2746,7 +2672,6 @@ describe('Onyx', () => {
 
             connection = Onyx.connect({
                 key: ONYX_KEYS.TEST_KEY,
-                initWithStoredValues: false,
                 callback: (value) => {
                     testKeyValue = value;
                 },
@@ -2810,7 +2735,6 @@ describe('Onyx', () => {
 
             connection = Onyx.connect({
                 key: ONYX_KEYS.COLLECTION.ROUTES,
-                initWithStoredValues: false,
                 callback: (value) => (result = value),
                 waitForCollectionCallback: true,
             });
@@ -2839,12 +2763,18 @@ describe('Onyx', () => {
         it('should replace the collection with empty values', async () => {
             let result: OnyxCollection<unknown>;
             const routeA = `${ONYX_KEYS.COLLECTION.ROUTES}A`;
+            const callback = jest.fn();
 
             connection = Onyx.connect({
                 key: ONYX_KEYS.COLLECTION.ROUTES,
-                initWithStoredValues: false,
-                callback: (value) => (result = value),
+                callback,
                 waitForCollectionCallback: true,
+            });
+            await waitForPromisesToResolve();
+
+            callback.mockReset();
+            callback.mockImplementation((value) => {
+                result = value;
             });
 
             await Onyx.mergeCollection(ONYX_KEYS.COLLECTION.ROUTES, {
@@ -2863,7 +2793,6 @@ describe('Onyx', () => {
 
             connection = Onyx.connect({
                 key: ONYX_KEYS.COLLECTION.ROUTES,
-                initWithStoredValues: false,
                 callback: (value) => (result = value),
                 waitForCollectionCallback: true,
             });
@@ -2935,7 +2864,6 @@ describe('Onyx', () => {
             let testKeyValue: unknown;
             connection = Onyx.connect({
                 key: ONYX_KEYS.COLLECTION.TEST_KEY,
-                initWithStoredValues: false,
                 waitForCollectionCallback: true,
                 callback: (value) => {
                     testKeyValue = value;
@@ -2954,7 +2882,6 @@ describe('Onyx', () => {
             let testKeyValue: unknown;
             connection = Onyx.connect({
                 key: ONYX_KEYS.COLLECTION.TEST_KEY,
-                initWithStoredValues: false,
                 waitForCollectionCallback: true,
                 callback: (value) => {
                     testKeyValue = value;
@@ -2973,7 +2900,6 @@ describe('Onyx', () => {
             let testKeyValue: unknown;
             connection = Onyx.connect({
                 key: ONYX_KEYS.COLLECTION.TEST_KEY,
-                initWithStoredValues: false,
                 waitForCollectionCallback: true,
                 callback: (value) => {
                     testKeyValue = value;
@@ -2996,7 +2922,6 @@ describe('Onyx', () => {
             let testKeyValue: unknown;
             connection = Onyx.connect({
                 key: ONYX_KEYS.COLLECTION.TEST_KEY,
-                initWithStoredValues: false,
                 waitForCollectionCallback: true,
                 callback: (value) => {
                     testKeyValue = value;
@@ -3019,7 +2944,6 @@ describe('Onyx', () => {
             let testKeyValue: unknown;
             connection = Onyx.connect({
                 key: ONYX_KEYS.COLLECTION.TEST_KEY,
-                initWithStoredValues: false,
                 waitForCollectionCallback: true,
                 callback: (value) => {
                     testKeyValue = value;

--- a/tests/unit/onyxUtilsTest.ts
+++ b/tests/unit/onyxUtilsTest.ts
@@ -181,7 +181,6 @@ describe('OnyxUtils', () => {
 
             const connection = Onyx.connect({
                 key: ONYXKEYS.COLLECTION.ROUTES,
-                initWithStoredValues: false,
                 callback: (value) => (result = value),
                 waitForCollectionCallback: true,
             });
@@ -218,7 +217,6 @@ describe('OnyxUtils', () => {
 
             const connection = Onyx.connect({
                 key: ONYXKEYS.COLLECTION.ROUTES,
-                initWithStoredValues: false,
                 callback: (value) => (result = value),
                 waitForCollectionCallback: true,
             });
@@ -242,7 +240,6 @@ describe('OnyxUtils', () => {
 
             const connection = Onyx.connect({
                 key: ONYXKEYS.COLLECTION.ROUTES,
-                initWithStoredValues: false,
                 callback: (value) => (result = value),
                 waitForCollectionCallback: true,
             });
@@ -281,7 +278,6 @@ describe('OnyxUtils', () => {
             const connection = Onyx.connect({
                 key: entryKey,
                 callback: callbackSpy,
-                initWithStoredValues: false,
             });
 
             const entryData = {value: 'updated_data'};
@@ -313,7 +309,6 @@ describe('OnyxUtils', () => {
             const connection = await Onyx.connect({
                 key: entryKey,
                 callback: callbackSpy,
-                initWithStoredValues: false,
             });
 
             // Create partial collection data that includes our member key
@@ -359,7 +354,6 @@ describe('OnyxUtils', () => {
                 key: ONYXKEYS.COLLECTION.TEST_KEY,
                 callback: collectionCallback,
                 waitForCollectionCallback: true,
-                initWithStoredValues: false,
             });
 
             await Onyx.set(entryKey, entryData);
@@ -388,7 +382,6 @@ describe('OnyxUtils', () => {
             const connection = Onyx.connect({
                 key: entryKey,
                 callback: callbackSpy,
-                initWithStoredValues: false,
             });
             await waitForPromisesToResolve();
             callbackSpy.mockClear();
@@ -416,9 +409,9 @@ describe('OnyxUtils', () => {
             const spyA = jest.fn();
             const spyB = jest.fn();
             const spyC = jest.fn();
-            const connA = Onyx.connect({key: keyA, callback: spyA, initWithStoredValues: false});
-            const connB = Onyx.connect({key: keyB, callback: spyB, initWithStoredValues: false});
-            const connC = Onyx.connect({key: keyC, callback: spyC, initWithStoredValues: false});
+            const connA = Onyx.connect({key: keyA, callback: spyA});
+            const connB = Onyx.connect({key: keyB, callback: spyB});
+            const connC = Onyx.connect({key: keyC, callback: spyC});
             await waitForPromisesToResolve();
             spyA.mockClear();
             spyB.mockClear();
@@ -448,15 +441,16 @@ describe('OnyxUtils', () => {
 
             await Onyx.set(entryKey, entryData);
 
-            const failingCallback = jest.fn(() => {
-                throw new Error('subscriber failure');
-            });
+            const failingCallback = jest.fn();
             const workingCallback = jest.fn();
 
-            const connFailing = Onyx.connect({key: entryKey, callback: failingCallback, initWithStoredValues: false});
-            const connWorking = Onyx.connect({key: entryKey, callback: workingCallback, initWithStoredValues: false});
+            const connFailing = Onyx.connect({key: entryKey, callback: failingCallback, reuseConnection: false});
+            const connWorking = Onyx.connect({key: entryKey, callback: workingCallback, reuseConnection: false});
             await waitForPromisesToResolve();
-            failingCallback.mockClear();
+            failingCallback.mockReset();
+            failingCallback.mockImplementation(() => {
+                throw new Error('subscriber failure');
+            });
             workingCallback.mockClear();
 
             // Spy on Logger to verify the error is logged

--- a/tests/unit/onyxUtilsTest.ts
+++ b/tests/unit/onyxUtilsTest.ts
@@ -271,7 +271,6 @@ describe('OnyxUtils', () => {
                 key: ONYXKEYS.COLLECTION.TEST_KEY,
                 callback: collectionCallback,
                 waitForCollectionCallback: true,
-                initWithStoredValues: false,
             });
 
             await waitForPromisesToResolve();
@@ -299,9 +298,9 @@ describe('OnyxUtils', () => {
             const spy2 = jest.fn();
             const spy3 = jest.fn();
 
-            const conn1 = Onyx.connect({key: `${ONYXKEYS.COLLECTION.TEST_KEY}1`, callback: spy1, initWithStoredValues: false});
-            const conn2 = Onyx.connect({key: `${ONYXKEYS.COLLECTION.TEST_KEY}2`, callback: spy2, initWithStoredValues: false});
-            const conn3 = Onyx.connect({key: `${ONYXKEYS.COLLECTION.TEST_KEY}3`, callback: spy3, initWithStoredValues: false});
+            const conn1 = Onyx.connect({key: `${ONYXKEYS.COLLECTION.TEST_KEY}1`, callback: spy1});
+            const conn2 = Onyx.connect({key: `${ONYXKEYS.COLLECTION.TEST_KEY}2`, callback: spy2});
+            const conn3 = Onyx.connect({key: `${ONYXKEYS.COLLECTION.TEST_KEY}3`, callback: spy3});
             await waitForPromisesToResolve();
             spy1.mockClear();
             spy2.mockClear();
@@ -333,12 +332,10 @@ describe('OnyxUtils', () => {
                 key: ONYXKEYS.COLLECTION.TEST_KEY,
                 callback: collectionCallback,
                 waitForCollectionCallback: true,
-                initWithStoredValues: false,
             });
             const connSingle = Onyx.connect({
                 key: ONYXKEYS.TEST_KEY,
                 callback: singleKeyCallback,
-                initWithStoredValues: false,
             });
             await waitForPromisesToResolve();
             collectionCallback.mockClear();
@@ -369,13 +366,11 @@ describe('OnyxUtils', () => {
                 key: ONYXKEYS.COLLECTION.TEST_KEY,
                 callback: testCallback,
                 waitForCollectionCallback: true,
-                initWithStoredValues: false,
             });
             const connRoutes = Onyx.connect({
                 key: ONYXKEYS.COLLECTION.ROUTES,
                 callback: routesCallback,
                 waitForCollectionCallback: true,
-                initWithStoredValues: false,
             });
             await waitForPromisesToResolve();
             testCallback.mockClear();
@@ -408,8 +403,8 @@ describe('OnyxUtils', () => {
 
             const spy1 = jest.fn();
             const spy2 = jest.fn();
-            const conn1 = Onyx.connect({key: `${ONYXKEYS.COLLECTION.TEST_KEY}1`, callback: spy1, initWithStoredValues: false});
-            const conn2 = Onyx.connect({key: `${ONYXKEYS.COLLECTION.TEST_KEY}2`, callback: spy2, initWithStoredValues: false});
+            const conn1 = Onyx.connect({key: `${ONYXKEYS.COLLECTION.TEST_KEY}1`, callback: spy1});
+            const conn2 = Onyx.connect({key: `${ONYXKEYS.COLLECTION.TEST_KEY}2`, callback: spy2});
             await waitForPromisesToResolve();
             spy1.mockClear();
             spy2.mockClear();
@@ -437,24 +432,16 @@ describe('OnyxUtils', () => {
             // it receives the first member. Subsequent changed members in the same batch must NOT
             // trigger further callbacks for this subscriber.
             const callback = jest.fn();
-            let connection: ReturnType<typeof Onyx.connect>;
-
-            callback.mockImplementation(() => {
-                if (!connection) {
-                    return;
-                }
-
-                Onyx.disconnect(connection);
-            });
-
-            connection = Onyx.connect({
+            const connection = Onyx.connect({
                 key: ONYXKEYS.COLLECTION.TEST_KEY,
                 callback,
                 waitForCollectionCallback: false,
-                initWithStoredValues: false,
             });
             await waitForPromisesToResolve();
-            callback.mockClear();
+            callback.mockReset();
+            callback.mockImplementation(() => {
+                Onyx.disconnect(connection);
+            });
 
             await Onyx.multiSet({
                 [`${ONYXKEYS.COLLECTION.TEST_KEY}1`]: {id: 1},
@@ -486,12 +473,10 @@ describe('OnyxUtils', () => {
             const connA = Onyx.connect({
                 key: ONYXKEYS.TEST_KEY,
                 callback: callbackA,
-                initWithStoredValues: false,
             });
             const connB = Onyx.connect({
                 key: ONYXKEYS.TEST_KEY_2,
                 callback: callbackB,
-                initWithStoredValues: false,
             });
             await waitForPromisesToResolve();
             callbackA.mockClear();

--- a/tests/unit/useOnyxTest.ts
+++ b/tests/unit/useOnyxTest.ts
@@ -927,72 +927,6 @@ describe('useOnyx', () => {
         });
     });
 
-    describe('initWithStoredValues', () => {
-        it('should return `undefined` and loaded state, and after merge return updated value and loaded state', async () => {
-            await StorageMock.setItem(ONYXKEYS.TEST_KEY, 'test1');
-
-            const {result} = renderHook(() => useOnyx(ONYXKEYS.TEST_KEY, {initWithStoredValues: false}));
-
-            await act(async () => waitForPromisesToResolve());
-
-            expect(result.current[0]).toBeUndefined();
-            expect(result.current[1].status).toEqual('loaded');
-
-            await act(async () => Onyx.merge(ONYXKEYS.TEST_KEY, 'test2'));
-
-            expect(result.current[0]).toEqual('test2');
-            expect(result.current[1].status).toEqual('loaded');
-        });
-
-        it('should return `undefined` value and loaded state if using `selector`, and after merge return selected value and loaded state', async () => {
-            await StorageMock.setItem(ONYXKEYS.TEST_KEY, 'test1');
-
-            const {result} = renderHook(() =>
-                useOnyx(ONYXKEYS.TEST_KEY, {
-                    initWithStoredValues: false,
-                    selector: ((value: OnyxEntry<string>) => `${value}_selected`) as UseOnyxSelector<OnyxKey, string>,
-                }),
-            );
-
-            await act(async () => waitForPromisesToResolve());
-
-            expect(result.current[0]).toBeUndefined();
-            expect(result.current[1].status).toEqual('loaded');
-
-            await act(async () => Onyx.merge(ONYXKEYS.TEST_KEY, 'test'));
-
-            expect(result.current[0]).toEqual('test_selected');
-            expect(result.current[1].status).toEqual('loaded');
-        });
-
-        it('should suppress stored values for the new key when switching keys with initWithStoredValues: false', async () => {
-            await StorageMock.setItem(ONYXKEYS.TEST_KEY, 'stored_value_one');
-            await StorageMock.setItem(ONYXKEYS.TEST_KEY_2, 'stored_value_two');
-
-            const {result, rerender} = renderHook((key: string) => useOnyx(key, {initWithStoredValues: false}), {initialProps: ONYXKEYS.TEST_KEY as string});
-
-            await act(async () => waitForPromisesToResolve());
-
-            // initWithStoredValues: false — stored value should be suppressed
-            expect(result.current[0]).toBeUndefined();
-            expect(result.current[1].status).toEqual('loaded');
-
-            rerender(ONYXKEYS.TEST_KEY_2);
-
-            await act(async () => waitForPromisesToResolve());
-
-            // Stored value for the new key should also be suppressed
-            expect(result.current[0]).toBeUndefined();
-            expect(result.current[1].status).toEqual('loaded');
-
-            // But live updates should still come through
-            await act(async () => Onyx.merge(ONYXKEYS.TEST_KEY_2, 'live_value'));
-
-            expect(result.current[0]).toEqual('live_value');
-            expect(result.current[1].status).toEqual('loaded');
-        });
-    });
-
     describe('multiple usage', () => {
         it('should connect to a key and load the value into cache, and return the value loaded in the next hook call', async () => {
             await StorageMock.setItem(ONYXKEYS.TEST_KEY, 'test');
@@ -1031,35 +965,6 @@ describe('useOnyx', () => {
             expect(result1.current[1].status).toEqual('loaded');
 
             expect(result2.current[0]).toEqual('test');
-            expect(result2.current[1].status).toEqual('loaded');
-        });
-
-        it('"initWithStoredValues" should work correctly for the same key if more than one hook is using it', async () => {
-            await StorageMock.setItem(ONYXKEYS.TEST_KEY, 'test1');
-
-            const {result: result1} = renderHook(() => useOnyx(ONYXKEYS.TEST_KEY, {initWithStoredValues: false}));
-
-            await act(async () => waitForPromisesToResolve());
-
-            expect(result1.current[0]).toBeUndefined();
-            expect(result1.current[1].status).toEqual('loaded');
-
-            await act(async () => Onyx.merge(ONYXKEYS.TEST_KEY, 'test2'));
-
-            expect(result1.current[0]).toEqual('test2');
-            expect(result1.current[1].status).toEqual('loaded');
-
-            // Second hook
-            const {result: result2} = renderHook(() => useOnyx(ONYXKEYS.TEST_KEY, {initWithStoredValues: false}));
-
-            await act(async () => waitForPromisesToResolve());
-
-            expect(result2.current[0]).toBeUndefined();
-            expect(result2.current[1].status).toEqual('loaded');
-
-            await act(async () => Onyx.merge(ONYXKEYS.TEST_KEY, 'test3'));
-
-            expect(result2.current[0]).toEqual('test3');
             expect(result2.current[1].status).toEqual('loaded');
         });
     });


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

Removes `initWithStoredValues` from Onyx as the final task of https://github.com/Expensify/App/issues/80091.

E/App PR: https://github.com/Expensify/App/pull/89488

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/App/issues/80091

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

Unit tests removed.

### Manual Tests
<!---
Each set of changes should be tested against the Expensify/App repo on all platforms to verify it does not break our staging App.
--->

We just need to test the removal of the last `initWithStoredValues` that was introduced in https://github.com/Expensify/App/pull/81973. Use https://github.com/Expensify/App/pull/89488 for testing:

1. Open app
2. Go to domain/domainID/members
3. Select several members
4. Click the primary action button and verify that the Move to group action there
5. Select a different group to move to
6. Click Save
7. Assert the members are not selected anymore and their group have changed

---

1. Open app
2. Go to domain/domainID/members
3. Select several members
4. Reload the browser/app
5. Assert they are not selected anymore

---

1. Open app
2. Go to domain/domainID/members
3. Select several members
4. Click the primary action button and verify that the Move to group action there
5. Select a different group to move to
6. Reload the browser/app
7. Assert you are back to members page and the members are not selected anymore

### Author Checklist

- [x] I linked the correct issue in the `### Related Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

N/A, emulator crashing for me

</details>

<details>
<summary>Android: mWeb Chrome</summary>


https://github.com/user-attachments/assets/40febe84-ce3b-4bfe-88b1-ab1560116edd



</details>

<details>
<summary>iOS: Native</summary>


https://github.com/user-attachments/assets/256b4bb4-7b47-4f08-b01a-5b211b562aa2



</details>

<details>
<summary>iOS: mWeb Safari</summary>


https://github.com/user-attachments/assets/56234b8b-5541-4d57-8ae8-153a271a4137



</details>

<details>
<summary>MacOS: Chrome / Safari</summary>


https://github.com/user-attachments/assets/20238b37-7258-489e-ad70-4efb7a4d4c76


https://github.com/user-attachments/assets/7ee83610-6ebb-47e7-b47d-8adf1460a530



</details>
