### PR TITLE
feat: add visibilitychange probe for proactive IDB health check

### DIFF
--- a/lib/storage/providers/IDBKeyValProvider/createStore.ts
+++ b/lib/storage/providers/IDBKeyValProvider/createStore.ts
@@ -133,51 +133,49 @@ function createStore(dbName: string, storeName: string): UseStore {
     }
 
     // Proactive IDB health check when tab returns to foreground.
-    // Safari kills IDB connections for backgrounded tabs. By probing before
-    // the ReconnectApp write storm hits, we drop the stale dbp early so the
-    // first real operation opens a fresh connection instead of failing.
-    if (typeof document !== 'undefined') {
-        document.addEventListener('visibilitychange', () => {
-            if (document.visibilityState !== 'visible' || !dbp) {
+    // Safari kills IDB connections for backgrounded tabs. By probing as soon as
+    // the tab becomes visible, we drop the stale dbp early so the first real
+    // operation opens a fresh connection instead of failing.
+    document.addEventListener('visibilitychange', () => {
+        if (document.visibilityState !== 'visible' || !dbp) {
+            return;
+        }
+
+        Logger.logInfo('IDB visibilitychange probe: tab became visible, checking connection health', {dbName, storeName});
+
+        const probePromise = dbp;
+
+        const dropCacheIfStale = (error: unknown) => {
+            if (dbp !== probePromise || !isStaleConnectionError(error)) {
                 return;
             }
-
-            Logger.logInfo('IDB visibilitychange probe: tab became visible, checking connection health', {dbName, storeName});
-
-            const probePromise = dbp;
-
-            const dropCacheIfStale = (error: unknown) => {
-                if (dbp !== probePromise || !isStaleConnectionError(error)) {
-                    return;
-                }
-                Logger.logAlert('IDB visibilitychange probe: stale connection detected, dropping cached connection', {
-                    dbName,
-                    storeName,
-                    errorMessage: error instanceof Error ? error.message : String(error),
-                });
-                dbp = undefined;
-            };
-
-            probePromise.then((db) => {
-                if (dbp !== probePromise) {
-                    return;
-                }
-                try {
-                    const tx = db.transaction(storeName, 'readonly');
-                    const probeStore = tx.objectStore(storeName);
-                    const req = probeStore.count();
-                    req.onsuccess = () => {
-                        Logger.logInfo('IDB visibilitychange probe: connection is healthy', {dbName, storeName});
-                    };
-                    req.onerror = () => {
-                        dropCacheIfStale(req.error);
-                    };
-                } catch (error) {
-                    dropCacheIfStale(error);
-                }
+            Logger.logAlert('IDB visibilitychange probe: stale connection detected, dropping cached connection', {
+                dbName,
+                storeName,
+                errorMessage: error instanceof Error ? error.message : String(error),
             });
+            dbp = undefined;
+        };
+
+        probePromise.then((db) => {
+            if (dbp !== probePromise) {
+                return;
+            }
+            try {
+                const tx = db.transaction(storeName, 'readonly');
+                const probeStore = tx.objectStore(storeName);
+                const req = probeStore.count();
+                req.onsuccess = () => {
+                    Logger.logInfo('IDB visibilitychange probe: connection is healthy', {dbName, storeName});
+                };
+                req.onerror = () => {
+                    dropCacheIfStale(req.error);
+                };
+            } catch (error) {
+                dropCacheIfStale(error);
+            }
         });
-    }
+    });
 
     // Handles three recoverable error classes:
     // 1. InvalidStateError — connection closed between getDB() resolving and db.transaction().

--- a/lib/storage/providers/IDBKeyValProvider/createStore.ts
+++ b/lib/storage/providers/IDBKeyValProvider/createStore.ts
@@ -164,10 +164,12 @@ function createStore(dbName: string, storeName: string): UseStore {
                     const tx = db.transaction(storeName, 'readonly');
                     const probeStore = tx.objectStore(storeName);
                     const req = probeStore.count();
+                    req.onsuccess = () => {
+                        Logger.logInfo('IDB visibilitychange probe: connection is healthy', {dbName, storeName});
+                    };
                     req.onerror = () => {
                         dropCacheIfStale(req.error);
                     };
-                    Logger.logInfo('IDB visibilitychange probe: connection is healthy', {dbName, storeName});
                 } catch (error) {
                     dropCacheIfStale(error);
                 }

--- a/lib/storage/providers/IDBKeyValProvider/createStore.ts
+++ b/lib/storage/providers/IDBKeyValProvider/createStore.ts
@@ -10,7 +10,7 @@ const HEAL_ATTEMPTS_MAX = 3;
  * internal recovery (RepairDB -> delete -> recreate) also fails.
  */
 function isBackingStoreError(error: unknown): boolean {
-    return error instanceof Error && error.message.includes('Internal error opening backing store');
+    return (error instanceof Error || error instanceof DOMException) && (error as Error).message.includes('Internal error opening backing store');
 }
 
 /**
@@ -19,13 +19,13 @@ function isBackingStoreError(error: unknown): boolean {
  * WebKit bugs: https://bugs.webkit.org/show_bug.cgi?id=197050, https://bugs.webkit.org/show_bug.cgi?id=201483
  */
 function isConnectionLostError(error: unknown): boolean {
-    if (!(error instanceof Error)) return false;
-    const msg = error.message.toLowerCase();
+    if (!(error instanceof Error || error instanceof DOMException)) return false;
+    const msg = (error as Error).message.toLowerCase();
     return msg.includes('connection to indexed database server lost') || msg.includes('connection is closing');
 }
 
 function isInvalidStateError(error: unknown): boolean {
-    return error instanceof Error && error.name === 'InvalidStateError';
+    return (error instanceof Error || error instanceof DOMException) && (error as Error).name === 'InvalidStateError';
 }
 
 /** Errors that trigger a budgeted heal-and-retry in store(). */

--- a/lib/storage/providers/IDBKeyValProvider/createStore.ts
+++ b/lib/storage/providers/IDBKeyValProvider/createStore.ts
@@ -140,13 +140,19 @@ function createStore(dbName: string, storeName: string): UseStore {
                 return;
             }
 
+            Logger.logInfo('IDB visibilitychange probe: tab became visible, checking connection health', {dbName, storeName});
+
             const probePromise = dbp;
 
             const dropCacheIfStale = (error: unknown) => {
                 if (dbp !== probePromise || !isStaleConnectionError(error)) {
                     return;
                 }
-                Logger.logInfo('IDB visibilitychange probe: connection lost, dropping cached connection', {dbName, storeName});
+                Logger.logAlert('IDB visibilitychange probe: stale connection detected, dropping cached connection', {
+                    dbName,
+                    storeName,
+                    errorMessage: error instanceof Error ? error.message : String(error),
+                });
                 dbp = undefined;
             };
 
@@ -161,6 +167,7 @@ function createStore(dbName: string, storeName: string): UseStore {
                     req.onerror = () => {
                         dropCacheIfStale(req.error);
                     };
+                    Logger.logInfo('IDB visibilitychange probe: connection is healthy', {dbName, storeName});
                 } catch (error) {
                     dropCacheIfStale(error);
                 }

--- a/lib/storage/providers/IDBKeyValProvider/createStore.ts
+++ b/lib/storage/providers/IDBKeyValProvider/createStore.ts
@@ -37,6 +37,11 @@ function getBudgetedHealErrorLabel(error: unknown): 'backing store' | 'connectio
     return isBackingStoreError(error) ? 'backing store' : 'connection lost';
 }
 
+/** Union of all error types indicating a stale/dead IDB connection. Used by the visibilitychange probe. */
+function isStaleConnectionError(error: unknown): boolean {
+    return isInvalidStateError(error) || isBackingStoreError(error) || isConnectionLostError(error);
+}
+
 // This is a copy of the createStore function from idb-keyval, we need a custom implementation
 // because we need to create the database manually in order to ensure that the store exists before we use it.
 // If the store does not exist, idb-keyval will throw an error
@@ -123,6 +128,44 @@ function createStore(dbName: string, storeName: string): UseStore {
     function resetHealBudget<T>(result: T): T {
         healAttemptsRemaining = HEAL_ATTEMPTS_MAX;
         return result;
+    }
+
+    // Proactive IDB health check when tab returns to foreground.
+    // Safari kills IDB connections for backgrounded tabs. By probing before
+    // the ReconnectApp write storm hits, we drop the stale dbp early so the
+    // first real operation opens a fresh connection instead of failing.
+    if (typeof document !== 'undefined') {
+        document.addEventListener('visibilitychange', () => {
+            if (document.visibilityState !== 'visible' || !dbp) {
+                return;
+            }
+
+            const probePromise = dbp;
+
+            const dropCacheIfStale = (error: unknown) => {
+                if (dbp !== probePromise || !isStaleConnectionError(error)) {
+                    return;
+                }
+                Logger.logInfo('IDB visibilitychange probe: connection lost, dropping cached connection', {dbName, storeName});
+                dbp = undefined;
+            };
+
+            probePromise.then((db) => {
+                if (dbp !== probePromise) {
+                    return;
+                }
+                try {
+                    const tx = db.transaction(storeName, 'readonly');
+                    const probeStore = tx.objectStore(storeName);
+                    const req = probeStore.count();
+                    req.onerror = () => {
+                        dropCacheIfStale(req.error);
+                    };
+                } catch (error) {
+                    dropCacheIfStale(error);
+                }
+            });
+        });
     }
 
     // Handles three recoverable error classes:

--- a/lib/storage/providers/IDBKeyValProvider/createStore.ts
+++ b/lib/storage/providers/IDBKeyValProvider/createStore.ts
@@ -33,8 +33,10 @@ function isBudgetedHealError(error: unknown): boolean {
     return isBackingStoreError(error) || isConnectionLostError(error);
 }
 
-function getBudgetedHealErrorLabel(error: unknown): 'backing store' | 'connection lost' {
-    return isBackingStoreError(error) ? 'backing store' : 'connection lost';
+function getBudgetedHealErrorLabel(error: unknown): string {
+    if (isBackingStoreError(error)) return 'backing store';
+    if (isConnectionLostError(error)) return 'connection lost';
+    return 'unknown';
 }
 
 /** Union of all error types indicating a stale/dead IDB connection. Used by the visibilitychange probe. */

--- a/lib/storage/providers/IDBKeyValProvider/createStore.ts
+++ b/lib/storage/providers/IDBKeyValProvider/createStore.ts
@@ -157,24 +157,29 @@ function createStore(dbName: string, storeName: string): UseStore {
             dbp = undefined;
         };
 
-        probePromise.then((db) => {
-            if (dbp !== probePromise) {
-                return;
-            }
-            try {
-                const tx = db.transaction(storeName, 'readonly');
-                const probeStore = tx.objectStore(storeName);
-                const req = probeStore.count();
-                req.onsuccess = () => {
-                    Logger.logInfo('IDB visibilitychange probe: connection is healthy', {dbName, storeName});
-                };
-                req.onerror = () => {
-                    dropCacheIfStale(req.error);
-                };
-            } catch (error) {
-                dropCacheIfStale(error);
-            }
-        });
+        probePromise
+            .then((db) => {
+                if (dbp !== probePromise) {
+                    return;
+                }
+                try {
+                    const tx = db.transaction(storeName, 'readonly');
+                    const probeStore = tx.objectStore(storeName);
+                    const req = probeStore.count();
+                    req.onsuccess = () => {
+                        Logger.logInfo('IDB visibilitychange probe: connection is healthy', {dbName, storeName});
+                    };
+                    req.onerror = () => {
+                        dropCacheIfStale(req.error);
+                    };
+                } catch (error) {
+                    dropCacheIfStale(error);
+                }
+            })
+            .catch(() => {
+                // The cached open promise rejected; cacheOpenPromise already cleared dbp on its own
+                // branch. Swallow here so the probe's separate branch doesn't surface an unhandled rejection.
+            });
     });
 
     // Handles three recoverable error classes:

--- a/tests/unit/storage/providers/createStoreTest.ts
+++ b/tests/unit/storage/providers/createStoreTest.ts
@@ -666,5 +666,50 @@ describe('createStore', () => {
             expect(result).toBe('value');
             expect(logAlertSpy).toHaveBeenCalledWith(expect.stringContaining('IDB visibilitychange probe: stale connection detected'), expect.objectContaining({dbName: expect.any(String)}));
         });
+
+        it('should not surface an unhandled rejection when the probe runs while the open promise rejects', async () => {
+            const store = createStore(uniqueDBName(), STORE_NAME);
+
+            // Keep the initial open pending until we reject it manually, so the probe attaches to a pending dbp.
+            let rejectOpen: () => void = () => {
+                /* assigned inside the indexedDB.open mock below */
+            };
+            jest.spyOn(indexedDB, 'open').mockImplementation(() => {
+                const req = {} as IDBOpenDBRequest;
+                rejectOpen = () => {
+                    Object.defineProperty(req, 'error', {value: new DOMException('probe open failed', 'AbortError'), configurable: true});
+                    req.onerror?.(new Event('error') as Event & {target: IDBOpenDBRequest});
+                };
+                return req;
+            });
+
+            const unhandled = jest.fn();
+            process.on('unhandledRejection', unhandled);
+
+            try {
+                // Start an op so dbp becomes a pending open promise; keep its rejection handled.
+                const opAssertion = expect(store('readonly', (s) => IDB.promisifyRequest(s.get('key1')))).rejects.toThrow('probe open failed');
+
+                // Tab becomes visible while the open is still pending — probe attaches to the pending dbp.
+                simulateVisibilityChange('hidden');
+                simulateVisibilityChange('visible');
+
+                // Now the open rejects — both the op chain and the probe chain see it.
+                rejectOpen();
+
+                await opAssertion;
+                // Give the probe's separate branch a couple of ticks to (not) surface an unhandled rejection.
+                await new Promise((resolve) => {
+                    setTimeout(resolve, 0);
+                });
+                await new Promise((resolve) => {
+                    setTimeout(resolve, 0);
+                });
+
+                expect(unhandled).not.toHaveBeenCalled();
+            } finally {
+                process.off('unhandledRejection', unhandled);
+            }
+        });
     });
 });

