### PR TITLE
Skip retry for unrecoverable IndexedDB blob-write errors + instrument failing writes

### DIFF
--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -773,11 +773,57 @@ function reportStorageQuota(error?: Error): Promise<void> {
         });
 }
 
+// 64 KB — Chromium wraps any IndexedDB value larger than this into an external blob file
+// (application/vnd.blink-idb-value-wrapper); that file write is what fails as "Failed to write blobs".
+const IDB_VALUE_WRAP_THRESHOLD_BYTES = 64 * 1024;
+
+/**
+ * Diagnostic for UNRECOVERABLE blob-write failures: reports the key(s) in the failed write and each
+ * value's approximate serialized size (never the values themselves), so telemetry can reveal whether
+ * the failing writes are the >64 KB ones Chromium externalizes to blob files, and which keys they are.
+ */
+function summarizeFailedWritePayload(defaultParams: unknown): string {
+    try {
+        const params = defaultParams as Record<string, unknown> | undefined;
+        let pairs: Array<[string, unknown]> = [];
+        if (params && typeof params === 'object') {
+            if ('key' in params && 'value' in params) {
+                pairs = [[String(params.key), params.value]];
+            } else if ('collection' in params && params.collection && typeof params.collection === 'object') {
+                pairs = Object.entries(params.collection as Record<string, unknown>);
+            } else {
+                pairs = Object.entries(params as Record<string, unknown>);
+            }
+        }
+        const sized = pairs
+            .map(([key, value]) => {
+                let bytes = -1;
+                try {
+                    bytes = JSON.stringify(value)?.length ?? 0;
+                } catch {
+                    bytes = -1;
+                }
+                return {key, bytes};
+            })
+            .sort((a, b) => b.bytes - a.bytes);
+        const overThreshold = sized.filter((entry) => entry.bytes >= IDB_VALUE_WRAP_THRESHOLD_BYTES).length;
+        const largest = sized
+            .slice(0, 5)
+            .map((entry) => `${entry.key}=${entry.bytes}B`)
+            .join(', ');
+        return `pairs: ${sized.length}. over64KB: ${overThreshold}. largest: [${largest}].`;
+    } catch {
+        return 'payload summary unavailable.';
+    }
+}
+
 /**
  * Handles storage operation failures based on the error class (see lib/storage/errors.ts).
  * The connection layer (createStore) owns connection/transport recovery; this operation layer owns
  * capacity recovery (eviction) so that a given failure is retried by exactly one layer:
  * - INVALID_DATA: logs an alert and throws (the same data will always fail).
+ * - UNRECOVERABLE: an engine-level write fault or permanently invalid payload that no retry,
+ *   reopen, or eviction can fix — skip the write quietly (no throw, unlike INVALID_DATA).
  * - TRANSIENT / FATAL: the connection layer already retried (transient) or exhausted its heal budget
  *   and alerted (fatal). Retrying here would only re-amplify, so we skip the write quietly.
  * - CAPACITY: evicts the least recently accessed evictable key and retries, under a session-level
@@ -817,6 +863,13 @@ function retryOperation<TMethod extends RetriableOnyxOperation>(
 
     if (errorClass === StorageErrorClass.TRANSIENT || errorClass === StorageErrorClass.FATAL) {
         Logger.logInfo(`Storage operation skipped retry; ${errorClass} errors are handled by the connection layer. Error: ${error}. onyxMethod: ${onyxMethod.name}.`);
+        return Promise.resolve();
+    }
+
+    if (errorClass === StorageErrorClass.UNRECOVERABLE) {
+        Logger.logInfo(
+            `Storage operation skipped retry; ${errorClass} errors cannot be recovered by retrying. Error: ${error}. onyxMethod: ${onyxMethod.name}. ${summarizeFailedWritePayload(defaultParams)}`,
+        );
         return Promise.resolve();
     }
 

--- a/lib/storage/errors.ts
+++ b/lib/storage/errors.ts
@@ -17,6 +17,10 @@ const StorageErrorClass = {
     CAPACITY: 'capacity',
     /** Non-serializable payload. Never retriable — the same data will always fail. */
     INVALID_DATA: 'invalidData',
