### PR TITLE
Fix cross-tab sync for collection-root subscribers

### DIFF
--- a/lib/Onyx.ts
+++ b/lib/Onyx.ts
@@ -21,6 +21,9 @@ import type {
     OnyxInput,
     OnyxMethodMap,
     SetOptions,
+    OnyxCollection,
+    NonUndefined,
+    OnyxEntry,
 } from './types';
 import OnyxUtils from './OnyxUtils';
 import OnyxKeys from './OnyxKeys';
@@ -50,21 +53,54 @@ function init({
     OnyxKeys.setRamOnlyKeys(new Set<OnyxKey>(ramOnlyKeys));
 
     if (shouldSyncMultipleInstances) {
-        Storage.keepInstancesSync?.((key, value) => {
-            // RAM-only keys should never sync from storage as they may have stale persisted data
-            // from before the key was migrated to RAM-only.
-            if (OnyxKeys.isRamOnlyKey(key)) {
-                return;
+        // Cross-tab sync (InstanceSync) hands us the full batch of key/value pairs that changed together in
+        // a single write. We process it synchronously, grouping collection members so each affected
+        // collection is notified once (mirroring the local mergeCollection batching) instead of
+        // re-delivering the whole collection per member.
+        Storage.keepInstancesSync?.((pairs) => {
+            const individual: Array<[OnyxKey, OnyxEntry<KeyValueMapping[OnyxKey]>]> = [];
+            const collectionBatches = new Map<string, {partial: NonUndefined<OnyxCollection<KeyValueMapping[OnyxKey]>>; previous: NonUndefined<OnyxCollection<KeyValueMapping[OnyxKey]>>}>();
+
+            for (const [key, value] of pairs) {
+                // RAM-only keys should never sync from storage as they may have stale persisted data
+                // from before the key was migrated to RAM-only.
+                if (OnyxKeys.isRamOnlyKey(key)) {
+                    continue;
+                }
+
+                const collectionKey = OnyxKeys.getCollectionKey(key);
+                const isCollectionMember = !!collectionKey && OnyxKeys.isCollectionMemberKey(collectionKey, key);
+
+                // Capture the previous cached value BEFORE cache.set() so keysChanged() can diff old vs new per member.
+                const previousValue = isCollectionMember ? cache.get(key) : undefined;
+                cache.set(key, value);
+
+                if (isCollectionMember && collectionKey) {
+                    let batch = collectionBatches.get(collectionKey);
+                    if (!batch) {
+                        batch = {partial: {}, previous: {}};
+                        collectionBatches.set(collectionKey, batch);
+                    }
+                    batch.partial[key] = value;
+                    // Keep the earliest previous value in case the same member appears twice in one batch.
+                    if (!(key in batch.previous)) {
+                        batch.previous[key] = previousValue;
+                    }
+                } else {
+                    individual.push([key, value]);
+                }
             }
 
-            cache.set(key, value);
+            // Non-collection keys: notify individually, matching keyChanged() semantics for exact keys.
+            for (const [key, value] of individual) {
+                OnyxUtils.keyChanged(key, value);
+            }
 
-            // Check if this is a collection member key to prevent duplicate callbacks
-            // When a collection is updated, individual members sync separately to other tabs
-            // Setting isProcessingCollectionUpdate=true prevents triggering collection callbacks for each individual update
-            const isKeyCollectionMember = OnyxKeys.isCollectionMember(key);
-
-            OnyxUtils.keyChanged(key, value as OnyxValue<typeof key>, undefined, isKeyCollectionMember);
+            // One keysChanged() per collection notifies the collection-root subscriber once and lets
+            // keysChanged() decide which individual member subscribers actually changed.
+            for (const [collectionKey, {partial, previous}] of collectionBatches) {
+                OnyxUtils.keysChanged(collectionKey, partial, previous);
+            }
         });
     }
 

--- a/lib/Onyx.ts
+++ b/lib/Onyx.ts
@@ -8,22 +8,22 @@ import type {
     ConnectOptions,
     InitOptions,
     KeyValueMapping,
-    OnyxInputKeyValueMapping,
     MixedOperationsQueue,
+    NonUndefined,
+    OnyxCollection,
+    OnyxEntry,
+    OnyxInput,
+    OnyxInputKeyValueMapping,
     OnyxKey,
     OnyxMergeCollectionInput,
-    OnyxSetCollectionInput,
     OnyxMergeInput,
+    OnyxMethodMap,
     OnyxMultiSetInput,
+    OnyxSetCollectionInput,
     OnyxSetInput,
     OnyxUpdate,
     OnyxValue,
-    OnyxInput,
-    OnyxMethodMap,
     SetOptions,
-    OnyxCollection,
-    NonUndefined,
-    OnyxEntry,
 } from './types';
 import OnyxUtils from './OnyxUtils';
 import OnyxKeys from './OnyxKeys';
@@ -82,6 +82,7 @@ function init({
                         collectionBatches.set(collectionKey, batch);
                     }
                     batch.partial[key] = value;
+
                     // Keep the earliest previous value in case the same member appears twice in one batch.
                     if (!(key in batch.previous)) {
                         batch.previous[key] = previousValue;

--- a/lib/storage/InstanceSync/index.web.ts
+++ b/lib/storage/InstanceSync/index.web.ts
@@ -5,24 +5,48 @@
  */
 import type {OnyxKey} from '../../types';
 import NoopProvider from '../providers/NoopProvider';
-import type {StorageKeyList, OnStorageKeyChanged} from '../providers/types';
+import type {StorageKeyList, OnStorageKeysChanged} from '../providers/types';
 import type StorageProvider from '../providers/types';
 
 const SYNC_ONYX = 'SYNC_ONYX';
 
 /**
- * Raise an event through `localStorage` to let other tabs know a value changed
- * @param {String} onyxKey
+ * Parses the SYNC_ONYX storage event value.
+ * The payload is a JSON array of the changed keys (a batch). I fall backs to treating the raw
+ * value as a single key for backwards compatibility with the previous one-key-per-event format.
  */
-function raiseStorageSyncEvent(onyxKey: OnyxKey) {
-    global.localStorage.setItem(SYNC_ONYX, onyxKey);
+function parseSyncOnyxStorageEventValue(value: string): StorageKeyList {
+    let onyxKeys: StorageKeyList;
+    try {
+        const parsed = JSON.parse(value) as StorageKeyList | string;
+        onyxKeys = Array.isArray(parsed) ? parsed : [value];
+    } catch {
+        onyxKeys = [value];
+    }
+
+    return onyxKeys;
+}
+
+/**
+ * Raise a single cross-tab event for a batch of changed keys. Sending them together (instead of one
+ * event per key) preserves the write's batch boundary across tabs, so the receiving tab can notify
+ * collection subscribers once for the whole batch — matching the local mergeCollection behavior —
+ * instead of re-delivering the whole collection once per member (which is O(N^2) and can crash the tab).
+ */
+function raiseStorageSyncManyKeysEvent(onyxKeys: StorageKeyList) {
+    if (onyxKeys.length === 0) {
+        return;
+    }
+    global.localStorage.setItem(SYNC_ONYX, JSON.stringify(onyxKeys));
     global.localStorage.removeItem(SYNC_ONYX);
 }
 
-function raiseStorageSyncManyKeysEvent(onyxKeys: StorageKeyList) {
-    for (const onyxKey of onyxKeys) {
-        raiseStorageSyncEvent(onyxKey);
-    }
+/**
+ * Raise an event through `localStorage` to let other tabs know a value changed.
+ * @param {String} onyxKey
+ */
+function raiseStorageSyncEvent(onyxKey: OnyxKey) {
+    raiseStorageSyncManyKeysEvent([onyxKey]);
 }
 
 let storage = NoopProvider;
@@ -30,9 +54,9 @@ let storage = NoopProvider;
 const InstanceSync = {
     shouldBeUsed: true,
     /**
-     * @param {Function} onStorageKeyChanged Storage synchronization mechanism keeping all opened tabs in sync
+     * @param {Function} onStorageKeysChanged Storage synchronization mechanism keeping all opened tabs in sync
      */
-    init: (onStorageKeyChanged: OnStorageKeyChanged, store: StorageProvider<unknown>) => {
+    init: (onStorageKeysChanged: OnStorageKeysChanged, store: StorageProvider<unknown>) => {
         storage = store;
 
         // This listener will only be triggered by events coming from other tabs
@@ -42,9 +66,9 @@ const InstanceSync = {
                 return;
             }
 
-            const onyxKey = event.newValue;
+            const onyxKeys = parseSyncOnyxStorageEventValue(event.newValue);
 
-            storage.getItem(onyxKey).then((value) => onStorageKeyChanged(onyxKey, value));
+            storage.multiGet(onyxKeys).then((pairs) => onStorageKeysChanged(pairs));
         });
     },
     setItem: raiseStorageSyncEvent,

--- a/lib/storage/InstanceSync/index.web.ts
+++ b/lib/storage/InstanceSync/index.web.ts
@@ -42,11 +42,16 @@ function raiseStorageSyncManyKeysEvent(onyxKeys: StorageKeyList) {
 }
 
 /**
- * Raise an event through `localStorage` to let other tabs know a value changed.
- * @param {String} onyxKey
+ * Raise an event through `localStorage` to let other tabs know a single key changed.
+ *
+ * This intentionally emits the raw key (the legacy, pre-batching format) rather than a JSON array, so a
+ * tab still running the previous bundle during a deploy keeps receiving single-key updates (a new message,
+ * a pin, a rename, etc.). Only multi-key writes use the batched JSON-array format; the receiver here
+ * understands both. The mixed-version gap is therefore limited to bulk collection writes, which resolve on reload.
  */
 function raiseStorageSyncEvent(onyxKey: OnyxKey) {
-    raiseStorageSyncManyKeysEvent([onyxKey]);
+    global.localStorage.setItem(SYNC_ONYX, onyxKey);
+    global.localStorage.removeItem(SYNC_ONYX);
 }
 
 let storage = NoopProvider;

--- a/lib/storage/InstanceSync/index.web.ts
+++ b/lib/storage/InstanceSync/index.web.ts
@@ -3,12 +3,20 @@
  * when using LocalStorage APIs in the browser. These events are great because multiple tabs can listen for when
  * data changes and then stay up-to-date with everything happening in Onyx.
  */
+import * as Logger from '../../Logger';
 import type {OnyxKey} from '../../types';
 import NoopProvider from '../providers/NoopProvider';
 import type {StorageKeyList, OnStorageKeysChanged} from '../providers/types';
 import type StorageProvider from '../providers/types';
 
 const SYNC_ONYX = 'SYNC_ONYX';
+
+// localStorage stores values as UTF-16 (~2 bytes/char). The per-origin quota isn't fixed by the spec —
+// it's user-agent dependent and commonly ~5MB — so we keep each SYNC_ONYX payload conservatively small
+// (and pair it with a try/catch in emitSyncEvent). This way a large key batch (e.g. Onyx.clear() on a
+// heavy account, or a bulk import) is split across several events instead of throwing QuotaExceededError.
+// See https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API
+const MAX_SYNC_PAYLOAD_LENGTH = 1_000_000;
 
 /**
  * Parses the SYNC_ONYX storage event value.
@@ -28,17 +36,46 @@ function parseSyncOnyxStorageEventValue(value: string): StorageKeyList {
 }
 
 /**
- * Raise a single cross-tab event for a batch of changed keys. Sending them together (instead of one
- * event per key) preserves the write's batch boundary across tabs, so the receiving tab can notify
- * collection subscribers once for the whole batch — matching the local mergeCollection behavior —
- * instead of re-delivering the whole collection once per member (which is O(N^2) and can crash the tab).
+ * Emit a single SYNC_ONYX storage event. Wrapped so a failed cross-tab signal
+ * degrades gracefully — other tabs simply miss this update until their next organic sync/reload — instead
+ * of throwing an uncaught rejection in the writing tab.
+ */
+function emitSyncEvent(value: string) {
+    try {
+        global.localStorage.setItem(SYNC_ONYX, value);
+        global.localStorage.removeItem(SYNC_ONYX);
+    } catch (error) {
+        Logger.logAlert(`[InstanceSync] Failed to raise storage sync event: ${error}`);
+    }
+}
+
+/**
+ * Raise cross-tab event(s) for a batch of changed keys. Sending keys together (instead of one event per
+ * key) preserves the write's batch boundary across tabs, so the receiving tab notifies collection
+ * subscribers once for the whole batch — matching the local mergeCollection behavior — instead of
+ * re-delivering the whole collection once per member (O(N^2), which can crash the tab). Large batches are
+ * chunked so no single payload approaches the localStorage quota.
  */
 function raiseStorageSyncManyKeysEvent(onyxKeys: StorageKeyList) {
     if (onyxKeys.length === 0) {
         return;
     }
-    global.localStorage.setItem(SYNC_ONYX, JSON.stringify(onyxKeys));
-    global.localStorage.removeItem(SYNC_ONYX);
+
+    let chunk: StorageKeyList = [];
+    let chunkLength = 2; // accounts for the surrounding `[]`
+    for (const onyxKey of onyxKeys) {
+        const keyLength = onyxKey.length + 3; // quotes + comma separator
+        if (chunk.length > 0 && chunkLength + keyLength > MAX_SYNC_PAYLOAD_LENGTH) {
+            emitSyncEvent(JSON.stringify(chunk));
+            chunk = [];
+            chunkLength = 2;
+        }
+        chunk.push(onyxKey);
+        chunkLength += keyLength;
+    }
+    if (chunk.length > 0) {
+        emitSyncEvent(JSON.stringify(chunk));
+    }
 }
 
 /**
@@ -50,8 +87,7 @@ function raiseStorageSyncManyKeysEvent(onyxKeys: StorageKeyList) {
  * understands both. The mixed-version gap is therefore limited to bulk collection writes, which resolve on reload.
  */
 function raiseStorageSyncEvent(onyxKey: OnyxKey) {
-    global.localStorage.setItem(SYNC_ONYX, onyxKey);
-    global.localStorage.removeItem(SYNC_ONYX);
+    emitSyncEvent(onyxKey);
 }
 
 let storage = NoopProvider;

--- a/lib/storage/InstanceSync/index.web.ts
+++ b/lib/storage/InstanceSync/index.web.ts
@@ -20,7 +20,7 @@ const MAX_SYNC_PAYLOAD_LENGTH = 1_000_000;
 
 /**
  * Parses the SYNC_ONYX storage event value.
- * The payload is a JSON array of the changed keys (a batch). I fall backs to treating the raw
+ * The payload is a JSON array of the changed keys (a batch). It falls back to treating the raw
  * value as a single key for backwards compatibility with the previous one-key-per-event format.
  */
 function parseSyncOnyxStorageEventValue(value: string): StorageKeyList {

--- a/lib/storage/index.ts
+++ b/lib/storage/index.ts
@@ -182,14 +182,14 @@ const storage: Storage = {
     getDatabaseSize: () => tryOrDegradePerformance(() => provider.getDatabaseSize()),
 
     /**
-     * @param onStorageKeyChanged - Storage synchronization mechanism keeping all opened tabs in sync (web only)
+     * @param onStorageKeysChanged - Storage synchronization mechanism keeping all opened tabs in sync (web only)
      */
-    keepInstancesSync(onStorageKeyChanged) {
+    keepInstancesSync(onStorageKeysChanged) {
         // If InstanceSync shouldn't be used, it means we're on a native platform and we don't need to keep instances in sync
         if (!InstanceSync.shouldBeUsed) return;
 
         shouldKeepInstancesSync = true;
-        InstanceSync.init(onStorageKeyChanged, this);
+        InstanceSync.init(onStorageKeysChanged, this);
     },
 };
 

--- a/lib/storage/providers/types.ts
+++ b/lib/storage/providers/types.ts
@@ -10,7 +10,8 @@ type DatabaseSize = {
     usageDetails?: Record<string, number>;
 };
 
-type OnStorageKeyChanged = <TKey extends OnyxKey>(key: TKey, value: OnyxValue<TKey>) => void;
+/** Called with the full batch of key/value pairs that changed together in a single cross-tab sync event. */
+type OnStorageKeysChanged = (pairs: StorageKeyValuePair[]) => void;
 
 type StorageProvider<TStore> = {
     store: TStore;
@@ -90,8 +91,8 @@ type StorageProvider<TStore> = {
     /**
      * @param onStorageKeyChanged Storage synchronization mechanism keeping all opened tabs in sync
      */
-    keepInstancesSync?: (onStorageKeyChanged: OnStorageKeyChanged) => void;
+    keepInstancesSync?: (onStorageKeysChanged: OnStorageKeysChanged) => void;
 };
 
 export default StorageProvider;
-export type {StorageKeyList, StorageKeyValuePair, OnStorageKeyChanged};
+export type {StorageKeyList, StorageKeyValuePair, OnStorageKeysChanged};

--- a/lib/storage/providers/types.ts
+++ b/lib/storage/providers/types.ts
@@ -98,7 +98,7 @@ type StorageProvider<TStore> = {
     classifyError: (error: unknown) => ValueOf<typeof StorageErrorClass>;
 
     /**
-     * @param onStorageKeyChanged Storage synchronization mechanism keeping all opened tabs in sync
+     * @param onStorageKeysChanged Storage synchronization mechanism keeping all opened tabs in sync
      */
     keepInstancesSync?: (onStorageKeysChanged: OnStorageKeysChanged) => void;
 };

--- a/tests/unit/onyxTest.ts
+++ b/tests/unit/onyxTest.ts
@@ -3317,7 +3317,7 @@ describe('RAM-only keys should not read from storage', () => {
         await act(async () => waitForPromisesToResolve());
 
         // Simulate another tab syncing a stale RAM-only key value
-        syncCallback(ONYX_KEYS.RAM_ONLY_TEST_KEY, 'synced_stale_value');
+        syncCallback([[ONYX_KEYS.RAM_ONLY_TEST_KEY, 'synced_stale_value']]);
         await act(async () => waitForPromisesToResolve());
 
         // The RAM-only key should NOT have been updated from the sync
@@ -3334,13 +3334,104 @@ describe('RAM-only keys should not read from storage', () => {
         });
         await act(async () => waitForPromisesToResolve());
 
-        syncCallback(ONYX_KEYS.OTHER_TEST, 'synced_normal_value');
+        syncCallback([[ONYX_KEYS.OTHER_TEST, 'synced_normal_value']]);
         await act(async () => waitForPromisesToResolve());
 
         expect(normalValue).toEqual('synced_normal_value');
 
         Onyx.disconnect(connection);
         Onyx.disconnect(connection2);
+    });
+
+    it('should notify collection-root and collection member subscribers when a collection member syncs from another instance', async () => {
+        Onyx.init({
+            keys: ONYX_KEYS,
+            shouldSyncMultipleInstances: true,
+        });
+        await act(async () => waitForPromisesToResolve());
+
+        const syncCallback = (StorageMock.keepInstancesSync as jest.Mock).mock.calls.at(-1)?.[0];
+        expect(syncCallback).toBeDefined();
+
+        await Onyx.setCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
+            [`${ONYX_KEYS.COLLECTION.TEST_KEY}1`]: {name: 'entry 1'},
+            [`${ONYX_KEYS.COLLECTION.TEST_KEY}2`]: {name: 'entry 2'},
+            [`${ONYX_KEYS.COLLECTION.TEST_KEY}3`]: {name: 'entry 3'},
+        } as GenericCollection);
+
+        let collection: GenericCollection = {};
+        const collectionConn = Onyx.connect({
+            key: ONYX_KEYS.COLLECTION.TEST_KEY,
+            waitForCollectionCallback: true,
+            callback: (value) => {
+                collection = value as GenericCollection;
+            },
+        });
+
+        let collectionMember2: unknown;
+        const collectionMember2Conn = Onyx.connect({
+            key: `${ONYX_KEYS.COLLECTION.TEST_KEY}2`,
+            callback: (value) => {
+                collectionMember2 = value;
+            },
+        });
+        await act(async () => waitForPromisesToResolve());
+
+        // Another tab writes a collection member; the storage-sync batch must notify the collection-root subscriber.
+        syncCallback([[`${ONYX_KEYS.COLLECTION.TEST_KEY}2`, {name: 'entry 2 changed'}]]);
+        await act(async () => waitForPromisesToResolve());
+
+        // The collection-root subscriber must receive the whole collection including the synced member.
+        expect(Object.keys(collection).length).toBe(3);
+        expect(collection[`${ONYX_KEYS.COLLECTION.TEST_KEY}2`]).toEqual({name: 'entry 2 changed'});
+
+        // The collection member subscriber must receive the synced data.
+        expect(collectionMember2).toEqual({name: 'entry 2 changed'});
+
+        Onyx.disconnect(collectionConn);
+        Onyx.disconnect(collectionMember2Conn);
+    });
+
+    it('should notify a collection-root subscriber once when multiple members sync from another instance', async () => {
+        Onyx.init({
+            keys: ONYX_KEYS,
+            shouldSyncMultipleInstances: true,
+        });
+        await act(async () => waitForPromisesToResolve());
+
+        const syncCallback = (StorageMock.keepInstancesSync as jest.Mock).mock.calls.at(-1)?.[0];
+        expect(syncCallback).toBeDefined();
+
+        await Onyx.setCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
+            [`${ONYX_KEYS.COLLECTION.TEST_KEY}1`]: {name: 'entry 1'},
+            [`${ONYX_KEYS.COLLECTION.TEST_KEY}2`]: {name: 'entry 2'},
+            [`${ONYX_KEYS.COLLECTION.TEST_KEY}3`]: {name: 'entry 3'},
+        } as GenericCollection);
+
+        const collectionCallback = jest.fn();
+        const connection = Onyx.connect({
+            key: ONYX_KEYS.COLLECTION.TEST_KEY,
+            waitForCollectionCallback: true,
+            callback: collectionCallback,
+        });
+        await act(async () => waitForPromisesToResolve());
+        collectionCallback.mockClear();
+
+        // Another tab writes two members; storage sync delivers them as one batch.
+        syncCallback([
+            [`${ONYX_KEYS.COLLECTION.TEST_KEY}1`, {name: 'entry 1 changed'}],
+            [`${ONYX_KEYS.COLLECTION.TEST_KEY}3`, {name: 'entry 3 changed'}],
+        ]);
+        await waitForPromisesToResolve();
+
+        // The batch produces a single collection-root notification carrying all members.
+        expect(collectionCallback).toHaveBeenCalledTimes(1);
+        const collection = collectionCallback.mock.calls[0][0] as Record<string, unknown>;
+        expect(collection[`${ONYX_KEYS.COLLECTION.TEST_KEY}1`]).toEqual({name: 'entry 1 changed'});
+        expect(collection[`${ONYX_KEYS.COLLECTION.TEST_KEY}2`]).toEqual({name: 'entry 2'});
+        expect(collection[`${ONYX_KEYS.COLLECTION.TEST_KEY}3`]).toEqual({name: 'entry 3 changed'});
+
+        Onyx.disconnect(connection);
     });
 
     it('should serve RAM-only keys from cache and normal keys from storage in multiGet', async () => {

--- a/tests/unit/onyxTest.ts
+++ b/tests/unit/onyxTest.ts
@@ -3317,7 +3317,6 @@ describe('RAM-only keys should not read from storage', () => {
         let collection: GenericCollection = {};
         const collectionConn = Onyx.connect({
             key: ONYX_KEYS.COLLECTION.TEST_KEY,
-            waitForCollectionCallback: true,
             callback: (value) => {
                 collection = value as GenericCollection;
             },
@@ -3366,7 +3365,6 @@ describe('RAM-only keys should not read from storage', () => {
         const collectionCallback = jest.fn();
         const connection = Onyx.connect({
             key: ONYX_KEYS.COLLECTION.TEST_KEY,
-            waitForCollectionCallback: true,
             callback: collectionCallback,
         });
         await act(async () => waitForPromisesToResolve());

--- a/tests/unit/onyxTest.ts
+++ b/tests/unit/onyxTest.ts
@@ -3387,6 +3387,52 @@ describe('RAM-only keys should not read from storage', () => {
         Onyx.disconnect(connection);
     });
 
+    it('should notify subscribers with undefined when a collection member is removed in another instance', async () => {
+        Onyx.init({
+            keys: ONYX_KEYS,
+            shouldSyncMultipleInstances: true,
+        });
+        await act(async () => waitForPromisesToResolve());
+
+        const syncCallback = (StorageMock.keepInstancesSync as jest.Mock).mock.calls.at(-1)?.[0];
+        expect(syncCallback).toBeDefined();
+
+        await Onyx.setCollection(ONYX_KEYS.COLLECTION.TEST_KEY, {
+            [`${ONYX_KEYS.COLLECTION.TEST_KEY}1`]: {name: 'entry 1'},
+            [`${ONYX_KEYS.COLLECTION.TEST_KEY}2`]: {name: 'entry 2'},
+        } as GenericCollection);
+
+        let collection: GenericCollection = {};
+        const collectionConn = Onyx.connect({
+            key: ONYX_KEYS.COLLECTION.TEST_KEY,
+            callback: (value) => {
+                collection = value as GenericCollection;
+            },
+        });
+
+        let collectionMember2: unknown = 'initial';
+        const collectionMember2Conn = Onyx.connect({
+            key: `${ONYX_KEYS.COLLECTION.TEST_KEY}2`,
+            callback: (value) => {
+                collectionMember2 = value;
+            },
+        });
+        await act(async () => waitForPromisesToResolve());
+
+        // Another tab removes member 2; the removed key reads back as undefined from storage.
+        syncCallback([[`${ONYX_KEYS.COLLECTION.TEST_KEY}2`, undefined]]);
+        await act(async () => waitForPromisesToResolve());
+
+        // The member subscriber must be told the member is gone.
+        expect(collectionMember2).toBeUndefined();
+
+        // The collection-root subscriber must receive the collection without the removed member.
+        expect(collection).toEqual({[`${ONYX_KEYS.COLLECTION.TEST_KEY}1`]: {name: 'entry 1'}});
+
+        Onyx.disconnect(collectionConn);
+        Onyx.disconnect(collectionMember2Conn);
+    });
+
     it('should serve RAM-only keys from cache and normal keys from storage in multiGet', async () => {
         const ramOnlyMember = `${ONYX_KEYS.COLLECTION.RAM_ONLY_COLLECTION}1`;
         const normalMember = `${ONYX_KEYS.COLLECTION.TEST_KEY}1`;

--- a/tests/unit/storage/instanceSyncWebTest.ts
+++ b/tests/unit/storage/instanceSyncWebTest.ts
@@ -1,0 +1,121 @@
+import InstanceSync from '../../../lib/storage/InstanceSync/index.web';
+import type StorageProvider from '../../../lib/storage/providers/types';
+import waitForPromisesToResolve from '../../utils/waitForPromisesToResolve';
+
+const SYNC_ONYX = 'SYNC_ONYX';
+
+// Mirrors MAX_SYNC_PAYLOAD_LENGTH in lib/storage/InstanceSync/index.web.ts (not exported).
+const MAX_SYNC_PAYLOAD_LENGTH = 1_000_000;
+
+/** Returns the SYNC_ONYX payloads written to localStorage, in write order. */
+function getSyncPayloads(setItemSpy: jest.SpyInstance): string[] {
+    return setItemSpy.mock.calls.filter(([key]) => key === SYNC_ONYX).map(([, value]) => value as string);
+}
+
+describe('InstanceSync (web)', () => {
+    let setItemSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        setItemSpy = jest.spyOn(Storage.prototype, 'setItem');
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    describe('event payload chunking', () => {
+        it('emits a single event when the batch fits within the payload limit', () => {
+            const keys = ['test_1', 'test_2', 'test_3'];
+            InstanceSync.multiSet(keys);
+
+            const payloads = getSyncPayloads(setItemSpy);
+            expect(payloads).toHaveLength(1);
+            expect(JSON.parse(payloads[0])).toEqual(keys);
+        });
+
+        it('splits a batch larger than the payload limit into multiple events without losing keys', () => {
+            // Three keys of ~400k chars each: the first two fit in one payload, the third starts a new one.
+            const keys = [1, 2, 3].map((i) => `test_${i}_${'x'.repeat(400_000)}`);
+            InstanceSync.multiSet(keys);
+
+            const payloads = getSyncPayloads(setItemSpy);
+            expect(payloads).toHaveLength(2);
+            for (const payload of payloads) {
+                expect(payload.length).toBeLessThanOrEqual(MAX_SYNC_PAYLOAD_LENGTH);
+            }
+
+            // All keys must arrive, in order, with no duplicates.
+            const receivedKeys = payloads.flatMap((payload) => JSON.parse(payload) as string[]);
+            expect(receivedKeys).toEqual(keys);
+        });
+
+        it('emits an oversized single key as its own event instead of dropping it', () => {
+            const hugeKey = `test_huge_${'x'.repeat(MAX_SYNC_PAYLOAD_LENGTH + 1000)}`;
+            InstanceSync.multiSet([hugeKey]);
+
+            const payloads = getSyncPayloads(setItemSpy);
+            expect(payloads).toHaveLength(1);
+            expect(JSON.parse(payloads[0])).toEqual([hugeKey]);
+        });
+
+        it('emits no event for an empty batch', () => {
+            InstanceSync.multiSet([]);
+
+            expect(getSyncPayloads(setItemSpy)).toHaveLength(0);
+        });
+    });
+
+    describe('storage event parsing', () => {
+        let onStorageKeysChanged: jest.Mock;
+        let multiGet: jest.Mock;
+        let storageEventHandler: (event: {key: string | null; newValue: string | null}) => void;
+
+        beforeEach(() => {
+            onStorageKeysChanged = jest.fn();
+            multiGet = jest.fn((keys: string[]) => Promise.resolve(keys.map((key) => [key, `value_of_${key}`])));
+
+            const addEventListenerSpy = jest.spyOn(global, 'addEventListener').mockImplementation(() => undefined);
+            InstanceSync.init(onStorageKeysChanged, {multiGet} as unknown as StorageProvider<unknown>);
+
+            const storageCall = addEventListenerSpy.mock.calls.find(([type]) => type === 'storage');
+            storageEventHandler = storageCall?.[1] as unknown as typeof storageEventHandler;
+            expect(storageEventHandler).toBeDefined();
+        });
+
+        it('parses a JSON-array payload as a batch of keys', async () => {
+            storageEventHandler({key: SYNC_ONYX, newValue: JSON.stringify(['test_1', 'test_2'])});
+            await waitForPromisesToResolve();
+
+            expect(multiGet).toHaveBeenCalledWith(['test_1', 'test_2']);
+            expect(onStorageKeysChanged).toHaveBeenCalledWith([
+                ['test_1', 'value_of_test_1'],
+                ['test_2', 'value_of_test_2'],
+            ]);
+        });
+
+        it('treats a legacy raw-key payload as a single key for backwards compatibility', async () => {
+            storageEventHandler({key: SYNC_ONYX, newValue: 'test_1'});
+            await waitForPromisesToResolve();
+
+            expect(multiGet).toHaveBeenCalledWith(['test_1']);
+            expect(onStorageKeysChanged).toHaveBeenCalledWith([['test_1', 'value_of_test_1']]);
+        });
+
+        it('treats a raw key that parses as non-array JSON as a single key', async () => {
+            // A key like "123" is valid JSON but not an array; the raw string must be kept as the key.
+            storageEventHandler({key: SYNC_ONYX, newValue: '123'});
+            await waitForPromisesToResolve();
+
+            expect(multiGet).toHaveBeenCalledWith(['123']);
+        });
+
+        it('ignores storage events that are not SYNC_ONYX', async () => {
+            storageEventHandler({key: 'someOtherKey', newValue: 'test_1'});
+            storageEventHandler({key: SYNC_ONYX, newValue: null});
+            await waitForPromisesToResolve();
+
+            expect(multiGet).not.toHaveBeenCalled();
+            expect(onStorageKeysChanged).not.toHaveBeenCalled();
+        });
+    });
+});


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details

<!-- Explanation of the change or anything fishy that is going on -->

Supersedes https://github.com/Expensify/react-native-onyx/pull/803 (same changes with latest `main` merged in — re-opened from a branch I can maintain). Originally coming from [here](https://github.com/Expensify/react-native-onyx/pull/799#issuecomment-4831583408), authored by @fabioh8010.

Cross-tab (multi-instance) storage sync events were not delivered to collection-root subscribers — e.g. the LHN subscribing to the whole `report_` collection — so actions like pin/unpin, drafting a message, or marking a report read/unread performed in one tab did not sync to other open tabs.

This PR:

- Batches storage sync events and notifies collection-root subscribers (not just individual member-key subscribers) when collection members sync from another instance.
- Handles legacy pre-batching sync events for backward compatibility.
- Splits large sync events into chunks to stay under storage event size limits.

**Note:** this fix depends on the OnyxDerived recompute coalescing that landed in E/App via https://github.com/Expensify/App/pull/96785 (now on staging). Without coalescing, the extra collection-root notifications caused a derived-value recompute storm. Re-verified against latest E/App `main` (which includes #96785) — see Manual Tests.

### Related Issues

<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->

https://github.com/Expensify/App/issues/94839

### Linked E/App PR

<!--
Every Onyx PR must ship with a corresponding Expensify/App PR that pins Onyx to this PR's HEAD via git+https
(e.g. "react-native-onyx": "git+https://github.com/Expensify/react-native-onyx.git#<commit_sha>").
That linked PR runs the full E/App test suite signals that the Onyx
change is safe. After this PR is merged and published to npm, swap the linked E/App PR to the pinned version
(e.g. "react-native-onyx": "3.0.72") and request a final review — it becomes the bump PR.

Paste the full Expensify/App PR URL below (e.g. https://github.com/Expensify/App/pull/12345):
-->

https://github.com/Expensify/App/pull/97218

### Automated Tests

<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

Added tests in `tests/unit/onyxTest.ts` verifying that both collection-root subscribers (`waitForCollectionCallback: true`) and collection member subscribers are notified when a collection member syncs from another instance. Existing multi-instance sync tests were updated to the new batched event shape.

### Manual Tests

<!---
Each set of changes should be tested against the Expensify/App repo on all platforms to verify it does not break our staging App.
--->

Tested on web against latest E/App `main` (includes the OnyxDerived microtask coalescing from https://github.com/Expensify/App/pull/96785), with Onyx pinned to this PR's head (latest `main` merged in, v3.0.94):

1. Opened two NewDot tabs signed in to the same account.
2. In Tab A: pinned/unpinned a report, drafted a message in a mid-list report, marked a report read/unread, and sent a message — verified each action synced to Tab B (pin icon, LHN re-ordering, draft icon, unread bold, new message) without refreshing.
3. Verified no derived recompute storm: instrumented `OnyxDerived` compute counts in the idle tab — only ~3–6 recomputes per action (previous failure mode without coalescing was thousands of recomputes and a frozen tab).
4. Verified no console errors and no tab freeze in either tab.

### Author Checklist

- [x] I linked the correct issue in the `### Related Issues` section above
- [x] I linked the corresponding Expensify/App PR in the `### Linked E/App PR` section above, and verified this change against it (E/App CI passed and manual testing completed)
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>


https://github.com/user-attachments/assets/ae5c35bf-5aa7-4578-9e44-76ce2bc643e9


https://github.com/user-attachments/assets/55585777-a31e-4e1f-86a0-3d21d2e0d37e


https://github.com/user-attachments/assets/bf627541-cc7b-456b-8d03-a59ce553c859



</details>