--- a/tests/unit/storage/providers/createStoreTest.ts
+++ b/tests/unit/storage/providers/createStoreTest.ts
@@ -594,7 +594,7 @@ describe('createStore', () => {
 
             const result = await store('readonly', (s) => IDB.promisifyRequest(s.get('key1')));
             expect(result).toBe('value');
-            expect(logInfoSpy).toHaveBeenCalledWith('IDB visibilitychange probe: connection lost, dropping cached connection', expect.objectContaining({dbName: expect.any(String)}));
+            expect(logAlertSpy).toHaveBeenCalledWith(expect.stringContaining('IDB visibilitychange probe: stale connection detected'), expect.objectContaining({dbName: expect.any(String)}));
         });
 
         it('should not probe when no connection exists yet', async () => {
@@ -629,7 +629,9 @@ describe('createStore', () => {
 
             const result = await store('readonly', (s) => IDB.promisifyRequest(s.get('key1')));
             expect(result).toBe('value');
-            expect(logInfoSpy).not.toHaveBeenCalledWith(expect.stringContaining('visibilitychange probe'), expect.anything());
+            // Probe ran but found healthy connection — no stale connection alert
+            expect(logAlertSpy).not.toHaveBeenCalledWith(expect.stringContaining('stale connection detected'), expect.anything());
+            expect(logInfoSpy).toHaveBeenCalledWith(expect.stringContaining('connection is healthy'), expect.anything());
         });
 
         it('should drop dbp when probe throws InvalidStateError', async () => {
@@ -662,7 +664,7 @@ describe('createStore', () => {
 
             const result = await store('readonly', (s) => IDB.promisifyRequest(s.get('key1')));
             expect(result).toBe('value');
-            expect(logInfoSpy).toHaveBeenCalledWith('IDB visibilitychange probe: connection lost, dropping cached connection', expect.objectContaining({dbName: expect.any(String)}));
+            expect(logAlertSpy).toHaveBeenCalledWith(expect.stringContaining('IDB visibilitychange probe: stale connection detected'), expect.objectContaining({dbName: expect.any(String)}));
         });
     });
 });

