### PR TITLE
Memoize shallowEqual verdicts by object identity in useOnyx

### DIFF
--- a/lib/memoizedShallowEqual.ts
+++ b/lib/memoizedShallowEqual.ts
@@ -1,0 +1,41 @@
+import {shallowEqual} from 'fast-equals';
+
+/**
+ * Memoizes shallowEqual verdicts by the identity of the compared objects. Onyx values are
+ * treated as immutable (merge/set replace objects, never mutate), so a (prev, next) reference
+ * pair always yields the same verdict. In the hot case — N no-selector hooks on the same big
+ * key — every hook compares the exact same two cache-owned objects, so the first hook pays for
+ * the O(keys) walk and the rest resolve in O(1). WeakMap keys make stale entries impossible to
+ * read (lookup requires holding both exact objects) and let GC reclaim them.
+ */
+const shallowEqualVerdicts = new WeakMap<object, WeakMap<object, boolean>>();
+
+/**
+ * Identity-pair-memoized shallowEqual: same (a, b) references → cached verdict, no walk.
+ */
+function memoizedShallowEqual(a: unknown, b: unknown): boolean {
+    // Only object pairs are memoizable (WeakMap keys) — anything else is O(1) to compare anyway.
+    if (typeof a !== 'object' || a === null || typeof b !== 'object' || b === null) {
+        return shallowEqual(a, b);
+    }
+
+    let verdictsForA = shallowEqualVerdicts.get(a);
+
+    if (!verdictsForA) {
+        verdictsForA = new WeakMap();
+        shallowEqualVerdicts.set(a, verdictsForA);
+    }
+
+    const cachedVerdict = verdictsForA.get(b);
+
+    if (cachedVerdict !== undefined) {
+        return cachedVerdict;
+    }
+
+    const verdict = shallowEqual(a, b);
+    verdictsForA.set(b, verdict);
+
+    return verdict;
+}
+
+export default memoizedShallowEqual;

--- a/lib/useOnyx.ts
+++ b/lib/useOnyx.ts
@@ -7,6 +7,7 @@ import connectionManager from './OnyxConnectionManager';
 import OnyxUtils from './OnyxUtils';
 import type {CollectionKeyBase, OnyxKey, OnyxValue} from './types';
 import onyxSnapshotCache from './OnyxSnapshotCache';
+import memoizedShallowEqual from './memoizedShallowEqual';
 import useLiveRef from './useLiveRef';
 
 type UseOnyxSelector<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>> = (data: OnyxValue<TKey> | undefined) => TReturnValue;
@@ -27,40 +28,6 @@ type UseOnyxOptions<TKey extends OnyxKey, TReturnValue> = {
      */
     selector?: UseOnyxSelector<TKey, TReturnValue>;
 };
-
-// Memoizes shallowEqual verdicts by the identity of the compared objects. Onyx values are
-// treated as immutable (merge/set replace objects, never mutate), so a (prev, next) reference
-// pair always yields the same verdict. In the hot case — N no-selector hooks on the same big
-// key — every hook compares the exact same two cache-owned objects, so the first hook pays for
-// the O(keys) walk and the rest resolve in O(1). WeakMap keys make stale entries impossible to
-// read (lookup requires holding both exact objects) and let GC reclaim them.
-const shallowEqualVerdicts = new WeakMap<object, WeakMap<object, boolean>>();
-
-// Identity-pair-memoized shallowEqual: same (prev, next) references → cached verdict, no walk.
-function memoizedShallowEqual(a: unknown, b: unknown): boolean {
-    // Only object pairs are memoizable (WeakMap keys) — anything else is O(1) to compare anyway.
-    if (typeof a !== 'object' || a === null || typeof b !== 'object' || b === null) {
-        return shallowEqual(a, b);
-    }
-
-    let verdictsForA = shallowEqualVerdicts.get(a);
-
-    if (!verdictsForA) {
-        verdictsForA = new WeakMap();
-        shallowEqualVerdicts.set(a, verdictsForA);
-    }
-
-    const cachedVerdict = verdictsForA.get(b);
-
-    if (cachedVerdict !== undefined) {
-        return cachedVerdict;
-    }
-
-    const verdict = shallowEqual(a, b);
-    verdictsForA.set(b, verdict);
-
-    return verdict;
-}
 
 type FetchStatus = 'loading' | 'loaded';
 

