### PR TITLE
feat: Split queries with many parameters into multiple queries to avoid `too many SQL variables` error

### DIFF
--- a/lib/storage/providers/SQLiteProvider.ts
+++ b/lib/storage/providers/SQLiteProvider.ts
@@ -10,6 +10,8 @@ import utils from '../../utils';
 import type StorageProvider from './types';
 import type {StorageKeyList, StorageKeyValuePair} from './types';
 
+const SQLITE_MAX_VARIABLE_NUMBER = 32766;
+
 /**
  * The type of the key-value pair stored in the SQLite database
  * @property record_key - the key of the record
@@ -100,12 +102,24 @@ const provider: StorageProvider<NitroSQLiteConnection | undefined> = {
             throw new Error('Store is not initialized!');
         }
 
-        const placeholders = keys.map(() => '?').join(',');
-        const command = `SELECT record_key, valueJSON FROM keyvaluepairs WHERE record_key IN (${placeholders});`;
-        return provider.store.executeAsync<OnyxSQLiteKeyValuePair>(command, keys).then(({rows}) => {
-            // eslint-disable-next-line no-underscore-dangle
-            const result = rows?._array.map((row) => [row.record_key, JSON.parse(row.valueJSON)]);
-            return (result ?? []) as StorageKeyValuePair[];
+        if (keys.length === 0) {
+            return Promise.resolve([]);
+        }
+
+        const keyChunks = utils.chunkArray(keys, SQLITE_MAX_VARIABLE_NUMBER);
+
+        return Promise.all(
+            keyChunks.map((keyChunk) => {
+                const placeholders = keyChunk.map(() => '?').join(',');
+                const command = `SELECT record_key, valueJSON FROM keyvaluepairs WHERE record_key IN (${placeholders});`;
+                return provider.store!.executeAsync<OnyxSQLiteKeyValuePair>(command, keyChunk);
+            }),
+        ).then((results) => {
+            const result = results.flatMap(({rows}) =>
+                // eslint-disable-next-line no-underscore-dangle
+                rows?._array.map((row) => [row.record_key, JSON.parse(row.valueJSON)]) ?? [],
+            );
+            return result as StorageKeyValuePair[];
         });
     },
     setItem(key, value) {
@@ -214,9 +228,19 @@ const provider: StorageProvider<NitroSQLiteConnection | undefined> = {
             throw new Error('Store is not initialized!');
         }
 
-        const placeholders = keys.map(() => '?').join(',');
-        const query = `DELETE FROM keyvaluepairs WHERE record_key IN (${placeholders});`;
-        return provider.store.executeAsync(query, keys).then(() => undefined);
+        if (keys.length === 0) {
+            return Promise.resolve();
+        }
+
+        const keyChunks = utils.chunkArray(keys, SQLITE_MAX_VARIABLE_NUMBER);
+
+        return Promise.all(
+            keyChunks.map((keyChunk) => {
+                const placeholders = keyChunk.map(() => '?').join(',');
+                const query = `DELETE FROM keyvaluepairs WHERE record_key IN (${placeholders});`;
+                return provider.store!.executeAsync(query, keyChunk);
+            }),
+        ).then(() => undefined);
     },
     clear() {
         if (!provider.store) {

--- a/lib/storage/providers/SQLiteProvider.ts
+++ b/lib/storage/providers/SQLiteProvider.ts
@@ -281,13 +281,22 @@ const provider: StorageProvider<NitroSQLiteConnection | undefined> = {
 
         const keyChunks = utils.chunkArray(keys, sqliteMaxVariableNumber);
 
-        return Promise.all(
-            keyChunks.map((keyChunk) => {
-                const placeholders = keyChunk.map(() => '?').join(',');
-                const query = `DELETE FROM keyvaluepairs WHERE record_key IN (${placeholders});`;
-                return provider.store!.executeAsync(query, keyChunk);
-            }),
-        ).then(() => undefined);
+        const buildDeleteQuery = (keyChunk: readonly string[]) => {
+            const placeholders = keyChunk.map(() => '?').join(',');
+            return `DELETE FROM keyvaluepairs WHERE record_key IN (${placeholders});`;
+        };
+
+        if (keyChunks.length === 1) {
+            const keyChunk = keyChunks[0];
+            return provider.store.executeAsync(buildDeleteQuery(keyChunk), keyChunk).then(() => undefined);
+        }
+
+        const commands: BatchQueryCommand[] = keyChunks.map((keyChunk) => ({
+            query: buildDeleteQuery(keyChunk),
+            params: [keyChunk],
+        }));
+
+        return provider.store.executeBatchAsync(commands).then(() => undefined);
     },
     clear() {
         if (!provider.store) {

--- a/lib/storage/providers/SQLiteProvider.ts
+++ b/lib/storage/providers/SQLiteProvider.ts
@@ -186,7 +186,7 @@ const provider: StorageProvider<NitroSQLiteConnection | undefined> = {
         }
 
         const query = 'REPLACE INTO keyvaluepairs (record_key, valueJSON) VALUES (?, ?);';
-        const params = pairs.map((pair) => [pair[0], JSON.stringify(pair[1] === undefined ? null : pair[1])]);
+        const params = pairs.map(([key, value]) => [key, JSON.stringify(value === undefined ? null : value)]);
         if (utils.isEmptyObject(params)) {
             return Promise.resolve();
         }

--- a/lib/storage/providers/SQLiteProvider.ts
+++ b/lib/storage/providers/SQLiteProvider.ts
@@ -156,9 +156,13 @@ const provider: StorageProvider<NitroSQLiteConnection | undefined> = {
 
         return Promise.all(
             keyChunks.map((keyChunk) => {
+                if (!provider.store) {
+                    throw new Error('Store is not initialized!');
+                }
+
                 const placeholders = keyChunk.map(() => '?').join(',');
                 const command = `SELECT record_key, valueJSON FROM keyvaluepairs WHERE record_key IN (${placeholders});`;
-                return provider.store!.executeAsync<OnyxSQLiteKeyValuePair>(command, keyChunk);
+                return provider.store.executeAsync<OnyxSQLiteKeyValuePair>(command, keyChunk);
             }),
         ).then((results) => {
             const result = results.flatMap(

--- a/lib/storage/providers/SQLiteProvider.ts
+++ b/lib/storage/providers/SQLiteProvider.ts
@@ -293,7 +293,7 @@ const provider: StorageProvider<NitroSQLiteConnection | undefined> = {
 
         const commands: BatchQueryCommand[] = keyChunks.map((keyChunk) => ({
             query: buildDeleteQuery(keyChunk),
-            params: [keyChunk],
+            params: keyChunk,
         }));
 
         return provider.store.executeBatchAsync(commands).then(() => undefined);

--- a/lib/storage/providers/SQLiteProvider.ts
+++ b/lib/storage/providers/SQLiteProvider.ts
@@ -10,7 +10,12 @@ import utils from '../../utils';
 import type StorageProvider from './types';
 import type {StorageKeyList, StorageKeyValuePair} from './types';
 
-const SQLITE_MAX_VARIABLE_NUMBER = 32766;
+/**
+ * The result of the `PRAGMA compile_options`, which lists SQLite compile-time options
+ */
+type CompileOptionsResult = {
+    compile_options: string;
+};
 
 /**
  * The type of the key-value pair stored in the SQLite database
@@ -37,6 +42,33 @@ type PageCountResult = {
 };
 
 const DB_NAME = 'OnyxDB';
+const SQLITE_MAX_VARIABLE_NUMBER = 32766;
+
+/** SQLite's maximum number of bound parameters per statement, read once from PRAGMA compile_options in init(). */
+let sqliteMaxVariableNumber = SQLITE_MAX_VARIABLE_NUMBER;
+
+/**
+ * Parses MAX_VARIABLE_NUMBER from the rows returned by `PRAGMA compile_options`.
+ */
+function parseMaxVariableNumber(compileOptionsResult: {rows?: {length: number; item: (index: number) => CompileOptionsResult | undefined}}): number {
+    const rowCount = compileOptionsResult.rows?.length ?? 0;
+
+    for (let index = 0; index < rowCount; index++) {
+        const compileOption = compileOptionsResult.rows?.item(index)?.compile_options;
+
+        if (!compileOption?.startsWith('MAX_VARIABLE_NUMBER=')) {
+            continue;
+        }
+
+        const maxVariableNumber = Number(compileOption.split('=')[1]);
+
+        if (maxVariableNumber > 0) {
+            return maxVariableNumber;
+        }
+    }
+
+    return SQLITE_MAX_VARIABLE_NUMBER;
+}
 
 /**
  * Prevents the stringifying of the object markers.
@@ -73,6 +105,9 @@ const provider: StorageProvider<NitroSQLiteConnection | undefined> = {
 
         provider.store.execute('CREATE TABLE IF NOT EXISTS keyvaluepairs (record_key TEXT NOT NULL PRIMARY KEY , valueJSON JSON NOT NULL) WITHOUT ROWID;');
 
+        const compileOptionsResult = provider.store.execute<CompileOptionsResult>('PRAGMA compile_options;');
+        sqliteMaxVariableNumber = parseMaxVariableNumber(compileOptionsResult);
+
         // All of the 3 pragmas below were suggested by SQLite team.
         // You can find more info about them here: https://www.sqlite.org/pragma.html
         provider.store.execute('PRAGMA CACHE_SIZE=-20000;');
@@ -106,7 +141,7 @@ const provider: StorageProvider<NitroSQLiteConnection | undefined> = {
             return Promise.resolve([]);
         }
 
-        const keyChunks = utils.chunkArray(keys, SQLITE_MAX_VARIABLE_NUMBER);
+        const keyChunks = utils.chunkArray(keys, sqliteMaxVariableNumber);
 
         return Promise.all(
             keyChunks.map((keyChunk) => {
@@ -232,7 +267,7 @@ const provider: StorageProvider<NitroSQLiteConnection | undefined> = {
             return Promise.resolve();
         }
 
-        const keyChunks = utils.chunkArray(keys, SQLITE_MAX_VARIABLE_NUMBER);
+        const keyChunks = utils.chunkArray(keys, sqliteMaxVariableNumber);
 
         return Promise.all(
             keyChunks.map((keyChunk) => {

--- a/lib/storage/providers/SQLiteProvider.ts
+++ b/lib/storage/providers/SQLiteProvider.ts
@@ -2,7 +2,7 @@
  * The SQLiteStorage provider stores everything in a key/value store by
  * converting the value to a JSON string
  */