--- a/tests/unit/storage/providers/createStoreTest.ts
+++ b/tests/unit/storage/providers/createStoreTest.ts
@@ -553,4 +553,116 @@ describe('createStore', () => {
             expect(logAlertSpy).not.toHaveBeenCalledWith(expect.stringContaining('dropping cached connection and reopening'), expect.anything());
         });
     });
+
+    describe('visibilitychange probe', () => {
+        function simulateVisibilityChange(state: string) {
+            Object.defineProperty(document, 'visibilityState', {value: state, writable: true, configurable: true});
+            document.dispatchEvent(new Event('visibilitychange'));
+        }
+
+        afterEach(() => {
+            Object.defineProperty(document, 'visibilityState', {value: 'visible', writable: true, configurable: true});
+        });
+
+        it('should drop stale dbp when probe detects connection lost on foreground', async () => {
+            const store = createStore(uniqueDBName(), STORE_NAME);
+
+            await store('readwrite', (s) => {
+                s.put('value', 'key1');
+                return IDB.promisifyRequest(s.transaction);
+            });
+
+            simulateVisibilityChange('hidden');
+
+            const original = IDBDatabase.prototype.transaction;
+            let probeIntercepted = false;
+            jest.spyOn(IDBDatabase.prototype, 'transaction').mockImplementation(function (this: IDBDatabase, ...args) {
+                if (!probeIntercepted) {
+                    probeIntercepted = true;
+                    throw new DOMException('Connection to Indexed Database server lost. Refresh the page to try again', 'UnknownError');
+                }
+                return original.apply(this, args);
+            });
+
+            simulateVisibilityChange('visible');
+
+            await new Promise((resolve) => {
+                setTimeout(resolve, 0);
+            });
+
+            jest.restoreAllMocks();
+
+            const result = await store('readonly', (s) => IDB.promisifyRequest(s.get('key1')));
+            expect(result).toBe('value');
+            expect(logInfoSpy).toHaveBeenCalledWith('IDB visibilitychange probe: connection lost, dropping cached connection', expect.objectContaining({dbName: expect.any(String)}));
+        });
+
+        it('should not probe when no connection exists yet', async () => {
+            const dbName = uniqueDBName();
+            createStore(dbName, STORE_NAME);
+
+            simulateVisibilityChange('hidden');
+            simulateVisibilityChange('visible');
+
+            await new Promise((resolve) => {
+                setTimeout(resolve, 0);
+            });
+
+            // No probe log for this specific store (dbp was never set)
+            expect(logInfoSpy).not.toHaveBeenCalledWith(expect.stringContaining('visibilitychange probe'), expect.objectContaining({dbName}));
+        });
+
+        it('should keep connection when probe succeeds', async () => {
+            const store = createStore(uniqueDBName(), STORE_NAME);
+
+            await store('readwrite', (s) => {
+                s.put('value', 'key1');
+                return IDB.promisifyRequest(s.transaction);
+            });
+
+            simulateVisibilityChange('hidden');
+            simulateVisibilityChange('visible');
+
+            await new Promise((resolve) => {
+                setTimeout(resolve, 0);
+            });
+
+            const result = await store('readonly', (s) => IDB.promisifyRequest(s.get('key1')));
+            expect(result).toBe('value');
+            expect(logInfoSpy).not.toHaveBeenCalledWith(expect.stringContaining('visibilitychange probe'), expect.anything());
+        });
+
+        it('should drop dbp when probe throws InvalidStateError', async () => {
+            const store = createStore(uniqueDBName(), STORE_NAME);
+
+            await store('readwrite', (s) => {
+                s.put('value', 'key1');
+                return IDB.promisifyRequest(s.transaction);
+            });
+
+            simulateVisibilityChange('hidden');
+
+            const original = IDBDatabase.prototype.transaction;
+            let callCount = 0;
+            jest.spyOn(IDBDatabase.prototype, 'transaction').mockImplementation(function (this: IDBDatabase, ...args) {
+                callCount++;
+                if (callCount === 1) {
+                    throw new DOMException('The database connection is closing.', 'InvalidStateError');
+                }
+                return original.apply(this, args);
+            });
+
+            simulateVisibilityChange('visible');
+
+            await new Promise((resolve) => {
+                setTimeout(resolve, 0);
+            });
+
+            jest.restoreAllMocks();
+
+            const result = await store('readonly', (s) => IDB.promisifyRequest(s.get('key1')));
+            expect(result).toBe('value');
+            expect(logInfoSpy).toHaveBeenCalledWith('IDB visibilitychange probe: connection lost, dropping cached connection', expect.objectContaining({dbName: expect.any(String)}));
+        });
+    });
 });


