### PR TITLE
Unify how merge and set handles AbortErrors

### DIFF
--- a/lib/storage/providers/IDBKeyValProvider/index.ts
+++ b/lib/storage/providers/IDBKeyValProvider/index.ts
@@ -9,6 +9,20 @@ import type {StorageKeyValuePair} from '../types';
 const DB_NAME = 'OnyxDB';
 const STORE_NAME = 'keyvaluepairs';
 
+/**
+ * Awaits an IndexedDB write transaction. idb-keyval's promisifyRequest rejects with
+ * `transaction.error`, which is `null` for an abort not caused by its own request
+ * (connection close / versionchange / a sibling transaction aborting). Normalize that
+ * `null` into a tagged AbortError so storage writes never reject with the unclassifiable
+ * "Error: null" — it otherwise slips past createStore's heal guards (they require an
+ * Error/DOMException) and renders as `Error: null` in OnyxUtils.retryOperation.
+ */
+function promisifyWriteTransaction(transaction: IDBTransaction): Promise<void> {
+    return IDB.promisifyRequest(transaction).catch((error) => {
+        throw error ?? new DOMException('IDB write transaction aborted without an error', 'AbortError');
+    });
+}
+
 const provider: StorageProvider<UseStore | undefined> = {
     // We don't want to initialize the store while the JS bundle loads as idb-keyval will try to use global.indexedDB
     // which might not be available in certain environments that load the bundle (e.g. electron main process).
@@ -38,7 +52,13 @@ const provider: StorageProvider<UseStore | undefined> = {
             return provider.removeItem(key);
         }
 
-        return IDB.set(key, value, provider.store);
+        // Drive the write through the manual store transaction so promisifyWriteTransaction can
+        // normalize a null abort error — idb-keyval's IDB.set() awaits the raw transaction and
+        // would propagate the unclassifiable "Error: null".
+        return provider.store('readwrite', (store) => {
+            store.put(value, key);
+            return promisifyWriteTransaction(store.transaction);
+        });
     },
     multiGet(keysParam) {
         if (!provider.store) {
@@ -71,7 +91,7 @@ const provider: StorageProvider<UseStore | undefined> = {
                     }
                 }
 
-                return IDB.promisifyRequest(store.transaction);
+                return promisifyWriteTransaction(store.transaction);
             });
         });
     },
@@ -93,7 +113,7 @@ const provider: StorageProvider<UseStore | undefined> = {
                 }
             }
 