--- a/lib/useOnyx.ts
+++ b/lib/useOnyx.ts
@@ -51,7 +51,7 @@ function memoizedShallowEqual(a: unknown, b: unknown): boolean {
     }
 
     const cachedVerdict = verdictsForA.get(b);
-    
+
     if (cachedVerdict !== undefined) {
         return cachedVerdict;
     }

--- a/lib/useOnyx.ts
+++ b/lib/useOnyx.ts
@@ -28,6 +28,40 @@ type UseOnyxOptions<TKey extends OnyxKey, TReturnValue> = {
     selector?: UseOnyxSelector<TKey, TReturnValue>;
 };
 
+// Memoizes shallowEqual verdicts by the identity of the compared objects. Onyx values are
+// treated as immutable (merge/set replace objects, never mutate), so a (prev, next) reference
+// pair always yields the same verdict. In the hot case — N no-selector hooks on the same big
+// key — every hook compares the exact same two cache-owned objects, so the first hook pays for
+// the O(keys) walk and the rest resolve in O(1). WeakMap keys make stale entries impossible to
+// read (lookup requires holding both exact objects) and let GC reclaim them.
+const shallowEqualVerdicts = new WeakMap<object, WeakMap<object, boolean>>();
+
+// Identity-pair-memoized shallowEqual: same (prev, next) references → cached verdict, no walk.
+function memoizedShallowEqual(a: unknown, b: unknown): boolean {
+    // Only object pairs are memoizable (WeakMap keys) — anything else is O(1) to compare anyway.
+    if (typeof a !== 'object' || a === null || typeof b !== 'object' || b === null) {
+        return shallowEqual(a, b);
+    }
+
+    let verdictsForA = shallowEqualVerdicts.get(a);
+
+    if (!verdictsForA) {
+        verdictsForA = new WeakMap();
+        shallowEqualVerdicts.set(a, verdictsForA);
+    }
+
+    const cachedVerdict = verdictsForA.get(b);
+    
+    if (cachedVerdict !== undefined) {
+        return cachedVerdict;
+    }
+
+    const verdict = shallowEqual(a, b);
+    verdictsForA.set(b, verdict);
+
+    return verdict;
+}
+
 type FetchStatus = 'loading' | 'loaded';
 
 type ResultMetadata = {
@@ -201,9 +235,11 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(
 
         // shallowEqual checks === first (O(1) for frozen snapshots and stable selector references),
         // then falls back to comparing top-level properties for individual keys that may have
-        // new references with equivalent content.
+        // new references with equivalent content. The comparison is memoized by object identity
+        // (see `memoizedShallowEqual`) so N hooks comparing the same two cache objects pay for
+        // one walk in total instead of one walk each.
         // Normalize null to undefined to ensure consistent comparison (both represent "no value").
-        const areValuesEqual = shallowEqual(previousValueRef.current ?? undefined, newValueRef.current ?? undefined);
+        const areValuesEqual = memoizedShallowEqual(previousValueRef.current ?? undefined, newValueRef.current ?? undefined);
 
         // We update the cached value and the result in the following conditions:
         // We will update the cached value and the result in any of the following situations:

--- a/tests/unit/memoizedShallowEqualTest.ts
+++ b/tests/unit/memoizedShallowEqualTest.ts
@@ -2,30 +2,30 @@ import memoizedShallowEqual from '../../lib/memoizedShallowEqual';
 
 describe('memoizedShallowEqual', () => {
     describe('shallowEqual semantics', () => {
-        it('returns true for the same reference', () => {
+        it('should return true for the same reference', () => {
             const obj = {a: 1};
             expect(memoizedShallowEqual(obj, obj)).toBe(true);
         });
 
-        it('returns true for different references with shallowly-equal content', () => {
+        it('should return true for different references with shallowly-equal content', () => {
             const member = {name: 'John'};
             expect(memoizedShallowEqual({a: 1, member}, {a: 1, member})).toBe(true);
         });
 
-        it('returns false when a top-level value differs', () => {
+        it('should return false when a top-level value differs', () => {
             expect(memoizedShallowEqual({a: 1}, {a: 2})).toBe(false);
         });
 
-        it('returns false when key counts differ', () => {
+        it('should return false when key counts differ', () => {
             expect(memoizedShallowEqual({a: 1}, {a: 1, b: 2})).toBe(false);
         });
 
-        it('returns false for equal deep content with different nested references', () => {
+        it('should return false for equal deep content with different nested references', () => {
             // Shallow, not deep: nested objects are compared by reference.
             expect(memoizedShallowEqual({member: {name: 'John'}}, {member: {name: 'John'}})).toBe(false);
         });
 
-        it('handles non-object inputs', () => {
+        it('should handle non-object inputs', () => {
             expect(memoizedShallowEqual(undefined, undefined)).toBe(true);
             expect(memoizedShallowEqual(undefined, {})).toBe(false);
             expect(memoizedShallowEqual('a', 'a')).toBe(true);
@@ -34,14 +34,14 @@ describe('memoizedShallowEqual', () => {
             expect(memoizedShallowEqual(NaN, NaN)).toBe(true);
         });
 
-        it('handles arrays', () => {
+        it('should handle arrays', () => {
             expect(memoizedShallowEqual([1, 2], [1, 2])).toBe(true);
             expect(memoizedShallowEqual([1, 2], [1, 3])).toBe(false);
         });
     });
 
     describe('memoization', () => {
-        it('returns the cached verdict for the same object pair without re-comparing', () => {
+        it('should return the cached verdict for the same object pair without re-comparing', () => {
             const a = {name: 'John'};
             const b = {name: 'Jane'};
             expect(memoizedShallowEqual(a, b)).toBe(false);
@@ -53,7 +53,7 @@ describe('memoizedShallowEqual', () => {
             expect(memoizedShallowEqual(a, b)).toBe(false);
         });
 
-        it('caches verdicts per pair, not per object', () => {
+        it('should cache verdicts per pair, not per object', () => {
             const a = {x: 1};
             const equalToA = {x: 1};
             const differentFromA = {x: 2};
@@ -66,7 +66,7 @@ describe('memoizedShallowEqual', () => {
             expect(memoizedShallowEqual(a, differentFromA)).toBe(false);
         });
 
-        it('does not memoize non-object inputs', () => {
+        it('should not memoize non-object inputs', () => {
             // Primitives cannot be WeakMap keys; these calls must not throw and must compare directly.
             expect(memoizedShallowEqual(1, {})).toBe(false);
             expect(memoizedShallowEqual({}, 1)).toBe(false);

--- a/tests/unit/memoizedShallowEqualTest.ts
+++ b/tests/unit/memoizedShallowEqualTest.ts
@@ -1,0 +1,76 @@
+import memoizedShallowEqual from '../../lib/memoizedShallowEqual';
+
+describe('memoizedShallowEqual', () => {
+    describe('shallowEqual semantics', () => {
+        it('returns true for the same reference', () => {
+            const obj = {a: 1};
+            expect(memoizedShallowEqual(obj, obj)).toBe(true);
+        });
+
+        it('returns true for different references with shallowly-equal content', () => {
+            const member = {name: 'John'};
+            expect(memoizedShallowEqual({a: 1, member}, {a: 1, member})).toBe(true);
+        });
+
+        it('returns false when a top-level value differs', () => {
+            expect(memoizedShallowEqual({a: 1}, {a: 2})).toBe(false);
+        });
+
+        it('returns false when key counts differ', () => {
+            expect(memoizedShallowEqual({a: 1}, {a: 1, b: 2})).toBe(false);
+        });
+
+        it('returns false for equal deep content with different nested references', () => {
+            // Shallow, not deep: nested objects are compared by reference.
+            expect(memoizedShallowEqual({member: {name: 'John'}}, {member: {name: 'John'}})).toBe(false);
+        });
+
+        it('handles non-object inputs', () => {
+            expect(memoizedShallowEqual(undefined, undefined)).toBe(true);
+            expect(memoizedShallowEqual(undefined, {})).toBe(false);
+            expect(memoizedShallowEqual('a', 'a')).toBe(true);
+            expect(memoizedShallowEqual('a', 'b')).toBe(false);
+            expect(memoizedShallowEqual(1, 1)).toBe(true);
+            expect(memoizedShallowEqual(NaN, NaN)).toBe(true);
+        });
+
+        it('handles arrays', () => {
+            expect(memoizedShallowEqual([1, 2], [1, 2])).toBe(true);
+            expect(memoizedShallowEqual([1, 2], [1, 3])).toBe(false);
+        });
+    });
+
+    describe('memoization', () => {
+        it('returns the cached verdict for the same object pair without re-comparing', () => {
+            const a = {name: 'John'};
+            const b = {name: 'Jane'};
+            expect(memoizedShallowEqual(a, b)).toBe(false);
+
+            // Mutate `b` so the objects are now content-equal. Onyx values are immutable,
+            // so the memo is expected to keep returning the verdict computed for this exact
+            // (a, b) pair — proving the second call resolved from the cache, not a re-compare.
+            b.name = 'John';
+            expect(memoizedShallowEqual(a, b)).toBe(false);
+        });
+
+        it('caches verdicts per pair, not per object', () => {
+            const a = {x: 1};
+            const equalToA = {x: 1};
+            const differentFromA = {x: 2};
+
+            expect(memoizedShallowEqual(a, equalToA)).toBe(true);
+            expect(memoizedShallowEqual(a, differentFromA)).toBe(false);
+
+            // Both verdicts are retained independently for the same `a`.
+            expect(memoizedShallowEqual(a, equalToA)).toBe(true);
+            expect(memoizedShallowEqual(a, differentFromA)).toBe(false);
+        });
+
+        it('does not memoize non-object inputs', () => {
+            // Primitives cannot be WeakMap keys; these calls must not throw and must compare directly.
+            expect(memoizedShallowEqual(1, {})).toBe(false);
+            expect(memoizedShallowEqual({}, 1)).toBe(false);
+            expect(memoizedShallowEqual(null, null)).toBe(true);
+        });
+    });
+});


### PR DESCRIPTION


### Details

**Problem**
When a large single Onyx key updates (e.g. `personalDetailsList` with ~18k members), every subscribed `useOnyx` hook independently runs `shallowEqual(previousValue, newValue)` inside `getSnapshot()` to decide whether to re-render. All of these hooks are comparing the exact same two object references (the old and new cache-owned values), yet each pays for its own full O(keys) walk.

Measured on a large account with ~200 subscribers to personalDetailsList: a single update triggered 29 full walks, ~512,000 key comparisons, ~530ms of synchronously blocked JS thread.

**Fix**
Memoize `shallowEqual` verdicts by the identity of the compared object pair:

`WeakMap&gt;`

The first hook comparing a given `(prev, next)` pair pays for the real `shallowEqual` walk and stores the verdict; every other hook comparing the same pair resolves in O(1). Non-object inputs bypass the memo (they&#39;re O(1) to compare anyway).

**Why this is safe**
- No behavior change. The memo caches a pure function keyed by its exact inputs — same semantics, same loading states, same re-render suppression. Cases where `shallowEqual` legitimately returns true on different references (fresh collection snapshots with unchanged members) behave identically.
- No invalidation logic. A verdict can only be read by holding both exact object references, so a stale answer is unreachable by construction. When Onyx replaces a value, the old object — and its verdict entries — are garbage-collected together (`WeakMap`).

**Results**
|                                                    | Before | After     |
| -------------------------------------------------- | ------ | --------- |
| shallowEqual time per `personalDetailsList` update | ~530ms | **~17ms** |
| Full walks per update                               | 29     | **1**     |
| Key comparisons per update                          | ~512k  | ~18k      |
| Behavior change                                     | —      | none      |

**Scope note**
This change removes the *redundancy* (N hooks paying for N identical comparisons), not the *existence* of the O(members) comparison — one full walk per update remains, and it is inherent to `personalDetailsList` being a single monolithic key. The root-cause fix is migrating it to a proper collection (`personalDetails_`), so an update only ever touches the changed member&#39;s subscribers. That is a large App/backend migration and is intentionally out of scope here; this optimization stands on its own regardless, since it applies to every large key with multiple subscribers (`report_`, `policy_`, snapshots, derived keys), not just this one.

### Related Issues

$ https://github.com/Expensify/App/issues/96856

### Linked E/App PR

https://github.com/Expensify/App/pull/96620

### Automated Tests


### Manual Tests
1. Navigate through multiple cached/not cached reports in the LHN
2. Verify messages, avatars and display names render correctly
3. Go to Account -> Profile and change the display name
4. Go back to LHN and verify the new name appears in report headers, LHN and message autorship without reload

### Author Checklist

- [x] I linked the correct issue in the `### Related Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos

Android: Native






Android: mWeb Chrome






iOS: Native






iOS: mWeb Safari






MacOS: Chrome / Safari

https://github.com/user-attachments/assets/72771238-a0eb-4068-a034-65f83572c86d