### PR DESCRIPTION
### Details

Adds a proactive `visibilitychange` probe to the IDB connection manager, building on the reactive heal mechanism from #780.

**Problem:** Safari kills IDB connections for backgrounded tabs ([WebKit #197050](https://bugs.webkit.org/show_bug.cgi?id=197050), [#201483](https://bugs.webkit.org/show_bug.cgi?id=201483)). When the user returns to the tab, the burst of writes on reconnect hits the dead cached `dbp` — every write fails before the reactive heal can kick in.

**Solution:** Register a `visibilitychange` listener inside `createStore()` that runs a lightweight readonly `count()` probe when the tab becomes visible. If the probe detects a dead IDB connection, it drops the stale `dbp` *before* the write burst arrives, so the first real operation opens a fresh connection.

**What it does:**

- `isStaleConnectionError()` — union detector for all three stale connection error types (InvalidStateError, backing store corruption, connection lost)
- `visibilitychange` listener with a `probePromise` guard — prevents a stale probe from clearing a `dbp` that was already replaced by a concurrent heal/retry
- Classified `req.onerror` — only drops `dbp` for actual stale connection errors, not unrelated IDB errors
- Diagnostic logging: `logInfo` on probe start ("tab became visible, checking connection health") and healthy result ("connection is healthy"); `logAlert` on stale detection ("stale connection detected, dropping cached connection") with the error message

### Related Issues

https://github.com/Expensify/App/issues/87864

### Linked E/App PR

https://github.com/Expensify/App/pull/92762

### Automated Tests

4 new tests in `tests/unit/storage/providers/createStoreTest.ts`, in the `describe('visibilitychange probe')` block:

- probe detects a dead connection and drops `dbp`
- probe is skipped when no `dbp` exists yet
- healthy connection is preserved
- `InvalidStateError` synchronous throw is handled

All tests pass (`npx jest tests/unit/storage/providers/createStoreTest.ts` → 23 passed).

### Manual Tests

**Simulating Safari connection lost:**
1. Open the app in Safari, log in
2. Switch to a different tab and wait 30+ seconds (Safari may kill IDB connections for backgrounded tabs)
3. Switch back to the tab
4. Verify in console: `IDB visibilitychange probe: stale connection detected, dropping cached connection` appears (if Safari killed the connection)
5. Interact with the app — it should recover seamlessly

### Author Checklist

- [x] I linked the correct issue in the `### Related Issues` section above
- [x] I linked the corresponding Expensify/App PR in the `### Linked E/App PR` section above, and verified this change against it (E/App CI passed and manual testing completed)
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

N/A — library-level change, IDB is web-only. No UI, no native code touched.

</details>

<details>
<summary>Android: mWeb Chrome</summary>

N/A — library-level change, IDB is web-only. No UI, no native code touched.

</details>

<details>
<summary>iOS: Native</summary>

N/A — library-level change, IDB is web-only. No UI, no native code touched.

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- TODO (reviewer request): add a real iOS mWeb Safari recording — this is the primary target platform for the probe -->

https://github.com/user-attachments/assets/9a5dbf0d-f868-4449-955c-b6588ae75888



</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

**Healed (simulated error):**

https://github.com/user-attachments/assets/e42fc3c0-38ca-416a-882e-89f907b77270

Killed connection (simulated error):

https://github.com/user-attachments/assets/f154bdae-4968-4152-9fc8-034dc95a6566

**Exhausted (simulated error):**

https://github.com/user-attachments/assets/6021d445-b871-43e8-b844-47c8ef8d73aa

Healed (simulated on Safari):

https://github.com/user-attachments/assets/6f2375fc-78b9-48be-b90e-d904ac939805

Killed connection (simulated on Safari):

https://github.com/user-attachments/assets/f7e6df4a-5b22-4415-aee1-fbaaae442567

Exhausted (simulated on Safari):

https://github.com/user-attachments/assets/38578b0f-6553-4183-8066-0bbc0fa07c66

**Healed offline (simulated on Chrome):**

https://github.com/user-attachments/assets/3106976c-e980-498c-a70e-8e8ca7c1ccda

</details>