-            return IDB.promisifyRequest(store.transaction);
+            return promisifyWriteTransaction(store.transaction);
         });
     },
     clear() {

--- a/lib/storage/providers/IDBKeyValProvider/index.ts
+++ b/lib/storage/providers/IDBKeyValProvider/index.ts
@@ -13,9 +13,7 @@ const STORE_NAME = 'keyvaluepairs';
  * Awaits an IndexedDB write transaction. idb-keyval's promisifyRequest rejects with
  * `transaction.error`, which is `null` for an abort not caused by its own request
  * (connection close / versionchange / a sibling transaction aborting). Normalize that
- * `null` into a tagged AbortError so storage writes never reject with the unclassifiable
- * "Error: null" — it otherwise slips past createStore's heal guards (they require an
- * Error/DOMException) and renders as `Error: null` in OnyxUtils.retryOperation.
+ * `null` into a tagged AbortError.
  */
 function promisifyWriteTransaction(transaction: IDBTransaction): Promise<void> {
     return IDB.promisifyRequest(transaction).catch((error) => {

--- a/lib/storage/providers/IDBKeyValProvider/index.ts
+++ b/lib/storage/providers/IDBKeyValProvider/index.ts
@@ -153,14 +153,22 @@ const provider: StorageProvider<UseStore | undefined> = {
             throw new Error('Store not initialized!');
         }
 
-        return IDB.del(key, provider.store);
+        return provider.store('readwrite', (store) => {
+            store.delete(key);
+            return promisifyWriteTransaction(store.transaction);
+        });
     },
     removeItems(keysParam) {
         if (!provider.store) {
             throw new Error('Store not initialized!');
         }
 
-        return IDB.delMany(keysParam, provider.store);
+        return provider.store('readwrite', (store) => {
+            for (const key of keysParam) {
+                store.delete(key);
+            }
+            return promisifyWriteTransaction(store.transaction);
+        });
     },
     getDatabaseSize() {
         if (!provider.store) {

--- a/tests/unit/storage/providers/IDBKeyvalProviderTest.ts
+++ b/tests/unit/storage/providers/IDBKeyvalProviderTest.ts
@@ -201,19 +201,19 @@ describe('IDBKeyValProvider', () => {
             jest.restoreAllMocks();
         });
 
-        it('setItem rejects with a tagged AbortError, never null', async () => {
+        it('should reject setItem with a tagged AbortError, never null', async () => {
             abortTransactionOnPut();
             const error = await IDBKeyValProvider.setItem(ONYXKEYS.TEST_KEY, 'value').catch((e: unknown) => e);
             expectAbortError(error);
         });
 
-        it('multiSet rejects with a tagged AbortError, never null', async () => {
+        it('should reject multiSet with a tagged AbortError, never null', async () => {
             abortTransactionOnPut();
             const error = await IDBKeyValProvider.multiSet([[ONYXKEYS.TEST_KEY, 'value']]).catch((e: unknown) => e);
             expectAbortError(error);
         });
 
-        it('multiMerge rejects with a tagged AbortError, never null', async () => {
+        it('should reject multiMerge with a tagged AbortError, never null', async () => {
             abortTransactionOnPut();
             const error = await IDBKeyValProvider.multiMerge([[ONYXKEYS.TEST_KEY, 'value']]).catch((e: unknown) => e);
             expectAbortError(error);

--- a/tests/unit/storage/providers/IDBKeyvalProviderTest.ts
+++ b/tests/unit/storage/providers/IDBKeyvalProviderTest.ts
@@ -176,15 +176,22 @@ describe('IDBKeyValProvider', () => {
 
     describe('write-error normalization (aborted transactions)', () => {
         // A write transaction aborted by something other than its own request (connection close,
-        // versionchange, a sibling transaction) leaves `transaction.error === null`. idb-keyval
-        // rejects with that null, which is unclassifiable: it slips past createStore's heal guards
-        // (they require an Error/DOMException) and renders as the production log line
-        // "[Onyx] Failed to save to storage. Error: null". Every write path must instead reject
-        // with a real Error so the failure can be classified and retried sanely.
+        // versionchange, a sibling transaction) leaves `transaction.error === null`, which idb-keyval
+        // rejects with as-is. Every write path must instead reject with a real Error so the failure
+        // can be classified and retried.
         function abortTransactionOnPut() {
             const originalPut = IDBObjectStore.prototype.put;
             jest.spyOn(IDBObjectStore.prototype, 'put').mockImplementation(function put(this: IDBObjectStore, ...args: Parameters<IDBObjectStore['put']>) {
                 const request = originalPut.apply(this, args);
+                this.transaction.abort();
+                return request;
+            });
+        }
+
+        function abortTransactionOnDelete() {
+            const originalDelete = IDBObjectStore.prototype.delete;
+            jest.spyOn(IDBObjectStore.prototype, 'delete').mockImplementation(function del(this: IDBObjectStore, ...args: Parameters<IDBObjectStore['delete']>) {
+                const request = originalDelete.apply(this, args);
                 this.transaction.abort();
                 return request;
             });
@@ -216,6 +223,24 @@ describe('IDBKeyValProvider', () => {
         it('should reject multiMerge with a tagged AbortError, never null', async () => {
             abortTransactionOnPut();
             const error = await IDBKeyValProvider.multiMerge([[ONYXKEYS.TEST_KEY, 'value']]).catch((e: unknown) => e);
+            expectAbortError(error);
+        });
+
+        it('should reject setItem(null) with a tagged AbortError, never null', async () => {
+            abortTransactionOnDelete();
+            const error = await IDBKeyValProvider.setItem(ONYXKEYS.TEST_KEY, null).catch((e: unknown) => e);
+            expectAbortError(error);
+        });
+
+        it('should reject removeItem with a tagged AbortError, never null', async () => {
+            abortTransactionOnDelete();
+            const error = await IDBKeyValProvider.removeItem(ONYXKEYS.TEST_KEY).catch((e: unknown) => e);
+            expectAbortError(error);
+        });
+
+        it('should reject removeItems with a tagged AbortError, never null', async () => {
+            abortTransactionOnDelete();
+            const error = await IDBKeyValProvider.removeItems([ONYXKEYS.TEST_KEY]).catch((e: unknown) => e);
             expectAbortError(error);
         });
     });

--- a/tests/unit/storage/providers/IDBKeyvalProviderTest.ts
+++ b/tests/unit/storage/providers/IDBKeyvalProviderTest.ts
@@ -174,6 +174,52 @@ describe('IDBKeyValProvider', () => {
         });
     });
 
+    describe('write-error normalization (aborted transactions)', () => {
+        // A write transaction aborted by something other than its own request (connection close,
+        // versionchange, a sibling transaction) leaves `transaction.error === null`. idb-keyval
+        // rejects with that null, which is unclassifiable: it slips past createStore's heal guards
+        // (they require an Error/DOMException) and renders as the production log line
+        // "[Onyx] Failed to save to storage. Error: null". Every write path must instead reject
+        // with a real Error so the failure can be classified and retried sanely.
+        function abortTransactionOnPut() {
+            const originalPut = IDBObjectStore.prototype.put;
+            jest.spyOn(IDBObjectStore.prototype, 'put').mockImplementation(function put(this: IDBObjectStore, ...args: Parameters<IDBObjectStore['put']>) {
+                const request = originalPut.apply(this, args);
+                this.transaction.abort();
+                return request;
+            });
+        }
+
+        function expectAbortError(error: unknown) {
+            expect(error).not.toBeNull();
+            expect(error).toBeInstanceOf(DOMException);
+            expect((error as DOMException).name).toBe('AbortError');
+            expect((error as DOMException).message.length).toBeGreaterThan(0);
+        }
+
+        afterEach(() => {
+            jest.restoreAllMocks();
+        });
+
+        it('setItem rejects with a tagged AbortError, never null', async () => {
+            abortTransactionOnPut();
+            const error = await IDBKeyValProvider.setItem(ONYXKEYS.TEST_KEY, 'value').catch((e: unknown) => e);
+            expectAbortError(error);
+        });
+
+        it('multiSet rejects with a tagged AbortError, never null', async () => {
+            abortTransactionOnPut();
+            const error = await IDBKeyValProvider.multiSet([[ONYXKEYS.TEST_KEY, 'value']]).catch((e: unknown) => e);
+            expectAbortError(error);
+        });
+
+        it('multiMerge rejects with a tagged AbortError, never null', async () => {
+            abortTransactionOnPut();
+            const error = await IDBKeyValProvider.multiMerge([[ONYXKEYS.TEST_KEY, 'value']]).catch((e: unknown) => e);
+            expectAbortError(error);
+        });
+    });
+
     describe('mergeItem', () => {
         it('should merge all the supported kinds of data correctly', async () => {
             await IDB.set(ONYXKEYS.TEST_KEY, 'value', IDBKeyValProvider.store);


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

**Problem**
Web (IndexedDB) storage writes could reject with a literal null, surfacing in production as:

```
[Onyx] Failed to save to storage. Error: null. onyxMethod: setWithRetry. retryAttempt: 2/5
```

Root cause: `idb-keyval`'s `promisifyRequest` rejects a write with `transaction.error`. Per the IndexedDB spec, `transaction.error` is `null` for an abort not caused by the transaction's own request — connection close, versionchange, or a sibling transaction aborting. `IDBKeyValProvider.setItem` (via `IDB.set`), `multiSet`, and `multiMerge`'s commit path all awaited only the transaction, so those aborts propagated as `null`.

A `null` is unclassifiable: it slips past `createStore`'s heal guards (which require `instanceof Error/DOMException`) and renders as `Error: null` in `OnyxUtils.retryOperation`, giving zero diagnostic signal on a real, recurring failure.

The asymmetry that exposed it: multiMerge awaits the get request first, and an aborted in-flight request carries an AbortError (request.error) — so the same abort logged a useful AbortError via merge but a useless null via set, purely because of which IDB object each path listened on.

**Solution**

Normalize every write rejection to a real, named Error so the failure is always classifiable. Added one shared helper:

```js
function promisifyWriteTransaction(transaction: IDBTransaction): Promise<void> {
    return IDB.promisifyRequest(transaction).catch((error) => {
        throw error ?? new DOMException('IDB write transaction aborted without an error', 'AbortError');
    });
}
```

Applied to all three write paths: `setItem`, `multiSet`, and `multiMerge`'s commit. A real typed error (e.g. `QuotaExceededError` at commit) still passes through unchanged via the ??; only a literal null is replaced with a tagged `AbortError`.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/App/issues/87867

### Linked E/App PR
<!--
Every Onyx PR must ship with a corresponding Expensify/App PR that pins Onyx to this PR's HEAD via git+https
(e.g. "react-native-onyx": "git+https://github.com/Expensify/react-native-onyx.git#<commit_sha>").
That linked PR runs the full E/App test suite signals that the Onyx
change is safe. After this PR is merged and published to npm, swap the linked E/App PR to the pinned version
(e.g. "react-native-onyx": "3.0.72") and request a final review — it becomes the bump PR.

Paste the full Expensify/App PR URL below (e.g. https://github.com/Expensify/App/pull/12345):
-->
https://github.com/Expensify/App/pull/92488

### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

Added a write-error normalization (aborted transactions) block to IDBKeyvalProviderTest.ts: forcing an aborted transaction, setItem / multiSet / multiMerge each reject with a tagged AbortError (never null).

### Manual Tests
<!---
Each set of changes should be tested against the Expensify/App repo on all platforms to verify it does not break our staging App.
--->

This requires specific situation to reproduce which are hard to reproduce locally 

### Author Checklist

- [x] I linked the correct issue in the `### Related Issues` section above
- [x] I linked the corresponding Expensify/App PR in the `### Linked E/App PR` section above, and verified this change against it (E/App CI passed and manual testing completed)
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/602f9d41-4017-4877-ade8-f5049c233994


<!-- add screenshots or videos here -->

</details>