### PR TITLE
Classify "Failed to write blobs" IDB errors as INVALID_DATA (never retry)

### DIFF
--- a/lib/storage/providers/IDBKeyValProvider/classifyError.ts
+++ b/lib/storage/providers/IDBKeyValProvider/classifyError.ts
@@ -14,6 +14,13 @@ function classifyIDBError(error: unknown): ValueOf<typeof StorageErrorClass> {
         return StorageErrorClass.INVALID_DATA;
     }
 
+    // A queued File/Blob whose backing bytes are gone — the source OS file was modified, deleted, or
+    // renamed after being picked, so the structured clone fails at write time. Chromium reports it as
+    // InvalidBlob (Windows) or IOError (macOS). Retrying re-reads the same dead blob and can never succeed.
+    if (message.includes('failed to write blobs')) {
+        return StorageErrorClass.INVALID_DATA;
+    }
+
     // Browser quota exceeded.
     if (name.includes('quotaexceedederror') || message.includes('quotaexceedederror')) {
         return StorageErrorClass.CAPACITY;

--- a/tests/unit/storage/providers/classifyErrorTest.ts
+++ b/tests/unit/storage/providers/classifyErrorTest.ts
@@ -1,0 +1,23 @@
+import classifyIDBError from '../../../../lib/storage/providers/IDBKeyValProvider/classifyError';
+import {StorageErrorClass} from '../../../../lib/storage/errors';
+
+describe('classifyIDBError', () => {
+    it.each([
+        // Dead File/Blob in the payload — the platform-specific dialects of "Failed to write blobs".
+        [new DOMException('Failed to write blobs (InvalidBlob)', 'DataError'), StorageErrorClass.INVALID_DATA],
+        [new DOMException('Failed to write blobs (IOError)', 'DataError'), StorageErrorClass.INVALID_DATA],
+        // Non-serializable payload.
+        [new TypeError("Failed to execute 'put' on 'IDBObjectStore': something could not be cloned."), StorageErrorClass.INVALID_DATA],
+        // Quota.
+        [new DOMException('The quota has been exceeded.', 'QuotaExceededError'), StorageErrorClass.CAPACITY],
+        // Backing-store corruption.
+        [new DOMException('Internal error opening backing store for indexedDB.open.', 'UnknownError'), StorageErrorClass.FATAL],
+        // Transient connection failures.
+        [new DOMException('Connection to Indexed Database server lost. Refresh the page to try again', 'UnknownError'), StorageErrorClass.TRANSIENT],
+        [new DOMException('IDB write transaction aborted without an error', 'AbortError'), StorageErrorClass.TRANSIENT],
+        // Anything else stays UNKNOWN.
+        [new Error('some brand new failure'), StorageErrorClass.UNKNOWN],
+    ])('classifies %s as %s', (error, expectedClass) => {
+        expect(classifyIDBError(error)).toBe(expectedClass);
+    });
+});


### PR DESCRIPTION
### Details

`DataError: Failed to write blobs (InvalidBlob)` (Windows Chromium) / `(IOError)` (macOS Chromium) is thrown by IndexedDB when a `File`/`Blob` in the written value references backing bytes that no longer exist — in practice, a picked file that was modified, deleted, or renamed on disk between being picked and the first persist of the request queue. Production logs show ~46k such failures over 3 days, all with the same signature: the write fails on the first attempt and on every one of the 5 bounded retries (`retryAttempt: 0/5` → `5/5`), because retrying re-reads the same dead blob.

Today this error falls through to `UNKNOWN`, which the operation layer handles with bounded retries — provably futile for this error class. This PR classifies `failed to write blobs` as `INVALID_DATA` ("non-serializable payload, never retriable — the same data will always fail"), which is exactly the taxonomy's contract for it. This kills the 5×-per-write retry storm; the UNKNOWN branch's own doc asks for recurring cases to be promoted into a named class, which is what this does.

This is a storage-layer defense: it stops the futile retries for any value that carries a dead File/Blob, regardless of which app flow produced it.

### Related Issues
https://github.com/Expensify/App/issues/97050

### Linked E/App PR
https://github.com/Expensify/App/pull/96957

### Automated Tests

Added `tests/unit/storage/providers/classifyErrorTest.ts` covering the new branch (both `InvalidBlob` and `IOError` dialects → `INVALID_DATA`) plus the existing classes (put-clone failure, quota, backing-store corruption, transient connection failures, and the `UNKNOWN` fallthrough).

### Manual Tests

1. Run the web app against this Onyx ref in Chrome.
2. In a report, attach a file from disk; while the preview modal is open, delete the file on disk; send.
3. Verify the console shows a single classified `invalidData` storage failure with no `retryAttempt: 1/5`–`5/5` retry sequence (previously: `class: unknown` with 5 futile retries per write).

### Author Checklist

- [x] I linked the correct issue in the `### Related Issues` section above
- [x] I linked the corresponding Expensify/App PR in the `### Linked E/App PR` section above, and verified this change against it (E/App CI passed and manual testing completed)
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>
<img width="1504" height="547" alt="Screenshot 2026-07-27 at 13 45 33" src="https://github.com/user-attachments/assets/d88d4f27-9632-4eed-b49a-e611ee48d015" />



</details>