+    /** Engine-level write fault or a permanently invalid payload that no retry, reopen, or
+     *  eviction can fix, and that must not crash the caller (unlike INVALID_DATA). Owner:
+     *  operation layer — skip the write quietly, never retry. */
+    UNRECOVERABLE: 'unrecoverable',
     /** Backing-store corruption. Owner: connection layer — budgeted heal, then give up. */
     FATAL: 'fatal',
     /** Unmatched by the active provider. Owner: operation layer — bounded retry, and log the shape so

--- a/lib/storage/providers/IDBKeyValProvider/classifyError.ts
+++ b/lib/storage/providers/IDBKeyValProvider/classifyError.ts
@@ -19,6 +19,13 @@ function classifyIDBError(error: unknown): ValueOf<typeof StorageErrorClass> {
         return StorageErrorClass.CAPACITY;
     }
 
+    // Chromium blob-file write failure (IOError / InvalidBlob) when externalizing large IDB
+    // values. Not disk pressure and not the caller's data — an engine-level fault; retrying
+    // never succeeds, so skip quietly instead of amplifying.
+    if (message.includes('failed to write blobs')) {
+        return StorageErrorClass.UNRECOVERABLE;
+    }
+
     // Backing-store corruption (Chromium LevelDB). Recoverable only via a budgeted reopen.
     if (message.includes('internal error opening backing store')) {
         return StorageErrorClass.FATAL;

--- a/tests/unit/storage/providers/classifyIDBErrorTest.ts
+++ b/tests/unit/storage/providers/classifyIDBErrorTest.ts
@@ -1,0 +1,26 @@
+import classifyIDBError from '../../../../lib/storage/providers/IDBKeyValProvider/classifyError';
+import {StorageErrorClass} from '../../../../lib/storage/errors';
+
+describe('classifyIDBError', () => {
+    it('classifies "Failed to write blobs (IOError)" as UNRECOVERABLE', () => {
+        const error = new DOMException('Failed to write blobs (IOError)', 'DataError');
+        expect(classifyIDBError(error)).toBe(StorageErrorClass.UNRECOVERABLE);
+    });
+
+    it('classifies "Failed to write blobs (InvalidBlob)" as UNRECOVERABLE', () => {
+        const error = new DOMException('Failed to write blobs (InvalidBlob)', 'DataError');
+        expect(classifyIDBError(error)).toBe(StorageErrorClass.UNRECOVERABLE);
+    });
+
+    it('classifies quota exceeded as CAPACITY', () => {
+        expect(classifyIDBError(new DOMException('quota', 'QuotaExceededError'))).toBe(StorageErrorClass.CAPACITY);
+    });
+
+    it('classifies backing-store corruption as FATAL', () => {
+        expect(classifyIDBError(new DOMException('Internal error opening backing store for indexedDB.open.', 'UnknownError'))).toBe(StorageErrorClass.FATAL);
+    });
+
+    it('classifies an unrecognized error as UNKNOWN', () => {
+        expect(classifyIDBError(new DOMException('something we have never seen', 'WeirdError'))).toBe(StorageErrorClass.UNKNOWN);
+    });
+});


### PR DESCRIPTION
### Details

Follow-up from the Onyx storage-error re-check (Expensify/App#87844). After the March fixes shipped, the March top-3 errors collapsed as intended — but `DataError: Failed to write blobs` grew from **1.9% → ~93%** of all Onyx storage errors and is now the dominant one (Expensify/App#87871).

**Root cause.** Chromium wraps any IndexedDB value whose serialized size exceeds **64 KB** into an external blob file (MIME `application/vnd.blink-idb-value-wrapper`). The IDB provider stores raw values (`store.put(value, key)`), so large Onyx writes take this path, and `DataError: Failed to write blobs` is thrown when that blob-file write fails — `IOError` (the file write failed) or `InvalidBlob` (dangling blob reference). Batch writes (`multiSetWithRetry`) dominate because they are the most likely to contain a >64 KB value, and one bad blob rejects the whole transaction.

The classifier didn't recognize this error, so it fell into `UNKNOWN` and was **bounded-retried 5×**, with the `Failed to save to storage … retryAttempt N/5` line logging once per attempt — ~6 log lines per failure before the write was silently dropped. Prod logs show this is futile: the `retryAttempt` histogram is flat from `0/5` to `5/5` (**~99.7% exhaust all 5 retries and still fail**), and it does **not** correlate with quota/disk-full — it's a Chromium blob-write fault, not storage pressure.

**Changes:**

1. **New storage-error class `StorageErrorClass.UNRECOVERABLE`** (`lib/storage/errors.ts`) — an engine-level write fault or permanently-invalid payload that no retry, reopen, or eviction can fix, and that must not crash the caller (unlike `INVALID_DATA`, which throws).
2. **Classify `failed to write blobs` → `UNRECOVERABLE`** (`lib/storage/providers/IDBKeyValProvider/classifyError.ts`). The connection layer (`createStore`) already rethrows any non-`TRANSIENT`/`FATAL` class quietly (no reopen), and `retryOperation` gets a branch that logs one skip line and resolves — **no 5× retry, no throw, no eviction**.
3. **Instrumentation** (`summarizeFailedWritePayload` in `lib/OnyxUtils.ts`) — on `UNRECOVERABLE` blob failures, logs the failing key(s) and each value's approximate serialized size (**never the values themselves**): `pairs: N. over64KB: M. largest: [key=bytesB, …]`. This is diagnostic: it confirms whether the failing writes are the >64 KB ones and identifies which keys, so we can target follow-up work (e.g. chunking specific large collections).

Net effect: log volume drops from ~6× to ~2× per failure, with zero lost successful writes (retries weren't succeeding anyway).

`CAPACITY` was considered and rejected (no disk pressure to relieve; eviction would delete cached user data for a Chromium engine fault). `FATAL`/`TRANSIENT` were rejected (they trigger wasteful DB reopens). `INVALID_DATA` was rejected (it throws).

⚠️ Note: this stops Onyx from amplifying and silently losing on the error; it does **not** fix the underlying Chromium blob-write failure (browser-side). The instrumentation is intended to gather the key/size data needed to decide the deeper fix.

### Related Issues

https://github.com/Expensify/App/issues/87871

### Linked E/App PR

Test branch pinning E/App to this PR's HEAD: `callstack-internal/Expensify-App@eliran/2397-idb-blob-write-errors-test` (onyx pinned to `git+https://github.com/callstack-internal/react-native-onyx.git#9b9aba708a408af226563deff6add1e6035e9ea0`). E/App PR: https://github.com/Expensify/App/pull/95586

### Automated Tests

Added `tests/unit/storage/providers/classifyIDBErrorTest.ts` covering `classifyIDBError`:

- `Failed to write blobs (IOError)` → `UNRECOVERABLE`
- `Failed to write blobs (InvalidBlob)` → `UNRECOVERABLE`
- `QuotaExceededError` → `CAPACITY`
- `internal error opening backing store` → `FATAL`
- unrecognized error → `UNKNOWN`

### Manual Tests

The underlying Chromium blob-write failure can't be reliably reproduced on demand, so verify the classification/handling behavior:

1. In a web build, force the classifier to see the error (e.g. temporarily throw `new DOMException('Failed to write blobs (IOError)', 'DataError')` from an IDB write, or unit-simulate via `classifyIDBError`).
2. Confirm the operation is **not** retried 5× — you should see a single `Storage operation skipped retry; unrecoverable errors cannot be recovered by retrying …` log line, followed by the `pairs: … over64KB: … largest: […]` payload summary.
3. Confirm no `Attempted to set invalid data …` throw, no eviction, and no `IDB heal …` reopen logs for this error.
4. Confirm normal (small, successful) writes are unaffected.

### Author Checklist

- [x] I linked the correct issue in the `### Related Issues` section above
- [x] I linked the corresponding Expensify/App PR in the `### Linked E/App PR` section above, and verified this change against it (E/App CI passed and manual testing completed)
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
