### PR TITLE
Skip retries in retryOperation for non-retriable storage errors

### DIFF
--- a/API-INTERNAL.md
+++ b/API-INTERNAL.md
@@ -83,6 +83,7 @@ If the requested key is a collection, it will return an object with all the coll
 <ul>
 <li>Storage capacity errors: evicts data and retries the operation</li>
 <li>Invalid data errors: logs an alert and throws an error</li>
+<li>Non-retriable errors: logs an alert and resolves without retrying</li>
 <li>Other errors: retries the operation</li>
 </ul>
 </dd>
@@ -323,6 +324,7 @@ Remove a key from Onyx and update the subscribers
 Handles storage operation failures based on the error type:
 - Storage capacity errors: evicts data and retries the operation
 - Invalid data errors: logs an alert and throws an error
+- Non-retriable errors: logs an alert and resolves without retrying
 - Other errors: retries the operation
 
 **Kind**: global function  

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -61,6 +61,14 @@ const SQLITE_STORAGE_ERRORS = [
 
 const STORAGE_ERRORS = [...IDB_STORAGE_ERRORS, ...SQLITE_STORAGE_ERRORS];
 
+// IndexedDB errors where retrying is futile because the underlying connection/store is broken.
+// The healing path (separate from retryOperation) is responsible for recovery.
+const IDB_NON_RETRIABLE_ERRORS = [
+    'internal error opening backing store', // LevelDB backing store is broken at the filesystem level
+] as const;
+
+const NON_RETRIABLE_ERRORS = [...IDB_NON_RETRIABLE_ERRORS];
+
 // Max number of retries for failed storage operations
 const MAX_STORAGE_OPERATION_RETRY_ATTEMPTS = 5;
 
@@ -786,6 +794,7 @@ function reportStorageQuota(error?: Error): Promise<void> {
  * Handles storage operation failures based on the error type:
  * - Storage capacity errors: evicts data and retries the operation
  * - Invalid data errors: logs an alert and throws an error
+ * - Non-retriable errors: logs an alert and resolves without retrying
  * - Other errors: retries the operation
  */
 function retryOperation<TMethod extends RetriableOnyxOperation>(error: Error, onyxMethod: TMethod, defaultParams: Parameters<TMethod>[0], retryAttempt: number | undefined): Promise<void> {
@@ -802,6 +811,12 @@ function retryOperation<TMethod extends RetriableOnyxOperation>(error: Error, on
     const errorMessage = error?.message?.toLowerCase?.();
     const errorName = error?.name?.toLowerCase?.();
     const isStorageCapacityError = STORAGE_ERRORS.some((storageError) => errorName?.includes(storageError) || errorMessage?.includes(storageError));
+    const isNonRetriableError = NON_RETRIABLE_ERRORS.some((nonRetriableError) => errorName?.includes(nonRetriableError) || errorMessage?.includes(nonRetriableError));
+
+    if (isNonRetriableError) {
+        Logger.logAlert(`Storage operation skipped retry for non-retriable error. Error: ${error}. onyxMethod: ${onyxMethod.name}.`);
+        return Promise.resolve();
+    }
 
     if (nextRetryAttempt > MAX_STORAGE_OPERATION_RETRY_ATTEMPTS) {
         Logger.logAlert(`Storage operation failed after 5 retries. Error: ${error}. onyxMethod: ${onyxMethod.name}.`);

--- a/tests/unit/onyxUtilsTest.ts
+++ b/tests/unit/onyxUtilsTest.ts
@@ -788,6 +788,7 @@ describe('OnyxUtils', () => {
         const genericError = new Error('Generic storage error');
         const invalidDataError = new Error("Failed to execute 'put' on 'IDBObjectStore': invalid data");
         const diskFullError = new Error('database or disk is full');
+        const nonRetriableIdbError = Object.assign(new Error('Internal error opening backing store for indexedDB.open.'), {name: 'UnknownError'});
 
         it('should retry only one time if the operation is firstly failed and then passed', async () => {
             StorageMock.setItem = jest.fn(StorageMock.setItem).mockRejectedValueOnce(genericError).mockImplementation(StorageMock.setItem);
@@ -820,6 +821,26 @@ describe('OnyxUtils', () => {
 
             // Should only be called once since there are no evictable keys
             expect(retryOperationSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it('should not retry for non-retriable IndexedDB backing-store errors', async () => {
+            StorageMock.setItem = jest.fn().mockRejectedValue(nonRetriableIdbError);
+
+            await Onyx.set(ONYXKEYS.TEST_KEY, {test: 'data'});
+
+            // Called once (initial attempt only) -- no recursion, unlike the 6 calls for generic errors
+            expect(retryOperationSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it('should log a single skip alert for non-retriable errors', async () => {
+            const logAlertSpy = jest.spyOn(Logger, 'logAlert');
+            StorageMock.setItem = jest.fn().mockRejectedValue(nonRetriableIdbError);
+
+            await Onyx.set(ONYXKEYS.TEST_KEY, {test: 'data'});
+
+            expect(logAlertSpy).toHaveBeenCalledWith(`Storage operation skipped retry for non-retriable error. Error: ${nonRetriableIdbError}. onyxMethod: setWithRetry.`);
+            // Not paired with the "5 retries exhausted" alert
+            expect(logAlertSpy).toHaveBeenCalledTimes(1);
         });
 
         it('should include the error in logAlert for IDBObjectStore invalid data errors', async () => {


### PR DESCRIPTION
### Details

Introduces a `NON_RETRIABLE_ERRORS` classification alongside the existing `STORAGE_ERRORS` list and short-circuits `retryOperation` for errors where retrying is provably futile — specifically `Internal error opening backing store for indexedDB.open`, where the LevelDB backing store is broken at the filesystem level and cannot recover from immediate retries.

Today, every non-capacity storage error in `retryOperation` retries 5 times with no delay, then silently resolves via `Promise.resolve()`. For the `UnknownError: Internal error opening backing store…` class analyzed in https://github.com/Expensify/App/issues/87862, this produces ~6× the log/Sentry volume of the underlying event rate — 884,955 occurrences (26.3% of all storage failures) inflated to ~5M log lines, all noise because no retry can succeed.

The healing path (separate action item https://github.com/Expensify/App/issues/90636) is responsible for recovering the IDB connection for this error class — `retryOperation` should defer to it, not compete with it.

#### Why this is safe
- The cache layer absorbs the write before `retryOperation` is reached, so callers cannot observe retry success vs. failure.
- Exhausted retries today already silently resolve via `Promise.resolve()`, so the only observable change is log volume.
- The capacity-error eviction path and the generic-error retry path are untouched (regression tests pass).
- Matching uses the same case-insensitive substring style as `STORAGE_ERRORS` (`includes` against lowercased `name` and `message`).

#### Scope
Scoped to `Internal error opening backing store`. The new classification structure (`IDB_NON_RETRIABLE_ERRORS` → `NON_RETRIABLE_ERRORS`, mirroring `IDB_STORAGE_ERRORS` → `STORAGE_ERRORS`) makes adding other connection-state errors trivial later.

### Related Issues

https://github.com/Expensify/App/issues/90633

### Automated Tests

Added two unit tests to `tests/unit/onyxUtilsTest.ts` in the existing `describe('retryOperation', ...)` block:

1. `should not retry for non-retriable IndexedDB backing-store errors` — mocks `Storage.setItem` to reject with `new Error('Internal error opening backing store for indexedDB.open.')` (name: `UnknownError`), asserts `retryOperation` is called exactly once (not 6×).
2. `should log a single skip alert for non-retriable errors` — asserts the new `Storage operation skipped retry for non-retriable error...` alert fires exactly once, and the existing "5 retries exhausted" alert does not fire.

All existing `retryOperation` regression tests continue to pass:
- Generic-error continuous-failure still retries 6× (token does not match).
- Capacity-error eviction path unchanged.
- IDBObjectStore invalid-data still throws.

Local results: `npx jest` — 451/451 pass across 16 suites. `npx tsc --noEmit` clean. ESLint clean on changed files.

### Manual Tests

End-to-end manual verification against `Expensify/App` (link to the App-side companion PR will be added once opened):

1. Pin `Expensify/App`'s `package.json` `react-native-onyx` dependency to this PR's head SHA, run `npm install`.
2. In Chrome DevTools, intercept `Storage.setItem` and reject it with `Object.assign(new Error('Internal error opening backing store for indexedDB.open.'), {name: 'UnknownError'})`.
3. Trigger an `Onyx.set()` call (e.g., navigate to a screen that writes a transient key).
4. Verify in console:
   - Exactly one `Failed to save to storage. Error: ... retryAttempt: 0/5` log line (not six).
   - Exactly one `Storage operation skipped retry for non-retriable error. Error: ... onyxMethod: setWithRetry.` alert.
   - No `Storage operation failed after 5 retries...` alert.

Post-deploy production signal (per https://github.com/Expensify/App/issues/90633 test plan):
- VictoriaLogs: volume of `Failed to save to storage. Error: ...Internal error opening backing store...` drops ~5–6×.
- New low-volume line `Storage operation skipped retry for non-retriable error...` appears at roughly 1× the underlying event rate.

### Author Checklist

- [x] I linked the correct issue in the `### Related Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- N/A — logging-only change with no UI impact. -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- N/A — logging-only change with no UI impact. -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- N/A — logging-only change with no UI impact. -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- N/A — logging-only change with no UI impact. -->

</details>

<details>
<summary>Mac
<img width="1509" height="434" alt="Screenshot 2026-05-19 at 11 43 52" src="https://github.com/user-attachments/assets/ef682ff4-1455-4f3a-aa0a-12d7360da214" />
<img width="1512" height="304" alt="Screenshot 2026-05-19 at 11 44 20" src="https://github.com/user-attachments/assets/f63f036b-a6c0-4ff7-801f-b69097085906" />
OS: Chrome / Safari</summary>



</details>