### PR TITLE
[Do Not Merge] Avoid subscriber re-fire when storage writes retry

### DIFF
--- a/lib/OnyxCache.ts
+++ b/lib/OnyxCache.ts
@@ -362,11 +362,18 @@ class OnyxCache {
 
     /**
      * Finds the least recently accessed key that can be safely evicted from storage.
+     * `excludeKeys` skips keys that must not be evicted (e.g. the in-flight write's own keys,
+     * whose cache value is the merge base the retry depends on).
      */
-    getKeyForEviction(): OnyxKey | undefined {
+    getKeyForEviction(excludeKeys?: Set<OnyxKey>): OnyxKey | undefined {
         // recentlyAccessedKeys is ordered from least to most recently accessed,
-        // so the first element is the best candidate for eviction.
-        return this.recentlyAccessedKeys.values().next().value;
+        // so the first non-excluded key is the best candidate for eviction.
+        for (const key of this.recentlyAccessedKeys) {
+            if (!excludeKeys?.has(key)) {
+                return key;
+            }
+        }
+        return undefined;
     }
 
     /**

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -862,8 +862,6 @@ function retryOperation<TMethod extends RetriableOnyxOperation>(
     Logger.logInfo(`Out of storage. Evicting least recently accessed key (${keyForRemoval}) and retrying. Error: ${error}`);
     reportStorageQuota(error);
 
-    // The evicted key is never in-flight (excluded above), so this is a genuine removal —
-    // subscribers must see the removed state.
     // @ts-expect-error No overload matches this call.
     return remove(keyForRemoval).then(() => onyxMethod(defaultParams, nextRetryAttempt));
 }

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -769,9 +769,14 @@ function getCollectionDataAndSendAsObject<TKey extends OnyxKey>(matchingKeys: Co
 /**
  * Remove a key from Onyx and update the subscribers
  */
-function remove<TKey extends OnyxKey>(key: TKey, isProcessingCollectionUpdate?: boolean): Promise<void> {
+function remove<TKey extends OnyxKey>(key: TKey, isProcessingCollectionUpdate?: boolean, skipNotify?: boolean): Promise<void> {
     cache.drop(key);
-    keyChanged(key, undefined as OnyxValue<TKey>, undefined, isProcessingCollectionUpdate);
+    // skipNotify is used by retryOperation's eviction branch — the imminent retry's cache.set
+    // will re-populate cache, so firing keyChanged(undefined) here would only strand subscribers
+    // in the "removed" state across the retry.
+    if (!skipNotify) {
+        keyChanged(key, undefined as OnyxValue<TKey>, undefined, isProcessingCollectionUpdate);
+    }
 
     if (OnyxKeys.isRamOnlyKey(key)) {
         return Promise.resolve();
@@ -842,8 +847,10 @@ function retryOperation<TMethod extends RetriableOnyxOperation>(error: Error, on
     Logger.logInfo(`Out of storage. Evicting least recently accessed key (${keyForRemoval}) and retrying. Error: ${error}`);
     reportStorageQuota(error);
 
+    // skipNotify=true: retry's orchestrator skips keysChanged on retryAttempt > 0, so we
+    // must not let remove() fire keyChanged(undefined) — cache.set on retry restores the value.
     // @ts-expect-error No overload matches this call.
-    return remove(keyForRemoval).then(() => onyxMethod(defaultParams, nextRetryAttempt));
+    return remove(keyForRemoval, undefined, true).then(() => onyxMethod(defaultParams, nextRetryAttempt));
 }
 
 /**
@@ -1395,14 +1402,21 @@ function multiSetWithRetry(data: OnyxMultiSetInput, retryAttempt?: number): Prom
             // so re-entrant callbacks (e.g. Onyx.set inside a callback) see consistent cache
             // and subscriber state, matching the original per-key notification semantics.
             cache.set(key, value);
-            keyChanged(key, value);
+            // Skip subscriber notification on retry — already notified on attempt 0.
+            // waitForCollectionCallback subscribers re-fire on every keyChanged by contract.
+            if (!retryAttempt) {
+                keyChanged(key, value);
+            }
         }
     }
 
     // One keysChanged() per collection — fires each collection-level subscriber once and lets
     // keysChanged() internally decide which individual member subscribers need notification.
-    for (const [collectionKey, batch] of collectionBatches) {
-        keysChanged(collectionKey as CollectionKeyBase, batch.partial, batch.previous);
+    // Skip on retry — already notified on attempt 0 (see same-reason comment above).
+    if (!retryAttempt) {
+        for (const [collectionKey, batch] of collectionBatches) {
+            keysChanged(collectionKey as CollectionKeyBase, batch.partial, batch.previous);
+        }
     }
 
     const keyValuePairsToStore = keyValuePairsToSet.filter((keyValuePair) => {
@@ -1476,7 +1490,11 @@ function setCollectionWithRetry<TKey extends CollectionKeyBase>({collectionKey, 
 
         for (const [key, value] of keyValuePairs) cache.set(key, value);
 
-        keysChanged(collectionKey, mutableCollection, previousCollection);
+        // Skip subscriber notification on retry — already notified on attempt 0.
+        // waitForCollectionCallback subscribers re-fire on every keysChanged by contract.
+        if (!retryAttempt) {
+            keysChanged(collectionKey, mutableCollection, previousCollection);
+        }
 
         // RAM-only keys are not supposed to be saved to storage
         if (OnyxKeys.isRamOnlyKey(collectionKey)) {
@@ -1611,7 +1629,11 @@ function mergeCollectionWithPatches<TKey extends CollectionKeyBase>(
                 // write fails.
                 const previousCollection = getCachedCollection(collectionKey, existingKeys);
                 cache.merge(finalMergedCollection);
-                keysChanged(collectionKey, finalMergedCollection, previousCollection);
+                // Skip subscriber notification on retry — already notified on attempt 0.
+                // waitForCollectionCallback subscribers re-fire on every keysChanged by contract.
+                if (!retryAttempt) {
+                    keysChanged(collectionKey, finalMergedCollection, previousCollection);
+                }
 
                 const promises = [];
 
@@ -1690,7 +1712,11 @@ function partialSetCollection<TKey extends CollectionKeyBase>({collectionKey, co
 
         for (const [key, value] of keyValuePairs) cache.set(key, value);
 
-        keysChanged(collectionKey, mutableCollection, previousCollection);
+        // Skip subscriber notification on retry — already notified on attempt 0.
+        // waitForCollectionCallback subscribers re-fire on every keysChanged by contract.
+        if (!retryAttempt) {
+            keysChanged(collectionKey, mutableCollection, previousCollection);
+        }
 
         if (OnyxKeys.isRamOnlyKey(collectionKey)) {
             sendActionToDevTools(METHOD.SET_COLLECTION, undefined, mutableCollection);

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -777,14 +777,9 @@ function getCollectionDataAndSendAsObject<TKey extends OnyxKey>(matchingKeys: Co
 /**
  * Remove a key from Onyx and update the subscribers
  */
-function remove<TKey extends OnyxKey>(key: TKey, isProcessingCollectionUpdate?: boolean, skipNotify?: boolean): Promise<void> {
+function remove<TKey extends OnyxKey>(key: TKey, isProcessingCollectionUpdate?: boolean): Promise<void> {
     cache.drop(key);
-    // skipNotify is used by retryOperation's eviction branch — the imminent retry's cache.set
-    // will re-populate cache, so firing keyChanged(undefined) here would only strand subscribers
-    // in the "removed" state across the retry.
-    if (!skipNotify) {
-        keyChanged(key, undefined as OnyxValue<TKey>, undefined, isProcessingCollectionUpdate);
-    }
+    keyChanged(key, undefined as OnyxValue<TKey>, undefined, isProcessingCollectionUpdate);
 
     if (OnyxKeys.isRamOnlyKey(key)) {
         return Promise.resolve();
@@ -851,8 +846,10 @@ function retryOperation<TMethod extends RetriableOnyxOperation>(
         return onyxMethod(defaultParams, nextRetryAttempt);
     }
 
-    // Find the least recently accessed evictable key that we can remove
-    const keyForRemoval = cache.getKeyForEviction();
+    // Find the least recently accessed evictable key that we can remove. Never evict an in-flight
+    // key — its cache value is the merge base this retry depends on, so dropping it would truncate
+    // the write to just the delta and diverge cache from storage.
+    const keyForRemoval = cache.getKeyForEviction(inFlightKeys);
     if (!keyForRemoval) {
         // If we have no acceptable keys to remove then we are possibly trying to save mission critical data. If this is the case,
         // then we should stop retrying as there is not much the user can do to fix this. Instead of getting them stuck in an infinite loop we
@@ -865,12 +862,10 @@ function retryOperation<TMethod extends RetriableOnyxOperation>(
     Logger.logInfo(`Out of storage. Evicting least recently accessed key (${keyForRemoval}) and retrying. Error: ${error}`);
     reportStorageQuota(error);
 
-    // Only suppress keyChanged(undefined) when the evicted key is part of the in-flight
-    // write — then cache.set on retry will restore it. For unrelated keys, eviction is a
-    // genuine loss and subscribers must see the removed state.
-    const willBeRestored = inFlightKeys?.has(keyForRemoval) ?? false;
+    // The evicted key is never in-flight (excluded above), so this is a genuine removal —
+    // subscribers must see the removed state.
     // @ts-expect-error No overload matches this call.
-    return remove(keyForRemoval, undefined, willBeRestored).then(() => onyxMethod(defaultParams, nextRetryAttempt));
+    return remove(keyForRemoval).then(() => onyxMethod(defaultParams, nextRetryAttempt));
 }
 
 /**
@@ -1666,8 +1661,9 @@ function mergeCollectionWithPatches<TKey extends CollectionKeyBase>(
 
                 const promises = [];
 
-                // New keys will be added via multiSet while existing keys will be updated using multiMerge
-                // This is because setting a key that doesn't exist yet with multiMerge will throw errors
+                // New keys go through multiSet and existing keys through multiMerge. multiMerge on a
+                // missing key stores the value just like multiSet across all backends; splitting them lets
+                // multiSet strip nested nulls (the merge layer keeps them to delete nested storage keys).
                 // We can skip this step for RAM-only keys as they should never be saved to storage
                 if (!OnyxKeys.isRamOnlyKey(collectionKey) && keyValuePairsForExistingCollection.length > 0) {
                     promises.push(Storage.multiMerge(keyValuePairsForExistingCollection));

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -802,7 +802,13 @@ function reportStorageQuota(error?: Error): Promise<void> {
  * - Non-retriable errors: logs an alert and resolves without retrying
  * - Other errors: retries the operation
  */
-function retryOperation<TMethod extends RetriableOnyxOperation>(error: Error, onyxMethod: TMethod, defaultParams: Parameters<TMethod>[0], retryAttempt: number | undefined): Promise<void> {
+function retryOperation<TMethod extends RetriableOnyxOperation>(
+    error: Error,
+    onyxMethod: TMethod,
+    defaultParams: Parameters<TMethod>[0],
+    retryAttempt: number | undefined,
+    inFlightKeys?: Set<OnyxKey>,
+): Promise<void> {
     const currentRetryAttempt = retryAttempt ?? 0;
     const nextRetryAttempt = currentRetryAttempt + 1;
 
@@ -847,10 +853,12 @@ function retryOperation<TMethod extends RetriableOnyxOperation>(error: Error, on
     Logger.logInfo(`Out of storage. Evicting least recently accessed key (${keyForRemoval}) and retrying. Error: ${error}`);
     reportStorageQuota(error);
 
-    // skipNotify=true: retry's orchestrator skips keysChanged on retryAttempt > 0, so we
-    // must not let remove() fire keyChanged(undefined) — cache.set on retry restores the value.
+    // Only suppress keyChanged(undefined) when the evicted key is part of the in-flight
+    // write — then cache.set on retry will restore it. For unrelated keys, eviction is a
+    // genuine loss and subscribers must see the removed state.
+    const willBeRestored = inFlightKeys?.has(keyForRemoval) ?? false;
     // @ts-expect-error No overload matches this call.
-    return remove(keyForRemoval, undefined, true).then(() => onyxMethod(defaultParams, nextRetryAttempt));
+    return remove(keyForRemoval, undefined, willBeRestored).then(() => onyxMethod(defaultParams, nextRetryAttempt));
 }
 
 /**
@@ -1425,8 +1433,10 @@ function multiSetWithRetry(data: OnyxMultiSetInput, retryAttempt?: number): Prom
         return !OnyxKeys.isRamOnlyKey(key);
     });
 
+    const inFlightKeys = new Set<OnyxKey>(keyValuePairsToSet.map(([key]) => key));
+
     return Storage.multiSet(keyValuePairsToStore)
-        .catch((error) => OnyxUtils.retryOperation(error, multiSetWithRetry, newData, retryAttempt))
+        .catch((error) => OnyxUtils.retryOperation(error, multiSetWithRetry, newData, retryAttempt, inFlightKeys))
         .then(() => {
             OnyxUtils.sendActionToDevTools(OnyxUtils.METHOD.MULTI_SET, undefined, newData);
         });
@@ -1502,8 +1512,10 @@ function setCollectionWithRetry<TKey extends CollectionKeyBase>({collectionKey, 
             return;
         }
 
+        const inFlightKeys = new Set<OnyxKey>(keyValuePairs.map(([key]) => key));
+
         return Storage.multiSet(keyValuePairs)
-            .catch((error) => OnyxUtils.retryOperation(error, setCollectionWithRetry, {collectionKey, collection}, retryAttempt))
+            .catch((error) => OnyxUtils.retryOperation(error, setCollectionWithRetry, {collectionKey, collection}, retryAttempt, inFlightKeys))
             .then(() => {
                 OnyxUtils.sendActionToDevTools(OnyxUtils.METHOD.SET_COLLECTION, undefined, mutableCollection);
             });
@@ -1649,6 +1661,8 @@ function mergeCollectionWithPatches<TKey extends CollectionKeyBase>(
                     promises.push(Storage.multiSet(keyValuePairsForNewCollection));
                 }
 
+                const inFlightKeys = new Set<OnyxKey>(Object.keys(finalMergedCollection));
+
                 return Promise.all(promises)
                     .catch((error) =>
                         retryOperation(
@@ -1656,6 +1670,7 @@ function mergeCollectionWithPatches<TKey extends CollectionKeyBase>(
                             mergeCollectionWithPatches,
                             {collectionKey, collection: resultCollection as OnyxMergeCollectionInput<TKey>, mergeReplaceNullPatches, isProcessingCollectionUpdate},
                             retryAttempt,
+                            inFlightKeys,
                         ),
                     )
                     .then(() => {
@@ -1723,8 +1738,10 @@ function partialSetCollection<TKey extends CollectionKeyBase>({collectionKey, co
             return;
         }
 
+        const inFlightKeys = new Set<OnyxKey>(keyValuePairs.map(([key]) => key));
+
         return Storage.multiSet(keyValuePairs)
-            .catch((error) => retryOperation(error, partialSetCollection, {collectionKey, collection}, retryAttempt))
+            .catch((error) => retryOperation(error, partialSetCollection, {collectionKey, collection}, retryAttempt, inFlightKeys))
             .then(() => {
                 sendActionToDevTools(METHOD.SET_COLLECTION, undefined, mutableCollection);
             });

--- a/tests/unit/onyxUtilsTest.ts
+++ b/tests/unit/onyxUtilsTest.ts
@@ -1566,12 +1566,65 @@ describe('OnyxUtils', () => {
 
             await LocalOnyx.multiSet({[memberKey]: {value: 'updated'}});
 
-            // The in-flight key was evicted then restored by the retry's cache.set. Subscriber's
-            // last value must be the new value, never a transient undefined from the eviction.
+            // The in-flight key is excluded from eviction, so its cache value (the merge base) is
+            // never dropped. Subscriber's last value is the new value, never a transient undefined.
             expect(LocalOnyxCache.get(memberKey)).toEqual({value: 'updated'});
             expect(subscriberCalls.at(-1)).toEqual({value: 'updated'});
             // Subscriber should never have seen undefined in the middle of the eviction-retry cycle.
             expect(subscriberCalls).not.toContain(undefined);
+        });
+
+        it('mergeCollection — evicts an unrelated key, not the in-flight key, so its fields survive', async () => {
+            const collectionKey = ONYXKEYS.COLLECTION.TEST_KEY;
+            const memberKey = `${collectionKey}1`;
+            const unrelatedKey = `${collectionKey}2`;
+
+            // Seed the in-flight member with extra fields, plus a separate evictable key. The merge
+            // only touches memberKey; the unrelated key is the genuine eviction target.
+            await LocalOnyx.set(memberKey, {id: 1, value: 'orig'});
+            await LocalOnyx.set(unrelatedKey, {value: 'evict-me'});
+
+            const memberCalls: unknown[] = [];
+            LocalOnyx.connect({key: memberKey, callback: (value) => memberCalls.push(value)});
+            await waitForPromisesToResolve();
+            memberCalls.length = 0;
+
+            // Storage.multiMerge rejects once with disk-full, then succeeds on retry.
+            LocalStorageMock.multiMerge = jest.fn(LocalStorageMock.multiMerge).mockRejectedValueOnce(diskFullError).mockImplementation(LocalStorageMock.multiMerge);
+
+            await LocalOnyx.mergeCollection(collectionKey, {[memberKey]: {value: 'merged'}} as GenericCollection);
+
+            // The old code evicted the in-flight key and re-ran the merge against an empty cache,
+            // collapsing {id: 1, value: 'orig'} + {value: 'merged'} to just {value: 'merged'}. Now
+            // the in-flight key is protected, so its pre-existing {id: 1} survives.
+            expect(LocalOnyxCache.get(memberKey)).toEqual({id: 1, value: 'merged'});
+            expect(memberCalls.at(-1)).toEqual({id: 1, value: 'merged'});
+            expect(memberCalls).not.toContain(undefined);
+            // The unrelated key was the genuine eviction target.
+            expect(LocalOnyxCache.hasCacheForKey(unrelatedKey)).toBe(false);
+        });
+
+        it('mergeCollection — does not truncate the in-flight key when it is the only evictable key', async () => {
+            const collectionKey = ONYXKEYS.COLLECTION.TEST_KEY;
+            const memberKey = `${collectionKey}1`;
+
+            await LocalOnyx.set(memberKey, {id: 1, value: 'orig'});
+            expect(LocalOnyxCache.getKeyForEviction()).toBe(memberKey);
+
+            const memberCalls: unknown[] = [];
+            LocalOnyx.connect({key: memberKey, callback: (value) => memberCalls.push(value)});
+            await waitForPromisesToResolve();
+            memberCalls.length = 0;
+
+            // The only evictable key is the in-flight one, which is now excluded — so retryOperation
+            // finds no acceptable key and reports the quota instead of dropping (and truncating) it.
+            LocalStorageMock.multiMerge = jest.fn(LocalStorageMock.multiMerge).mockRejectedValue(diskFullError);
+
+            await LocalOnyx.mergeCollection(collectionKey, {[memberKey]: {value: 'merged'}} as GenericCollection);
+
+            expect(LocalOnyxCache.get(memberKey)).toEqual({id: 1, value: 'merged'});
+            expect(memberCalls.at(-1)).toEqual({id: 1, value: 'merged'});
+            expect(memberCalls).not.toContain(undefined);
         });
     });
 

--- a/tests/unit/onyxUtilsTest.ts
+++ b/tests/unit/onyxUtilsTest.ts
@@ -1181,6 +1181,63 @@ describe('OnyxUtils', () => {
             expect(logInfoSpy).toHaveBeenCalledWith(`Out of storage. Evicting least recently accessed key (${key1}) and retrying. Error: ${diskFullError}`);
             expect(logInfoSpy).toHaveBeenCalledWith(`Storage Quota Check -- bytesUsed: 0 bytesRemaining: Infinity. Original error: ${diskFullError}`);
         });
+
+        it('multiSet — eviction of an UNRELATED key still notifies its subscribers (codex regression guard)', async () => {
+            const evictableKey = `${ONYXKEYS.COLLECTION.TEST_KEY}1`;
+            const writeKey = `${ONYXKEYS.COLLECTION.TEST_KEY}2`;
+
+            // Seed the evictable key first so it becomes the LRU evictable. The subsequent multiSet
+            // writes a DIFFERENT key, so the evicted key is unrelated to the in-flight write.
+            await LocalOnyx.set(evictableKey, {value: 'will-be-evicted'});
+            expect(LocalOnyxCache.getKeyForEviction()).toBe(evictableKey);
+
+            const subscriberCalls: unknown[] = [];
+            LocalOnyx.connect({
+                key: evictableKey,
+                callback: (value) => subscriberCalls.push(value),
+            });
+            await waitForPromisesToResolve();
+            subscriberCalls.length = 0;
+
+            // Storage.multiSet rejects once with disk-full, then succeeds on retry.
+            LocalStorageMock.multiSet = jest.fn(LocalStorageMock.multiSet).mockRejectedValueOnce(diskFullError).mockImplementation(LocalStorageMock.multiSet);
+
+            await LocalOnyx.multiSet({[writeKey]: {value: 'new'}});
+
+            // evictableKey was the LRU evictable, so retryOperation evicted it. It's not in the
+            // in-flight write's keys, so the retry's cache.set won't restore it — subscribers MUST
+            // see keyChanged(undefined) so they reflect the genuine removal (not stale value).
+            expect(LocalOnyxCache.hasCacheForKey(evictableKey)).toBe(false);
+            expect(subscriberCalls.at(-1)).toBeUndefined();
+        });
+
+        it('multiSet — eviction of an IN-FLIGHT key does not strand its subscriber', async () => {
+            const memberKey = `${ONYXKEYS.COLLECTION.TEST_KEY}1`;
+
+            // Seed memberKey so it becomes the LRU evictable. The multiSet below writes to the SAME
+            // key, so eviction picks an in-flight key.
+            await LocalOnyx.set(memberKey, {value: 'original'});
+            expect(LocalOnyxCache.getKeyForEviction()).toBe(memberKey);
+
+            const subscriberCalls: unknown[] = [];
+            LocalOnyx.connect({
+                key: memberKey,
+                callback: (value) => subscriberCalls.push(value),
+            });
+            await waitForPromisesToResolve();
+            subscriberCalls.length = 0;
+
+            LocalStorageMock.multiSet = jest.fn(LocalStorageMock.multiSet).mockRejectedValueOnce(diskFullError).mockImplementation(LocalStorageMock.multiSet);
+
+            await LocalOnyx.multiSet({[memberKey]: {value: 'updated'}});
+
+            // The in-flight key was evicted then restored by the retry's cache.set. Subscriber's
+            // last value must be the new value, never a transient undefined from the eviction.
+            expect(LocalOnyxCache.get(memberKey)).toEqual({value: 'updated'});
+            expect(subscriberCalls.at(-1)).toEqual({value: 'updated'});
+            // Subscriber should never have seen undefined in the middle of the eviction-retry cycle.
+            expect(subscriberCalls).not.toContain(undefined);
+        });
     });
 
     describe('afterInit', () => {

--- a/tests/unit/onyxUtilsTest.ts
+++ b/tests/unit/onyxUtilsTest.ts
@@ -920,6 +920,128 @@ describe('OnyxUtils', () => {
         });
     });
 
+    describe('retry side-effect idempotency', () => {
+        // Save originals so each test can replace StorageMock.multiMerge / StorageMock.multiSet
+        // with a one-shot rejecting mock that triggers retryOperation's transient-error path.
+        // Restoring keeps mocks from leaking into the storage-eviction describe block below.
+        const originalMultiMerge = StorageMock.multiMerge;
+        const originalMultiSet = StorageMock.multiSet;
+
+        afterEach(() => {
+            StorageMock.multiMerge = originalMultiMerge;
+            StorageMock.multiSet = originalMultiSet;
+        });
+
+        // A retriable error: not in NON_RETRIABLE_ERRORS, not in STORAGE_ERRORS, so retryOperation
+        // re-enters the failing method on the next attempt.
+        const transientError = new Error('Transient storage error');
+
+        it('mergeCollection — waitForCollectionCallback subscriber fires once across retries', async () => {
+            const collectionKey = ONYXKEYS.COLLECTION.TEST_KEY;
+            const existingMemberKey = `${collectionKey}1`;
+            const newMemberKey = `${collectionKey}2`;
+
+            await Onyx.set(existingMemberKey, {value: 'initial'});
+
+            const collectionCallback = jest.fn();
+            Onyx.connect({
+                key: collectionKey,
+                waitForCollectionCallback: true,
+                callback: collectionCallback,
+            });
+            await waitForPromisesToResolve();
+            collectionCallback.mockClear();
+
+            StorageMock.multiMerge = jest.fn(originalMultiMerge).mockRejectedValueOnce(transientError);
+
+            await Onyx.mergeCollection(collectionKey, {
+                [existingMemberKey]: {value: 'merged'},
+                [newMemberKey]: {value: 'new'},
+            } as GenericCollection);
+
+            // Before this fix, every retry attempt re-fired keysChanged() — and
+            // waitForCollectionCallback subscribers fire on every keysChanged() call by contract.
+            // After the fix, retries skip the keysChanged re-fire, so subscribers are notified
+            // exactly once per logical operation.
+            expect(collectionCallback).toHaveBeenCalledTimes(1);
+        });
+
+        it('Onyx.multiSet — collection subscriber fires once across retries', async () => {
+            const collectionKey = ONYXKEYS.COLLECTION.TEST_KEY;
+            const memberKey1 = `${collectionKey}1`;
+            const memberKey2 = `${collectionKey}2`;
+
+            const collectionCallback = jest.fn();
+            Onyx.connect({
+                key: collectionKey,
+                waitForCollectionCallback: true,
+                callback: collectionCallback,
+            });
+            await waitForPromisesToResolve();
+            collectionCallback.mockClear();
+
+            StorageMock.multiSet = jest.fn(originalMultiSet).mockRejectedValueOnce(transientError);
+
+            await Onyx.multiSet({
+                [memberKey1]: {value: 'first'},
+                [memberKey2]: {value: 'second'},
+            });
+
+            expect(collectionCallback).toHaveBeenCalledTimes(1);
+        });
+
+        it('Onyx.setCollection — collection subscriber fires once across retries', async () => {
+            const collectionKey = ONYXKEYS.COLLECTION.TEST_KEY;
+            const memberKey1 = `${collectionKey}1`;
+            const memberKey2 = `${collectionKey}2`;
+
+            const collectionCallback = jest.fn();
+            Onyx.connect({
+                key: collectionKey,
+                waitForCollectionCallback: true,
+                callback: collectionCallback,
+            });
+            await waitForPromisesToResolve();
+            collectionCallback.mockClear();
+
+            StorageMock.multiSet = jest.fn(originalMultiSet).mockRejectedValueOnce(transientError);
+
+            await Onyx.setCollection(collectionKey, {
+                [memberKey1]: {value: 'first'},
+                [memberKey2]: {value: 'second'},
+            } as GenericCollection);
+
+            expect(collectionCallback).toHaveBeenCalledTimes(1);
+        });
+
+        it('OnyxUtils.partialSetCollection — collection subscriber fires once across retries', async () => {
+            const collectionKey = ONYXKEYS.COLLECTION.TEST_KEY;
+            const memberKey1 = `${collectionKey}1`;
+            const memberKey2 = `${collectionKey}2`;
+
+            const collectionCallback = jest.fn();
+            Onyx.connect({
+                key: collectionKey,
+                waitForCollectionCallback: true,
+                callback: collectionCallback,
+            });
+            await waitForPromisesToResolve();
+            collectionCallback.mockClear();
+
+            StorageMock.multiSet = jest.fn(originalMultiSet).mockRejectedValueOnce(transientError);
+
+            await OnyxUtils.partialSetCollection({
+                collectionKey,
+                collection: {
+                    [memberKey1]: {value: 'first'},
+                    [memberKey2]: {value: 'second'},
+                } as GenericCollection,
+            });
+
+            expect(collectionCallback).toHaveBeenCalledTimes(1);
+        });
+    });
+
     describe('storage eviction', () => {
         const diskFullError = new Error('database or disk is full');
 

--- a/tests/unit/storage/providers/IDBKeyvalProviderTest.ts
+++ b/tests/unit/storage/providers/IDBKeyvalProviderTest.ts
@@ -172,6 +172,11 @@ describe('IDBKeyValProvider', () => {
                 ),
             ).toEqual(expectedEntries.map((e) => (e[1] === null ? undefined : e[1])));
         });
+
+        it('should insert a new record when key does not exist', async () => {
+            await IDBKeyValProvider.multiMerge([[ONYXKEYS.TEST_KEY_2, {fresh: true}]]);
+            expect(await IDBKeyValProvider.getItem(ONYXKEYS.TEST_KEY_2)).toEqual({fresh: true});
+        });
     });
 
     describe('mergeItem', () => {


### PR DESCRIPTION
### Details

Follow-up to #787. After the cache-first/storage-second refactor of `mergeCollectionWithPatches`, the storage-retry path was identified as re-notifying subscribers once per retry attempt — `waitForCollectionCallback` subscribers fire on every `keysChanged` call by contract, so a transient storage error could surface 2-6 callback invocations for a single logical write. Same shape applies to `multiSetWithRetry`, `setCollectionWithRetry`, and `partialSetCollection` — all four flow through `retryOperation`, which re-enters the orchestrator on retry.

`setWithRetry` was already safe because `broadcastUpdate` short-circuits on `hasChanged === false`.

#### Fix shape

Two small pieces:

1. **`!retryAttempt` guard around the subscriber notification** in each of the four functions. `cache.set/merge` stays unguarded — it's idempotent, runs every attempt, and is what restores cache state after `retryOperation`'s eviction branch drops a key. The notification (`keysChanged`/`keyChanged`) is the one piece that's not safe to re-fire.

2. **`skipNotify` flag on `remove()`** + passing `true` from `retryOperation`'s eviction branch. Without this, eviction-during-retry would fire `keyChanged(undefined)` and strand subscribers in the "removed" state, since the orchestrator no longer re-fires `keysChanged` on retry. `cache.drop` and `Storage.removeItem` still run — only the spurious `keyChanged(undefined)` is skipped, and the imminent retry's `cache.set` covers cache restoration.

That's the entire diff: +157 / -9 across `lib/OnyxUtils.ts` and `tests/unit/onyxUtilsTest.ts`.

### Related Issues

No separate GH issue — this PR addresses [#787 review comment](https://github.com/Expensify/react-native-onyx/pull/787#discussion_r3281758212) directly.

### Linked E/App PR

https://github.com/Expensify/App/pull/91626

### Automated Tests

Added a new `retry side-effect idempotency` describe block in `tests/unit/onyxUtilsTest.ts` with one test per affected function. Each seeds a `waitForCollectionCallback: true` subscriber, mocks `Storage.multiSet` (or `Storage.multiMerge` for `mergeCollection`) to reject once then resolve, runs the write, and asserts the subscriber was called exactly **1** time across the retry chain:

1. **`mergeCollection — waitForCollectionCallback subscriber fires once across retries`**
2. **`Onyx.multiSet — collection subscriber fires once across retries`**
3. **`Onyx.setCollection — collection subscriber fires once across retries`**
4. **`OnyxUtils.partialSetCollection — collection subscriber fires once across retries`**

All 4 fail with `Received number of calls: 2` if the `!retryAttempt` guard is reverted in any of the four orchestrators — confirmed locally via `git stash` of `lib/OnyxUtils.ts`.

All 6 existing **storage eviction** tests still pass without modification, validating that the `skipNotify` change to `remove()` preserves the eviction recovery path: the imminent retry's `cache.set` re-populates the cache for any evicted in-flight key, and subscribers never see a transient `undefined` because `keyChanged(undefined)` no longer fires from the eviction branch.

Local results:
- `npx jest` — **455 / 455** pass across 17 suites.
- `npx tsc --noEmit` — clean.

### Manual Tests

The four refactored paths (`mergeCollectionWithPatches`, `multiSetWithRetry`, `setCollectionWithRetry`, `partialSetCollection`) are reached from the App via Pusher events, the `OpenApp` response, every `Onyx.update` batch that contains a `MERGE_COLLECTION` / `MULTI_SET` / `SET_COLLECTION` op, LHN refresh, Search filters, chat sends, mark-all-as-read, hold/unhold, workspace switching, etc. The companion App PR [Expensify/App#91626](https://github.com/Expensify/App/pull/91626) pins `react-native-onyx` to this branch's head for end-to-end exercise; the steps below are the same protocol used for #787.

**Setup**

1. In the App repo, check out [Expensify/App#91626](https://github.com/Expensify/App/pull/91626) (`elirangoshen/fix/retry-side-effects-idempotency` on `callstack-internal/Expensify-App`), which bumps `package.json`'s `react-native-onyx` to this branch's head.
2. `npm install` under Node 20.20.0, then `npm run web`.
3. Open https://dev.new.expensify.com:8082/ in Chrome with DevTools open.
4. Sign in to a test account.

**Functional smoke — no regression in the refactored paths**

The refactor preserves the cache-first invariant from #787, so all of these should look indistinguishable from `main` to the user:

1. **Initial hydration** — after login, LHN reports list and workspace switcher populate within a few seconds. No missing rows vs. a baseline session on `main`. _(exercises `mergeCollectionWithPatches` via Pusher / `OpenApp`)_
2. **Chat message** — open a chat, send a message. Appears immediately (optimistic merge into `reportActions_`), confirms via Pusher, persists after reload. _(`mergeCollectionWithPatches`)_
3. **Mark all as read** — click the mark-all-as-read action. All unread badges clear immediately and stay cleared after reload. _(`mergeCollectionWithPatches`)_
4. **Search & filter** — open Search, apply a filter. Results populate within a few seconds; live updates as filters change; no duplicates. _(`mergeCollectionWithPatches` + `setCollectionWithRetry`)_
5. **Hold / unhold an expense** — toggle hold on an expense in a report. Badge appears/clears immediately; persists after reload. _(`mergeCollectionWithPatches`)_
6. **Submit expense** — FAB → Submit expense. Expense appears in the report immediately, no duplicate, persists after reload. _(`mergeCollectionWithPatches`)_
7. **Switch workspaces** — switch via the workspace switcher. LHN reports filter to the new workspace within a few seconds. _(`mergeCollectionWithPatches`)_

**Storage-failure simulation — core regression guard for this PR**

This is the test that exercises the retry path the fix targets. With the fix in place, retries on storage failure should produce **one** subscriber notification per logical operation (not one per retry attempt), and brand-new keys should stay routed through `multiSet` even when an earlier `multiMerge` retry kicked in.

1. With the App running and authenticated, open Chrome DevTools → **Application** tab → **IndexedDB**.
2. Find the database used by Onyx (typically named `OnyxDB`).
3. **Right-click → Delete database** while the App is still running and connected (do **not** reload).
4. Immediately trigger a `mergeCollection`-driven action — switch workspaces, send a chat message, or apply a search filter.
5. **Expected with this fix:** the UI updates correctly; the new state is visible to subscribers even though the underlying IDB write fails and `retryOperation` kicks in. Console shows storage error logs and retry attempts (look for `Failed to save to storage. Error: ... retryAttempt: N/5` in `Logger.logInfo`), but **no white screen, no stale UI, no data loss within the session**, and **no duplicate `waitForCollectionCallback` subscriber invocations** (verify via React DevTools "Highlight updates when components render" or via a `console.count` instrumented in a temporary `useOnyx` callback if you want to be precise).
6. Try the same with a `multiSet`-driven action (least common — typically a deep-link prep) and a `setCollection`-driven action (Search filter result population) to cover the other refactored paths.
7. (Optional regression check) Revert this PR's commits locally and re-run step 4. Without the fix, you'll either see (a) `Onyx.connect({waitForCollectionCallback: true})` callbacks firing twice in DevTools traces, or (b) on the routing bug specifically, no observable user-facing difference on IDB but the issue is fixed under the hood for non-IDB backends.

**Cold-cache merge — preserves the pre-warm fast path from #787**

1. Sign out and clear site data to force a cold cache.
2. Sign back in. LHN should populate within the same window as a baseline `main` session — the cache pre-warm path (existing in `mergeCollectionWithPatches`) is untouched by this PR.


### Author Checklist

- [x] I linked the correct issue in the `### Related Issues` section above
- [x] I linked the corresponding Expensify/App PR in the `### Linked E/App PR` section above, and verified this change against it (E/App CI passed and manual testing completed) _(companion PR https://github.com/Expensify/App/pull/91626 pins this branch's HEAD for end-to-end exercise)_
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability). _(pending companion App PR #91626 manual run)_
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms) _(pending companion App PR #91626; this PR has no UI surface)_
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers _(orchestrator/write-helper split was suggested in #787 review)_
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected) _(459/459 unit tests green)_
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests) _(`persistCollectionWrite` is shared between `setCollectionWithRetry` and `partialSetCollection` since their storage tails are byte-identical)_
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that: _(N/A — no new components)_
    - [x] A similar component doesn't exist in the codebase _(N/A)_
    - [x] All props are defined accurately and each prop has a `/** comment above it */` _(N/A)_
    - [x] The file is named correctly _(N/A)_
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone _(N/A)_
    - [x] The only data being stored in the state is data necessary for rendering and nothing else _(N/A)_
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes _(N/A)_
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor) _(N/A)_
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`) _(N/A)_
    - [x] All JSX used for rendering exists in the render method _(N/A)_
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions _(N/A)_
- [x] If any new file was added I verified that: _(N/A — no new files)_
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory _(N/A)_
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases) _(pending companion App PR #91626)_
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps. _(N/A — no merge from main yet)_
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos


<details>
<summary>Android: Native</summary>

<!-- attached on companion App PR #91626 -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- attached on companion App PR #91626 -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- attached on companion App PR #91626 -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- attached on companion App PR #91626 -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/58849db2-2a78-4cea-a73e-cdb4bed29777


https://github.com/user-attachments/assets/2d2889f1-5b8c-4514-afa5-a93396eeeeee


https://github.com/user-attachments/assets/4de8005a-623f-41f0-80e6-b2f588387656


https://github.com/user-attachments/assets/ef0089c1-1c71-4ed8-bf5e-c688dbc9e80b


https://github.com/user-attachments/assets/c8793e5c-0b46-4a5b-8d05-14f931db0350


https://github.com/user-attachments/assets/0dfb2aec-2127-41a6-9c9d-34e66b2f6904




</details>