-import type {BatchQueryCommand, NitroSQLiteConnection} from 'react-native-nitro-sqlite';
+import type {BatchQueryCommand, NitroSQLiteConnection, QueryResult} from 'react-native-nitro-sqlite';
 import {open} from 'react-native-nitro-sqlite';
 import {getFreeDiskStorage} from 'react-native-device-info';
 import type {FastMergeReplaceNullPatch} from '../../utils';
@@ -43,31 +43,38 @@ type PageCountResult = {
 
 const DB_NAME = 'OnyxDB';
 const SQLITE_MAX_VARIABLE_NUMBER = 32766;
+const COMPILE_OPTIONS = {
+    MAX_VARIABLE_NUMBER: 'MAX_VARIABLE_NUMBER',
+} as const;
 
 /** SQLite's maximum number of bound parameters per statement, read once from PRAGMA compile_options in init(). */
 let sqliteMaxVariableNumber = SQLITE_MAX_VARIABLE_NUMBER;
 
 /**
- * Parses MAX_VARIABLE_NUMBER from the rows returned by `PRAGMA compile_options`.
+ * Returns the value of a compile option from the rows returned by `PRAGMA compile_options`.
+ * For flag-only options (e.g. `ENABLE_FTS3`), returns an empty string when the option is present.
  */
-function parseMaxVariableNumber(compileOptionsResult: {rows?: {length: number; item: (index: number) => CompileOptionsResult | undefined}}): number {
+function getCompileOptionValue(compileOptionsResult: QueryResult<CompileOptionsResult>, optionName: string): string | undefined {
+    const optionPrefix = `${optionName}=`;
     const rowCount = compileOptionsResult.rows?.length ?? 0;
 
     for (let index = 0; index < rowCount; index++) {
         const compileOption = compileOptionsResult.rows?.item(index)?.compile_options;
 
-        if (!compileOption?.startsWith('MAX_VARIABLE_NUMBER=')) {
+        if (!compileOption) {
             continue;
         }
 
-        const maxVariableNumber = Number(compileOption.split('=')[1]);
+        if (compileOption === optionName) {
+            return '';
+        }
 
-        if (maxVariableNumber > 0) {
-            return maxVariableNumber;
+        if (compileOption.startsWith(optionPrefix)) {
+            return compileOption.slice(optionPrefix.length);
         }
     }
 
-    return SQLITE_MAX_VARIABLE_NUMBER;
+    return undefined;
 }
 
 /**
@@ -105,14 +112,18 @@ const provider: StorageProvider<NitroSQLiteConnection | undefined> = {
 
         provider.store.execute('CREATE TABLE IF NOT EXISTS keyvaluepairs (record_key TEXT NOT NULL PRIMARY KEY , valueJSON JSON NOT NULL) WITHOUT ROWID;');
 
-        const compileOptionsResult = provider.store.execute<CompileOptionsResult>('PRAGMA compile_options;');
-        sqliteMaxVariableNumber = parseMaxVariableNumber(compileOptionsResult);
-
         // All of the 3 pragmas below were suggested by SQLite team.
         // You can find more info about them here: https://www.sqlite.org/pragma.html
         provider.store.execute('PRAGMA CACHE_SIZE=-20000;');
         provider.store.execute('PRAGMA synchronous=NORMAL;');
         provider.store.execute('PRAGMA journal_mode=WAL;');
+
+        const compileOptionsResult = provider.store.execute<CompileOptionsResult>('PRAGMA compile_options;');
+
+        // Get the value of MAX_VARIABLE_NUMBER from the compile options and
+        // stores it in a global variable, that is going to be used during runtime.
+        const maxVariableNumber = Number(getCompileOptionValue(compileOptionsResult, COMPILE_OPTIONS.MAX_VARIABLE_NUMBER));
+        sqliteMaxVariableNumber = maxVariableNumber > 0 ? maxVariableNumber : SQLITE_MAX_VARIABLE_NUMBER;
     },
     getItem(key) {
         if (!provider.store) {
@@ -150,9 +161,10 @@ const provider: StorageProvider<NitroSQLiteConnection | undefined> = {
                 return provider.store!.executeAsync<OnyxSQLiteKeyValuePair>(command, keyChunk);
             }),
         ).then((results) => {
-            const result = results.flatMap(({rows}) =>
-                // eslint-disable-next-line no-underscore-dangle
-                rows?._array.map((row) => [row.record_key, JSON.parse(row.valueJSON)]) ?? [],
+            const result = results.flatMap(
+                ({rows}) =>
+                    // eslint-disable-next-line no-underscore-dangle
+                    rows?._array.map((row) => [row.record_key, JSON.parse(row.valueJSON)]) ?? [],
             );
             return result as StorageKeyValuePair[];
         });

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -322,6 +322,25 @@ function omit<TValue>(obj: Record<string, TValue>, condition: string | string[] 
     return filterObject(obj, condition, false);
 }
 
+/**
+ * Splits an array into chunks no larger than maxChunkSize.
+ */
+function chunkArray<T>(items: readonly T[], maxChunkSize: number): T[][] {
+    if (items.length === 0) {
+        return [];
+    }
+
+    if (items.length <= maxChunkSize) {
+        return [items as T[]];
+    }
+
+    const chunks: T[][] = [];
+    for (let i = 0; i < items.length; i += maxChunkSize) {
+        chunks.push(items.slice(i, i + maxChunkSize));
+    }
+    return chunks;
+}
+
 export default {
     fastMerge,
     isEmptyObject,
@@ -330,6 +349,7 @@ export default {
     checkCompatibilityWithExistingValue,
     pick,
     omit,
+    chunkArray,
     ONYX_INTERNALS__REPLACE_OBJECT_MARK,
 };
 export type {FastMergeResult, FastMergeReplaceNullPatch, FastMergeOptions};

--- a/tests/unit/mocks/sqliteMock.ts
+++ b/tests/unit/mocks/sqliteMock.ts
@@ -7,13 +7,13 @@
  *   - open({name})
  *   - connection.execute(sql)
  *   - connection.executeAsync<T>(sql, params?)
- *   - connection.executeBatchAsync([{query, params}])
+ *   - connection.executeBatchAsync([{query, params}, ...])
  *
  * Result rows are shaped to match Nitro: `{rows: {_array, item, length}}`.
  */
 import BetterSqlite3 from 'better-sqlite3';
 import type {Database} from 'better-sqlite3';
-import type {NitroSQLiteConnection, NitroSQLiteQueryResultRows, QueryResult, QueryResultRow, SQLiteQueryParams} from 'react-native-nitro-sqlite';
+import type {BatchQueryCommand, NitroSQLiteConnection, NitroSQLiteQueryResultRows, QueryResult, QueryResultRow, SQLiteQueryParams} from 'react-native-nitro-sqlite';
 
 // `better-sqlite3` is declared as `export = Database` (CommonJS), so the type is
 // derived from the default import's namespace rather than via a named type import.
@@ -71,6 +71,40 @@ function prepareAndBind(database: Database, sql: string, parameters?: SQLiteQuer
     return {statement: database.prepare(sql), boundArguments: parameters ?? []};
 }
 
+type BatchQuery = {
+    query: string;
+    params?: SQLiteQueryParams;
+};
+
+/**
+ * Expands batch commands the same way NitroSQLite does in `batchParamsToCommands`:
+ * `params` is either one binding set for the query, or an array of binding sets
+ * (same query executed once per row).
+ */
+function batchParamsToCommands(commands: BatchQueryCommand[]): BatchQuery[] {
+    const expanded: BatchQuery[] = [];
+
+    for (const command of commands) {
+        const {query, params} = command;
+
+        if (!params) {
+            expanded.push({query});
+            continue;
+        }
+
+        if (Array.isArray(params[0])) {
+            for (const rowParams of params as SQLiteQueryParams[]) {
+                expanded.push({query, params: rowParams});
+            }
+            continue;
+        }
+
+        expanded.push({query, params: params as SQLiteQueryParams});
+    }
+
+    return expanded;
+}
+
 function runOne<TRow extends QueryResultRow>(database: Database, sql: string, parameters?: SQLiteQueryParams): QueryResult<TRow> {
     // Multi-statement (CREATE TABLE; SELECT ...; etc.) — better-sqlite3 cannot
     // prepare more than one statement at a time. SQLiteProvider's init() issues
@@ -120,29 +154,13 @@ function makeConnection(name: string): Pick<NitroSQLiteConnection, 'execute' | '
         executeBatchAsync(commands) {
             try {
                 let total = 0;
+                const expandedCommands = batchParamsToCommands(commands);
+
                 connection.transaction(() => {
-                    for (const command of commands) {
-                        const namedOrder = extractNamedParameterOrder(command.query);
-                        const statement = connection.prepare(command.query);
-                        const parameterRows = (command.params ?? []) as SQLiteQueryParams[];
-                        if (parameterRows.length === 0) {
-                            const info = statement.run();
-                            total += info.changes;
-                            continue;
-                        }
-                        for (const row of parameterRows) {
-                            if (namedOrder) {
-                                const bindings: Record<string, unknown> = {};
-                                for (let index = 0; index < namedOrder.length; index++) {
-                                    bindings[namedOrder[index]] = row[index];
-                                }
-                                const info = statement.run(bindings);
-                                total += info.changes;
-                            } else {
-                                const info = statement.run(...row);
-                                total += info.changes;
-                            }
-                        }
+                    for (const command of expandedCommands) {
+                        const {statement, boundArguments} = prepareAndBind(connection, command.query, command.params);
+                        const info = statement.run(...(boundArguments as unknown[]));
+                        total += info.changes;
                     }
                 })();
                 return Promise.resolve({rowsAffected: total});

--- a/tests/unit/mocks/sqliteMock.ts
+++ b/tests/unit/mocks/sqliteMock.ts
@@ -54,7 +54,7 @@ function wrapRows<TRow extends QueryResultRow>(rowsArray: TRow[]): NitroSQLiteQu
     };
 }
 
-function prepareAndBind(database: Database, sql: string, parameters?: SQLiteQueryParams) {
+function prepareAndBind(database: Database, sql: BatchQueryCommand['query'], parameters?: BatchQueryCommand['params']) {
     const namedOrder = extractNamedParameterOrder(sql);
     if (namedOrder) {
         // Map positional parameters array to named bindings object — NitroSQLite's
@@ -71,18 +71,13 @@ function prepareAndBind(database: Database, sql: string, parameters?: SQLiteQuer
     return {statement: database.prepare(sql), boundArguments: parameters ?? []};
 }
 
-type BatchQuery = {
-    query: string;
-    params?: SQLiteQueryParams;
-};
-
 /**
  * Expands batch commands the same way NitroSQLite does in `batchParamsToCommands`:
  * `params` is either one binding set for the query, or an array of binding sets
  * (same query executed once per row).
  */
-function batchParamsToCommands(commands: BatchQueryCommand[]): BatchQuery[] {
-    const expanded: BatchQuery[] = [];
+function batchParamsToCommands(commands: BatchQueryCommand[]): BatchQueryCommand[] {
+    const expanded: BatchQueryCommand[] = [];
 
     for (const command of commands) {
         const {query, params} = command;

--- a/tests/unit/storage/providers/SQLiteProviderTest.ts
+++ b/tests/unit/storage/providers/SQLiteProviderTest.ts
@@ -312,6 +312,99 @@ describe('SQLiteProvider', () => {
         });
     });
 
+    describe('query splitting', () => {
+        const CHUNK_SIZE = 2;
+        const originalChunkArray = utils.chunkArray;
+
+        const createKeyValueEntries = (count: number): Array<[string, unknown]> => Array.from({length: count}, (_, index) => [`chunk_key_${index}`, index]);
+
+        beforeEach(() => {
+            resetAllDatabases();
+            SQLiteProvider.init();
+
+            jest.spyOn(utils, 'chunkArray').mockImplementation((items, _maxChunkSize) => originalChunkArray(items, CHUNK_SIZE));
+        });
+
+        afterEach(() => {
+            jest.restoreAllMocks();
+        });
+
+        describe('multiGet', () => {
+            it('should return all values when keys exceed MAX_VARIABLE_NUMBER', async () => {
+                const entries = createKeyValueEntries(5);
+                await SQLiteProvider.multiSet(entries);
+
+                const keys = entries.map(([key]) => key);
+                const result = await SQLiteProvider.multiGet(keys);
+
+                expect(result).toEqual(expect.arrayContaining(entries));
+                expect(result).toHaveLength(entries.length);
+            });
+
+            it('should issue one IN query per chunk', async () => {
+                const entries = createKeyValueEntries(5);
+                await SQLiteProvider.multiSet(entries);
+
+                const executeAsyncSpy = jest.spyOn(SQLiteProvider.store!, 'executeAsync');
+                executeAsyncSpy.mockClear();
+
+                const keys = entries.map(([key]) => key);
+                await SQLiteProvider.multiGet(keys);
+
+                const inQueries = executeAsyncSpy.mock.calls.filter(([sql]) => typeof sql === 'string' && sql.includes('WHERE record_key IN'));
+                expect(inQueries).toHaveLength(3);
+            });
+        });
+
+        describe('removeItems', () => {
+            it('should remove all keys when keys exceed MAX_VARIABLE_NUMBER', async () => {
+                const entries = createKeyValueEntries(5);
+                await SQLiteProvider.multiSet(entries);
+
+                const keys = entries.map(([key]) => key);
+                await SQLiteProvider.removeItems(keys);
+
+                expect(await SQLiteProvider.getAllKeys()).toEqual([]);
+            });
+
+            it('should use executeAsync when keys fit in a single chunk', async () => {
+                const entries = createKeyValueEntries(2);
+                await SQLiteProvider.multiSet(entries);
+
+                const executeAsyncSpy = jest.spyOn(SQLiteProvider.store!, 'executeAsync');
+                const executeBatchAsyncSpy = jest.spyOn(SQLiteProvider.store!, 'executeBatchAsync');
+                executeAsyncSpy.mockClear();
+                executeBatchAsyncSpy.mockClear();
+
+                const keys = entries.map(([key]) => key);
+                await SQLiteProvider.removeItems(keys);
+
+                expect(executeAsyncSpy).toHaveBeenCalledTimes(1);
+                expect(executeBatchAsyncSpy).not.toHaveBeenCalled();
+            });
+
+            it('should use executeBatchAsync when keys span multiple chunks', async () => {
+                const entries = createKeyValueEntries(5);
+                await SQLiteProvider.multiSet(entries);
+
+                const executeAsyncSpy = jest.spyOn(SQLiteProvider.store!, 'executeAsync');
+                const executeBatchAsyncSpy = jest.spyOn(SQLiteProvider.store!, 'executeBatchAsync');
+                executeAsyncSpy.mockClear();
+                executeBatchAsyncSpy.mockClear();
+
+                const keys = entries.map(([key]) => key);
+                await SQLiteProvider.removeItems(keys);
+
+                expect(executeAsyncSpy).not.toHaveBeenCalled();
+                expect(executeBatchAsyncSpy).toHaveBeenCalledTimes(1);
+
+                const batchCommands = executeBatchAsyncSpy.mock.calls[0][0];
+                expect(batchCommands).toHaveLength(3);
+                expect(batchCommands.every((command) => command.query.includes('DELETE FROM keyvaluepairs WHERE record_key IN'))).toBe(true);
+            });
+        });
+    });
+
     // SQLite-specific: the IN-list is parameterised, so a key containing SQL
     // fragments must be treated as a literal record_key.
     describe('SQL-injection safety', () => {

--- a/tests/unit/utilsTest.ts
+++ b/tests/unit/utilsTest.ts
@@ -390,6 +390,53 @@ describe('utils', () => {
         });
     });
 
+    describe('chunkArray', () => {
+        it('should return an empty array when given an empty array', () => {
+            expect(utils.chunkArray([], 3)).toEqual([]);
+        });
+
+        it('should return a single chunk when the array length is less than maxChunkSize', () => {
+            const items = [1, 2];
+            const result = utils.chunkArray(items, 3);
+
+            expect(result).toEqual([[1, 2]]);
+            expect(result[0]).toBe(items);
+        });
+
+        it('should return a single chunk when the array length equals maxChunkSize', () => {
+            const items = [1, 2, 3];
+            const result = utils.chunkArray(items, 3);
+
+            expect(result).toEqual([[1, 2, 3]]);
+            expect(result[0]).toBe(items);
+        });
+
+        it('should split the array into evenly sized chunks', () => {
+            expect(utils.chunkArray([1, 2, 3, 4, 5, 6], 3)).toEqual([
+                [1, 2, 3],
+                [4, 5, 6],
+            ]);
+        });
+
+        it('should include a smaller final chunk when the array length is not divisible by maxChunkSize', () => {
+            expect(utils.chunkArray([1, 2, 3, 4, 5], 2)).toEqual([[1, 2], [3, 4], [5]]);
+        });
+
+        it('should create one item per chunk when maxChunkSize is 1', () => {
+            expect(utils.chunkArray(['a', 'b', 'c'], 1)).toEqual([['a'], ['b'], ['c']]);
+        });
+
+        it('should work with readonly arrays and preserve element types', () => {
+            const items = Object.freeze(['x', 'y', 'z', 'w']) as readonly string[];
+            const result = utils.chunkArray(items, 2);
+
+            expect(result).toEqual([
+                ['x', 'y'],
+                ['z', 'w'],
+            ]);
+        });
+    });
+
     describe('isEmptyObject', () => {
         it('should return true for an empty object', () => {
             expect(utils.isEmptyObject({})).toBe(true);


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

@mountiny 

### Details
<!-- Explanation of the change or anything fishy that is going on -->

This PR fixes an issue with our SQLite storage provider implementation, where in some cases, very large Onyx DBs with lots of keys would cause queries with `IN (...)` to exceed the number of allowed parameters per query (usually more than 32,766, as per https://sqlite.org/limits.html).

This PR does the following:

1. When the storage provider is initialized, fetch the `MAX_VARIABLE_NUMBER` compile option once and store it globally.
2. In `multiGet` and `removeItems` split queries into multiple separate queries, if the number of keys exceeds the max.

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/App/issues/94577

### Linked E/App PR
<!--
Every Onyx PR must ship with a corresponding Expensify/App PR that pins Onyx to this PR's HEAD via git+https
(e.g. "react-native-onyx": "git+https://github.com/Expensify/react-native-onyx.git#<commit_sha>").
That linked PR runs the full E/App test suite signals that the Onyx
change is safe. After this PR is merged and published to npm, swap the linked E/App PR to the pinned version
(e.g. "react-native-onyx": "3.0.72") and request a final review — it becomes the bump PR.

Paste the full Expensify/App PR URL below (e.g. https://github.com/Expensify/App/pull/12345):
-->

https://github.com/Expensify/App/pull/94947


### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Manual Tests
<!---
Each set of changes should be tested against the Expensify/App repo on all platforms to verify it does not break our staging App.
--->

To reproduce this error, we must manually add some code to the app locally:

1. Add this `useEffect` in https://github.com/Expensify/App/blob/371c63dd33c770f0b2ab6d592d557156c66860ad/src/App.tsx#L73-L144:

```typescript
import React, {useEffect} from 'react';
import Onyx from 'react-native-onyx';
import type {OnyxMultiSetInput} from 'react-native-onyx';
import OnyxUtils from 'react-native-onyx/dist/OnyxUtils';

function App() {
    // ...

    useEffect(() => {
        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
        const data = Array(33000)
            .fill(0)
            .reduce<Record<string, string>>((acc, _, i) => {
                const key = `TooManyVariablesDemo-${i}`;
                acc[key] = key;
                return acc;
            }, {}) as unknown as OnyxMultiSetInput;

        Onyx.multiSet(data).then(() => {
            OnyxUtils.getAllKeys().then((keys) => {
                console.log(`[TooManySQLVariablesDemo] Number of keys in Onyx: ${keys.size}`);
            });
        });
    }, []);

    // ...
}
```

2. Add an explicit `catch` block to the `clearOnyxAndResetApp` function in https://github.com/Expensify/App/blob/371c63dd33c770f0b2ab6d592d557156c66860ad/src/libs/actions/App.ts#L879-L933

```typescript
function clearOnyxAndResetApp(shouldNavigateToHomepage?: boolean) {
    // ...

    const resetPromise = clearWorkboxRecoveryCaches().then(() =>
    clearOnyxAndSeedFullReconnect(KEYS_TO_PRESERVE)
        .then(() => {
            // ...
        })
        .catch((error) => {
            Log.alert('[TooManySQLVariablesDemo] Error clearing Onyx', {error});
        }),
    );

    return resetPromise
}
```

3. Run the app and open the developer tools.
4. Make sure that the `[TooManySQLVariablesDemo] Number of keys in Onyx: <number of keys in Onyx>` log appears with at least more than 32,766 keys (as this is the configured limit for number of parameters/variables in a query)
5. Add a breakpoint in the `.catch((error) => { ... })` block from step 2
6. Make sure the breakpoint is hit without the fix from this PR and that the error reads as the following:

```log
[NativeNitroSQLiteException][SqlExecutionError] too many SQL variables
```

8. Repeat steps 1-5 with the fix in place and make sure that the breakpoint is not hit and no error is thrown.

### Author Checklist

- [x] I linked the correct issue in the `### Related Issues` section above
- [x] I linked the corresponding Expensify/App PR in the `### Linked E/App PR` section above, and verified this change against it (E/App CI passed and manual testing completed)
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

**Before fix:**


https://github.com/user-attachments/assets/a4b39ec9-848e-4424-8bd1-c45ec9b45727


**After fix:**


https://github.com/user-attachments/assets/12da0b11-4580-4ae4-8482-e67f9e2bb5ef



</details>

