### PR TITLE
Make mergeCollectionWithPatches cache-first

### DIFF
--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -1579,47 +1579,52 @@ function mergeCollectionWithPatches<TKey extends CollectionKeyBase>(
             // because we will simply overwrite the existing values in storage.
             const keyValuePairsForNewCollection = prepareKeyValuePairsForStorage(newCollection, true);
 
-            const promises = [];
-
-            // We need to get the previously existing values so we can compare the new ones
-            // against them, to avoid unnecessary subscriber updates.
-            const previousCollectionPromise = Promise.all(existingKeys.map((key) => get(key).then((value) => [key, value]))).then(Object.fromEntries);
-
-            // New keys will be added via multiSet while existing keys will be updated using multiMerge
-            // This is because setting a key that doesn't exist yet with multiMerge will throw errors
-            // We can skip this step for RAM-only keys as they should never be saved to storage
-            if (!OnyxKeys.isRamOnlyKey(collectionKey) && keyValuePairsForExistingCollection.length > 0) {
-                promises.push(Storage.multiMerge(keyValuePairsForExistingCollection));
-            }
-
-            // We can skip this step for RAM-only keys as they should never be saved to storage
-            if (!OnyxKeys.isRamOnlyKey(collectionKey) && keyValuePairsForNewCollection.length > 0) {
-                promises.push(Storage.multiSet(keyValuePairsForNewCollection));
-            }
-
             // finalMergedCollection contains all the keys that were merged, without the keys of incompatible updates
             const finalMergedCollection = {...existingKeyCollection, ...newCollection};
 
-            // Prefill cache if necessary by calling get() on any existing keys and then merge original data to cache
-            // and update all subscribers
-            const promiseUpdate = previousCollectionPromise.then((previousCollection) => {
+            // Pre-warm cache for any existing storage keys that aren't yet in cache. get() is a no-op
+            // (sync-resolved) for cache hits, and on a cache miss it reads from storage and writes the
+            // value back to cache. This is required so the subsequent cache.merge() merges the new delta
+            // into the real previous storage value (rather than starting from `undefined` and dropping
+            // the existing keys).
+            return Promise.all(existingKeys.map((key) => get(key))).then(() => {
+                // Snapshot previous values from the (now-warm) cache for keysChanged's diff, then update
+                // cache and notify subscribers synchronously BEFORE issuing storage writes. This matches
+                // the cache-first / storage-second invariant followed by every other Onyx write method
+                // (setWithRetry, applyMerge, setCollectionWithRetry, partialSetCollection, clear),
+                // ensuring subscribers still reflect the merged data even if the subsequent storage
+                // write fails.
+                const previousCollection = getCachedCollection(collectionKey, existingKeys);
                 cache.merge(finalMergedCollection);
                 keysChanged(collectionKey, finalMergedCollection, previousCollection);
-            });
 
-            return Promise.all(promises)
-                .catch((error) =>
-                    retryOperation(
-                        error,
-                        mergeCollectionWithPatches,
-                        {collectionKey, collection: resultCollection as OnyxMergeCollectionInput<TKey>, mergeReplaceNullPatches, isProcessingCollectionUpdate},
-                        retryAttempt,
-                    ),
-                )
-                .then(() => {
-                    sendActionToDevTools(METHOD.MERGE_COLLECTION, undefined, resultCollection);
-                    return promiseUpdate;
-                });
+                const promises = [];
+
+                // New keys will be added via multiSet while existing keys will be updated using multiMerge
+                // This is because setting a key that doesn't exist yet with multiMerge will throw errors
+                // We can skip this step for RAM-only keys as they should never be saved to storage
+                if (!OnyxKeys.isRamOnlyKey(collectionKey) && keyValuePairsForExistingCollection.length > 0) {
+                    promises.push(Storage.multiMerge(keyValuePairsForExistingCollection));
+                }
+
+                // We can skip this step for RAM-only keys as they should never be saved to storage
+                if (!OnyxKeys.isRamOnlyKey(collectionKey) && keyValuePairsForNewCollection.length > 0) {
+                    promises.push(Storage.multiSet(keyValuePairsForNewCollection));
+                }
+
+                return Promise.all(promises)
+                    .catch((error) =>
+                        retryOperation(
+                            error,
+                            mergeCollectionWithPatches,
+                            {collectionKey, collection: resultCollection as OnyxMergeCollectionInput<TKey>, mergeReplaceNullPatches, isProcessingCollectionUpdate},
+                            retryAttempt,
+                        ),
+                    )
+                    .then(() => {
+                        sendActionToDevTools(METHOD.MERGE_COLLECTION, undefined, resultCollection);
+                    });
+            });
         })
         .then(() => undefined);
 }

