### PR TITLE
perf: avoid per-read emptiness scan getCollectionData

### DIFF
--- a/lib/OnyxCache.ts
+++ b/lib/OnyxCache.ts
@@ -385,7 +385,7 @@ class OnyxCache {
         // Initialize frozen snapshots for collection keys
         for (const collectionKey of collectionKeys) {
             if (!this.collectionSnapshots.has(collectionKey)) {
-                this.collectionSnapshots.set(collectionKey, Object.freeze({}));
+                this.collectionSnapshots.set(collectionKey, FROZEN_EMPTY_COLLECTION);
             }
         }
     }
@@ -403,6 +403,7 @@ class OnyxCache {
 
         const members: NonUndefined<OnyxCollection<KeyValueMapping[OnyxKey]>> = {};
         let hasMemberChanges = false;
+        let hasMembers = false;
 
         // Use the indexed forward lookup for O(collectionMembers) iteration.
         // Falls back to scanning all storageKeys if the index isn't populated yet.
@@ -421,6 +422,7 @@ class OnyxCache {
             // and should not be included in the frozen collection snapshot.
             if (val !== undefined && val !== null) {
                 members[key] = val;
+                hasMembers = true;
 
                 // Check if this member's reference changed from the old snapshot
                 if (!hasMemberChanges && (!previousSnapshot || previousSnapshot[key] !== val)) {
@@ -449,6 +451,14 @@ class OnyxCache {
             return;
         }
 
+        // When the collection has no members, reuse one shared empty object for every empty
+        // collection. That way reads can tell a collection is empty with a quick `===` check
+        // instead of looping over its keys every time.
+        if (!hasMembers) {
+            this.collectionSnapshots.set(collectionKey, FROZEN_EMPTY_COLLECTION);
+            return;
+        }
+
         Object.freeze(members);
 
         this.collectionSnapshots.set(collectionKey, members);
@@ -466,16 +476,19 @@ class OnyxCache {
         }
 
         const snapshot = this.collectionSnapshots.get(collectionKey);
-        if (utils.isEmptyObject(snapshot)) {
-            // We check storageKeys.size (not collection-specific keys) to distinguish
-            // "init complete, this collection is genuinely empty" from "init not done yet."
-            // During init, setAllKeys loads ALL keys at once — so if any key exists,
-            // the full storage picture is loaded and an empty collection is truly empty.
-            // Returning undefined before init prevents subscribers from seeing a false empty state.
-            if (this.storageKeys.size > 0) {
-                return FROZEN_EMPTY_COLLECTION;
-            }
+
+        // We never stored anything for this collection key.
+        if (snapshot === undefined) {
             return undefined;
+        }
+
+        // The collection is empty (it holds our shared empty object). But "empty" is ambiguous
+        // during startup: we can't tell an actually-empty collection apart from one whose data
+        // hasn't loaded yet. Once any key exists, we know setAllKeys has run and loaded everything,
+        // so an empty collection really is empty. Before that, return undefined so subscribers
+        // don't briefly see a collection as empty when it just hasn't loaded.
+        if (snapshot === FROZEN_EMPTY_COLLECTION) {
+            return this.storageKeys.size > 0 ? FROZEN_EMPTY_COLLECTION : undefined;
         }
 
         return snapshot;

--- a/tests/unit/onyxCacheTest.tsx
+++ b/tests/unit/onyxCacheTest.tsx
@@ -625,6 +625,27 @@ describe('Onyx', () => {
                 });
             });
 
+            it('should return the stable empty reference after all members are removed', async () => {
+                await initOnyx();
+                // Unrelated key keeps storageKeys non-empty so an empty collection is treated as "loaded and empty"
+                await Onyx.set(ONYX_KEYS.TEST_KEY, 'value');
+                await Onyx.set(`${ONYX_KEYS.COLLECTION.MOCK_COLLECTION}1`, {id: 1});
+
+                const populated = cache.getCollectionData(ONYX_KEYS.COLLECTION.MOCK_COLLECTION);
+                expect(Object.keys(populated!)).toHaveLength(1);
+
+                // Remove the last member — the collection becomes empty
+                await Onyx.set(`${ONYX_KEYS.COLLECTION.MOCK_COLLECTION}1`, null);
+
+                const first = cache.getCollectionData(ONYX_KEYS.COLLECTION.MOCK_COLLECTION);
+                const second = cache.getCollectionData(ONYX_KEYS.COLLECTION.MOCK_COLLECTION);
+
+                expect(first).toBeDefined();
+                expect(Object.keys(first!)).toHaveLength(0);
+                // Reads must return the same empty reference so useSyncExternalStore doesn't re-render
+                expect(first).toBe(second);
+            });
+
             it('should preserve unchanged member references when a sibling is updated', async () => {
                 await initOnyx();
                 const member1Value = {id: 1, name: 'unchanged'};


### PR DESCRIPTION


### Details

**Problem**

`OnyxCache.getCollectionData()` calls `isEmptyObject(snapshot)` on every read to decide whether to return the collection or the empty-collection fallback. Profiling the Search page (4× CPU throttle) showed this check is a significant cost:

- In a DevTools trace, `isEmptyObject` accounted for ~919 ms of self-time, called almost entirely from `getCollectionData`.
- Instrumenting `getCollectionData` per collection key confirmed the emptiness check dominates read time and that its cost scales with collection size:

| collection                       | reads | total time (ms) | emptiness-check time (ms) | ms per read (emptiness check) |
| -------------------------------- | ----- | --------------- | ------------------------- | ----------------------------- |
| `report_`                        | 180   | 201.3           | 192.8                     | ~1.07                         |
| `transactions_`                  | 114   | 131.5           | 130.2                     | ~1.14                         |
| `reportActions_`                 | 84    | 98.9            | 93.9                      | ~1.12                         |
| `transactionViolations_` (small) | 699   | 35.6            | 34.1                      | ~0.05                         |

Rebuilds were negligible (≤4 across the run), so the cost is the per-read check itself, not snapshot rebuilding.

**Solution**

Store the shared frozen-empty object (`FROZEN_EMPTY_COLLECTION`) as the snapshot for empty collections instead of a fresh `{}`. The read path then:

- returns `undefined` for a collection that was never stored,
- detects &#34;empty&#34; with a single `snapshot === FROZEN_EMPTY_COLLECTION` reference comparison (no key scan),
- and for non-empty collections returns the snapshot directly, so `isEmptyObject` no longer runs on populated data at all.

Emptiness is now determined once, at snapshot-build time (`rebuildCollectionSnapshot`, which is dirty-gated and rare), rather than on every read.

**Performance improvement:**
On large account and staging, I was able to record 500-1000ms spent on `isEmptyObject` in `getCollectionData`. On dev, it was **400-700ms** before and **11ms** after.

### Related Issues

$ https://github.com/Expensify/App/issues/96855

### Linked E/App PR

https://github.com/Expensify/App/pull/96853


### Automated Tests
Unit tests already cover it, added only one missing

### Manual Tests
1. Open the app
2. Open multiple cold/warm reports
3. Verify every report opens correctly and shows all the data properly

### Author Checklist

- [x] I linked the correct issue in the `### Related Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** &amp; verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there&#39;s a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool &amp;&amp; `.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained &#34;why&#34; the code was doing something instead of only explaining &#34;what&#34; the code was doing.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named &#34;index.js&#34;. All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn&#39;t include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function&#39;s arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn&#39;t exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I&#39;ve added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don&#39;t apply to this PR.

### Screenshots/Videos

Android: Native






Android: mWeb Chrome






iOS: Native






iOS: mWeb Safari






MacOS: Chrome / Safari





