### PR TITLE
Perf/optimize get all with json aggregation

### DIFF
--- a/lib/storage/providers/SQLiteProvider.ts
+++ b/lib/storage/providers/SQLiteProvider.ts
@@ -201,12 +201,10 @@ const provider: StorageProvider<NitroSQLiteConnection | undefined> = {
             throw new Error('Store is not initialized!');
         }
 
-        // We ask SQLite to combine the whole table into one JSON string, instead of returning
-        // every row and parsing each one in JavaScript. This way we only run JSON.parse a single
-        // time. Since record_key is the primary key, the rows already come back sorted by key,
-        // so ordering by record_key costs almost nothing.
+        // Aggregate the whole table into a single JSON string in SQLite so we only run JSON.parse
+        // once, instead of returning every row and parsing each one individually in JavaScript.
         return provider.store
-            .executeAsync<{aggregated: string | null}>('SELECT json_group_array(json_array(record_key, json(valueJSON))) AS aggregated FROM keyvaluepairs ORDER BY record_key;')
+            .executeAsync<{aggregated: string | null}>('SELECT json_group_array(json_array(record_key, json(valueJSON))) AS aggregated FROM keyvaluepairs;')
             .then(({rows}) => {
                 const aggregated = rows?.item(0)?.aggregated;
                 if (aggregated == null) {

--- a/lib/storage/providers/SQLiteProvider.ts
+++ b/lib/storage/providers/SQLiteProvider.ts
@@ -201,11 +201,19 @@ const provider: StorageProvider<NitroSQLiteConnection | undefined> = {
             throw new Error('Store is not initialized!');
         }
 
-        return provider.store.executeAsync<OnyxSQLiteKeyValuePair>('SELECT record_key, valueJSON FROM keyvaluepairs;').then(({rows}) => {
-            // eslint-disable-next-line no-underscore-dangle
-            const result = rows?._array.map((row) => [row.record_key, JSON.parse(row.valueJSON)]);
-            return (result ?? []) as StorageKeyValuePair[];
-        });
+        // We ask SQLite to combine the whole table into one JSON string, instead of returning
+        // every row and parsing each one in JavaScript. This way we only run JSON.parse a single
+        // time. Since record_key is the primary key, the rows already come back sorted by key,
+        // so ordering by record_key costs almost nothing.
+        return provider.store
+            .executeAsync<{aggregated: string | null}>('SELECT json_group_array(json_array(record_key, json(valueJSON))) AS aggregated FROM keyvaluepairs ORDER BY record_key;')
+            .then(({rows}) => {
+                const aggregated = rows?.item(0)?.aggregated;
+                if (aggregated == null) {
+                    return [];
+                }
+                return JSON.parse(aggregated) as StorageKeyValuePair[];
+            });
     },
     removeItem(key) {
         if (!provider.store) {

--- a/tests/unit/storage/providers/SQLiteProviderTest.ts
+++ b/tests/unit/storage/providers/SQLiteProviderTest.ts
@@ -290,6 +290,23 @@ describe('SQLiteProvider', () => {
         });
     });
 
+    describe('getAll', () => {
+        it('should return every stored key-value pair with correct values', async () => {
+            await SQLiteProvider.multiSet(testEntries);
+
+            const out = await SQLiteProvider.getAll();
+            const sortedActual = [...out].sort((a, b) => a[0].localeCompare(b[0]));
+            const sortedExpected = [...testEntries].sort((a, b) => a[0].localeCompare(b[0]));
+
+            expect(out).toHaveLength(5);
+            expect(sortedActual).toEqual(sortedExpected);
+        });
+
+        it('should return an empty array when the store is empty', async () => {
+            expect(await SQLiteProvider.getAll()).toEqual([]);
+        });
+    });
+
     describe('removeItem', () => {
         it('should remove the key from the store', async () => {
             await SQLiteProvider.multiSet(testEntries);


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

Previously getAll() fetched every row from keyvaluepairs and ran JSON.parse once per row (N parses) to hydrate the Onyx cache at startup. It now asks SQLite to aggregate the whole table into a single JSON string.

- Native-only - getAll() resolves to SQLiteProvider on iOS/Android. Web (IDBKeyValProvider) is unaffected.
- Runs on the cold-start cache hydration path
- Perf gain is modest on real accounts (~11%, within noise)


### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/App/issues/89652#issuecomment-4876548042

### Linked E/App PR
<!--
Every Onyx PR must ship with a corresponding Expensify/App PR that pins Onyx to this PR's HEAD via git+https
(e.g. "react-native-onyx": "git+https://github.com/Expensify/react-native-onyx.git#<commit_sha>").
That linked PR runs the full E/App test suite signals that the Onyx
change is safe. After this PR is merged and published to npm, swap the linked E/App PR to the pinned version
(e.g. "react-native-onyx": "3.0.72") and request a final review — it becomes the bump PR.

Paste the full Expensify/App PR URL below (e.g. https://github.com/Expensify/App/pull/12345):
-->

https://github.com/Expensify/App/pull/95511


### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

- Added unit tests

### Manual Tests
<!---
Each set of changes should be tested against the Expensify/App repo on all platforms to verify it does not break our staging App.
--->

- Sign in on native, let the app fully sync
- Background the app and force-kill it (swipe away / kill process).
- Cold launch the app
- Verify:
  - LHN fully populates - same report list, order, unread/pinned states as before
  - Open several reports (chat, expense, workspace) - all messages, amounts, avatars render correctly
  - Open Settings - Workspaces - Profile - Wallet - all persisted data present
  - No missing, duplicated, or blank data


### Author Checklist

- [x] I linked the correct issue in the `### Related Issues` section above
- [x] I linked the corresponding Expensify/App PR in the `### Linked E/App PR` section above, and verified this change against it (E/App CI passed and manual testing completed)
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos

<summary>Android: Native</summary>

<details>



https://github.com/user-attachments/assets/331ae2b3-7720-428c-949d-46ee75aa40e6


<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/9d95f9f8-9a9f-4a50-bb9f-ec9011cd926b




</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