--- a/tests/unit/onyxUtilsTest.ts
+++ b/tests/unit/onyxUtilsTest.ts
@@ -804,6 +804,49 @@ describe('OnyxUtils', () => {
         });
     });
 
+    describe('mergeCollection cache-first ordering', () => {
+        it('updates cache and notifies subscribers even when Storage.multiMerge rejects', async () => {
+            const collectionKey = ONYXKEYS.COLLECTION.TEST_KEY;
+            const existingMemberKey = `${collectionKey}1`;
+            const newMemberKey = `${collectionKey}2`;
+
+            // Seed an existing member so the merge path exercises multiMerge (existing) + multiSet (new)
+            await Onyx.set(existingMemberKey, {value: 'initial'});
+
+            const collectionCallback = jest.fn();
+            Onyx.connect({
+                key: collectionKey,
+                waitForCollectionCallback: true,
+                callback: collectionCallback,
+            });
+            await waitForPromisesToResolve();
+            collectionCallback.mockClear();
+
+            // Force Storage.multiMerge to reject with a non-retriable IDB error so the failure
+            // path is taken without burning the full retry budget and without rejecting the
+            // outer Onyx.mergeCollection promise.
+            const nonRetriableIdbError = Object.assign(new Error('Internal error opening backing store for indexedDB.open.'), {name: 'UnknownError'});
+            StorageMock.multiMerge = jest.fn().mockRejectedValue(nonRetriableIdbError);
+
+            await Onyx.mergeCollection(collectionKey, {
+                [existingMemberKey]: {value: 'merged'},
+                [newMemberKey]: {value: 'new'},
+            } as GenericCollection);
+
+            // Cache must reflect the merge regardless of the multiMerge rejection. This is the
+            // cache-first / storage-second invariant that mergeCollectionWithPatches must honor.
+            const cachedCollection = OnyxCache.getCollectionData(collectionKey);
+            expect(cachedCollection?.[existingMemberKey]).toEqual({value: 'merged'});
+            expect(cachedCollection?.[newMemberKey]).toEqual({value: 'new'});
+
+            // Subscribers must have been notified with the merged values.
+            expect(collectionCallback).toHaveBeenCalled();
+            const lastBroadcast = collectionCallback.mock.calls.at(-1)?.[0] as Record<string, unknown> | undefined;
+            expect(lastBroadcast?.[existingMemberKey]).toEqual({value: 'merged'});
+            expect(lastBroadcast?.[newMemberKey]).toEqual({value: 'new'});
+        });
+    });
+
     describe('storage eviction', () => {
         const diskFullError = new Error('database or disk is full');
 

--- a/tests/unit/onyxUtilsTest.ts
+++ b/tests/unit/onyxUtilsTest.ts
@@ -805,6 +805,18 @@ describe('OnyxUtils', () => {
     });
 
     describe('mergeCollection cache-first ordering', () => {
+        // Save originals so we can restore them after each test. The tests below replace
+        // StorageMock.multiMerge / StorageMock.multiSet with rejecting mocks; without
+        // restoring, the mock leaks into later describe blocks (e.g. eviction tests) whose
+        // setup relies on these storage methods working normally.
+        const originalMultiMerge = StorageMock.multiMerge;
+        const originalMultiSet = StorageMock.multiSet;
+
+        afterEach(() => {
+            StorageMock.multiMerge = originalMultiMerge;
+            StorageMock.multiSet = originalMultiSet;
+        });
+
         it('updates cache and notifies subscribers even when Storage.multiMerge rejects', async () => {
             const collectionKey = ONYXKEYS.COLLECTION.TEST_KEY;
             const existingMemberKey = `${collectionKey}1`;
@@ -844,6 +856,46 @@ describe('OnyxUtils', () => {
             const lastBroadcast = collectionCallback.mock.calls.at(-1)?.[0] as Record<string, unknown> | undefined;
             expect(lastBroadcast?.[existingMemberKey]).toEqual({value: 'merged'});
             expect(lastBroadcast?.[newMemberKey]).toEqual({value: 'new'});
+        });
+
+        it('updates cache and notifies subscribers even when Storage.multiSet rejects', async () => {
+            const collectionKey = ONYXKEYS.COLLECTION.TEST_KEY;
+            const newMemberKey1 = `${collectionKey}1`;
+            const newMemberKey2 = `${collectionKey}2`;
+
+            // No keys are seeded, so every merged key is a "new" key. This forces the merge path
+            // to use Storage.multiSet (existing keys would go through Storage.multiMerge).
+            const collectionCallback = jest.fn();
+            Onyx.connect({
+                key: collectionKey,
+                waitForCollectionCallback: true,
+                callback: collectionCallback,
+            });
+            await waitForPromisesToResolve();
+            collectionCallback.mockClear();
+
+            // Force Storage.multiSet to reject with a non-retriable IDB error so the failure
+            // path is taken without burning the full retry budget and without rejecting the
+            // outer Onyx.mergeCollection promise.
+            const nonRetriableIdbError = Object.assign(new Error('Internal error opening backing store for indexedDB.open.'), {name: 'UnknownError'});
+            StorageMock.multiSet = jest.fn().mockRejectedValue(nonRetriableIdbError);
+
+            await Onyx.mergeCollection(collectionKey, {
+                [newMemberKey1]: {value: 'first'},
+                [newMemberKey2]: {value: 'second'},
+            } as GenericCollection);
+
+            // Cache must reflect the merge regardless of the multiSet rejection. This is the
+            // cache-first / storage-second invariant that mergeCollectionWithPatches must honor.
+            const cachedCollection = OnyxCache.getCollectionData(collectionKey);
+            expect(cachedCollection?.[newMemberKey1]).toEqual({value: 'first'});
+            expect(cachedCollection?.[newMemberKey2]).toEqual({value: 'second'});
+
+            // Subscribers must have been notified with the merged values.
+            expect(collectionCallback).toHaveBeenCalled();
+            const lastBroadcast = collectionCallback.mock.calls.at(-1)?.[0] as Record<string, unknown> | undefined;
+            expect(lastBroadcast?.[newMemberKey1]).toEqual({value: 'first'});
+            expect(lastBroadcast?.[newMemberKey2]).toEqual({value: 'second'});
         });
     });
 


### PR DESCRIPTION
### Details

`mergeCollectionWithPatches` was the only Onyx write method that did **not** follow the cache-first / storage-second invariant. Every other write method (`setWithRetry`, `applyMerge`, `setCollectionWithRetry`, `partialSetCollection`, `clear`) updates the in-memory cache synchronously before issuing a storage write — so when storage fails (e.g., the IDB corruption population analyzed in Expensify/App#87862), the cache is already correct and subscribers still see the right data.

`mergeCollectionWithPatches` instead pushed `Storage.multiMerge` / `Storage.multiSet` first and bundled the `cache.merge` + `keysChanged` update into a `previousCollectionPromise.then(...)` chain that ran in parallel with storage. In the warm-cache common case the cache update happened to win the race, but if `previousCollectionPromise` lost the race (cache miss falling back to a slow storage read), subscribers could observe a state inconsistent with what the merge logically applied.

This change restores the invariant:

1. `Promise.all(existingKeys.map((key) => get(key)))` runs first to pre-warm the cache from storage for any cache-miss existing keys. `get()` is a sync-resolved no-op for cache hits, so this is microtask-cheap for the warm-cache common case. The pre-warm is required because `cache.merge`'s `fastMerge` needs the previous storage value as the merge base — without it, cold-cache merges would start from `undefined` and silently drop existing data (the behavior the old `previousCollectionPromise` happened to provide as a side effect via `get()`'s cache-population path).
2. `cache.merge(finalMergedCollection)` and `keysChanged(...)` then run synchronously on the now-warm cache, **before** the storage promises are issued.
3. `Storage.multiMerge` / `Storage.multiSet` are pushed afterwards. The `retryOperation` / DevTools chain is unchanged.

Result: subscribers receive the merged data **before** any storage write is attempted, and storage failure no longer races the cache update — matching the behavior of every other Onyx write method.

### Related Issues

https://github.com/Expensify/App/issues/90634

### Companion PR

Expensify/App#91160 — bumps the App's react-native-onyx pin to this branch's head for end-to-end verification.

### Automated Tests

Added a new regression test in \`tests/unit/onyxUtilsTest.ts\`:

> \`mergeCollection cache-first ordering > updates cache and notifies subscribers even when Storage.multiMerge rejects\`

It seeds an existing collection member, mocks \`Storage.multiMerge\` to reject with a non-retriable IDB backing-store error, and asserts both the cache (via \`OnyxCache.getCollectionData\`) and a connected collection subscriber receive the merged values regardless of the storage rejection.

All 452 existing unit tests still pass — including the timing-sensitive \`mergeCollection\` / \`Onyx.update\` callback-ordering tests that probe \`keysChanged\` and \`retryOperation\` semantics.

### Manual Tests

The companion App PR (**Expensify/App#91160**) pulls this branch in via `package.json` + lockfile, so the real end-to-end exercises happen against a running App session. Full step-by-step lives in that PR's `Tests` section; the summary below covers the same scenarios.

`mergeCollectionWithPatches` is reached from these App entry points: `Search.ts`, `IOU/Hold.ts`, `IOU/MoneyRequest.ts`, `Report/MarkAllMessageAsRead.tsx`, `Report/index.ts`, `Policy/Policy.ts`, plus every `Onyx.update` batch that contains a `MERGE_COLLECTION` op (LHN refresh, Pusher events, `OpenApp` response, etc.).

**Setup**

1. In the App repo, check out `elirangoshen/fix/90634-mergeCollectionWithPatches-cache-first` (Expensify/App#91160), which pins `react-native-onyx` to this branch's head
2. `npm install` under Node 20.20.0, then `npm run web`
3. Open https://dev.new.expensify.com:8082/ in Chrome with DevTools open
4. Sign in to a test account

**Functional smoke (no regression in `mergeCollection`-driven flows)**

1. **Initial hydration** — after login, LHN reports list and workspace switcher populate within a few seconds. No missing rows vs. a baseline session on `main`.
2. **Chat message** — open a chat, send a message. Appears immediately (optimistic merge into `reportActions_`), confirms via Pusher, persists after reload.
3. **Mark all as read** — click the mark-all-as-read action. All unread badges clear immediately and stay cleared after reload.
4. **Search & filter** — open Search, apply a filter. Results populate within a few seconds; live updates as filters change; no duplicates.
5. **Hold / unhold an expense** — toggle hold on an expense in a report. Badge appears/clears immediately; persists after reload.
6. **Submit expense** — FAB → Submit expense. Expense appears in the report immediately, no duplicate, persists after reload.
7. **Switch workspaces** — switch via the workspace switcher. LHN reports filter to the new workspace within a few seconds.

**Storage-failure simulation — the core regression guard for this PR**

The fix protects against a race where a failing `Storage.multiMerge` could leave the in-memory cache without the merge's update (and therefore leave subscribers stale). With the fix in place, `cache.merge` and `keysChanged` always fire **before** the storage write, so subscribers stay correct regardless of storage outcome.

1. With the App running and authenticated, open Chrome DevTools → **Application** tab → **IndexedDB**
2. Find the database used by Onyx (typically named `OnyxDB`)
3. **Right-click → Delete database** while the App is still running and connected (do **not** reload)
4. Immediately trigger a `mergeCollection`-driven action — switch workspaces, send a chat message, or apply a search filter
5. **Expected with this fix**: the UI updates correctly; the new state is visible to subscribers even though the underlying IDB write fails. Console will show storage error logs, but **no white screen, no stale UI, no data loss within the session**.
6. (Optional regression check) Reverting just this PR's commit locally and re-running step 4 should produce timing-sensitive misses where the UI fails to reflect the action.

**Evidence**

Screen recording of the smoke tests (1–7), the IDB-failure simulation, and the cold-cache test will be attached to the App PR (Expensify/App#91160) — since this PR has no UI surface of its own, all video evidence lives there.

### Author Checklist

- [x] I linked the correct issue in the `### Related Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos



https://github.com/user-attachments/assets/3f4cd711-a87e-4d19-814e-3e4be9e77796


https://github.com/user-attachments/assets/2d8c0033-f9c5-4b31-b327-58f47bc47f20


https://github.com/user-attachments/assets/9e7db41d-225f-4c5f-8812-1bb2ddc9ef95


https://github.com/user-attachments/assets/3974ef1c-42db-4e12-8097-deaae7d2a460


https://github.com/user-attachments/assets/70833621-9b32-45d0-a8bc-62fa40a1ef13


https://github.com/user-attachments/assets/a68bacce-5aca-42de-ad89-17f011af7f6c


https://github.com/user-attachments/assets/f6a7acea-fd5d-4b76-8157-e0904b2b6122


https://github.com/user-attachments/assets/13757492-ea3d-4bdb-ab03-340847b10aef


https://github.com/user-attachments/assets/80db7434-f669-4c3e-ada1-6be33f5d9ab0


https://github.com/user-attachments/assets/a80a54a3-86db-424d-9ee9-d0e1b10ab490


https://github.com/user-attachments/assets/55728d57-17e6-4ec3-8f7d-bf5820de04fa


https://github.com/user-attachments/assets/00fc6c1a-2b33-42a1-b4ff-8ff3d5737ac6


