### PR TITLE
Classify SQLite disk-pressure errors and stop retrying them

### DIFF
--- a/API-INTERNAL.md
+++ b/API-INTERNAL.md
@@ -2,9 +2,21 @@
 
 # Internal API Reference
 
+## Constants
+
+<dl>
+<dt><a href="#DISK_PRESSURE_LOG_INTERVAL_MS">DISK_PRESSURE_LOG_INTERVAL_MS</a></dt>
+<dd><p>Minimum interval between disk-pressure alerts. One disk-pressure burst fails every queued operation
+with the identical error, so per-operation logging would amplify the very storm it reports.</p>
+</dd>
+</dl>
+
 ## Functions
 
 <dl>
+<dt><a href="#resetDiskPressureLogThrottle">resetDiskPressureLogThrottle()</a></dt>
+<dd><p>Test-only: clears the disk-pressure log throttle so each test observes its own alert.</p>
+</dd>
 <dt><a href="#getMergeQueue">getMergeQueue()</a></dt>
 <dd><p>Getter - returns the merge queue.</p>
 </dd>
@@ -89,6 +101,9 @@ and alerted (fatal). Retrying here would only re-amplify, so we skip the write q
 <li>CAPACITY: evicts the least recently accessed evictable key and retries, under a session-level
 circuit breaker (see lib/StorageCircuitBreaker.ts) that halts the loop once eviction stops making
 progress or failures storm — the per-operation budget alone cannot stop a session-wide storm.</li>
+<li>DISK_PRESSURE: the device disk itself is full (or the database files are unreadable), so neither
+retries nor in-DB eviction can free space — the write is dropped (cache stays authoritative) with
+a single throttled alert + quota snapshot per burst.</li>
 <li>UNKNOWN: the provider couldn&#39;t classify it — log the full error shape (name + message +
 provider) once so it&#39;s visible, then bounded retry without eviction.</li>
 </ul>
@@ -157,6 +172,19 @@ Retries on failure.</p>
 </dd>
 </dl>
 
+<a name="DISK_PRESSURE_LOG_INTERVAL_MS"></a>
+
+## DISK\_PRESSURE\_LOG\_INTERVAL\_MS
+Minimum interval between disk-pressure alerts. One disk-pressure burst fails every queued operation
+with the identical error, so per-operation logging would amplify the very storm it reports.
+
+**Kind**: global constant  
+<a name="resetDiskPressureLogThrottle"></a>
+
+## resetDiskPressureLogThrottle()
+Test-only: clears the disk-pressure log throttle so each test observes its own alert.
+
+**Kind**: global function  
 <a name="getMergeQueue"></a>
 
 ## getMergeQueue()
@@ -333,6 +361,9 @@ capacity recovery (eviction) so that a given failure is retried by exactly one l
 - CAPACITY: evicts the least recently accessed evictable key and retries, under a session-level
   circuit breaker (see lib/StorageCircuitBreaker.ts) that halts the loop once eviction stops making
   progress or failures storm — the per-operation budget alone cannot stop a session-wide storm.
+- DISK_PRESSURE: the device disk itself is full (or the database files are unreadable), so neither
+  retries nor in-DB eviction can free space — the write is dropped (cache stays authoritative) with
+  a single throttled alert + quota snapshot per burst.
 - UNKNOWN: the provider couldn't classify it — log the full error shape (name + message +
   provider) once so it's visible, then bounded retry without eviction.
 

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -52,6 +52,16 @@ const METHOD = {
 // Max number of retries for failed storage operations
 const MAX_STORAGE_OPERATION_RETRY_ATTEMPTS = 5;
 
+/** Minimum interval between disk-pressure alerts. One disk-pressure burst fails every queued operation
+ * with the identical error, so per-operation logging would amplify the very storm it reports. */
+const DISK_PRESSURE_LOG_INTERVAL_MS = 60000;
+let lastDiskPressureLogTime = 0;
+
+/** Test-only: clears the disk-pressure log throttle so each test observes its own alert. */
+function resetDiskPressureLogThrottle(): void {
+    lastDiskPressureLogTime = 0;
+}
+
 type OnyxMethod = ValueOf<typeof METHOD>;
 
 // Key/value store of Onyx key and arrays of values to merge
@@ -783,6 +793,9 @@ function reportStorageQuota(error?: Error): Promise<void> {
  * - CAPACITY: evicts the least recently accessed evictable key and retries, under a session-level
  *   circuit breaker (see lib/StorageCircuitBreaker.ts) that halts the loop once eviction stops making
  *   progress or failures storm — the per-operation budget alone cannot stop a session-wide storm.
+ * - DISK_PRESSURE: the device disk itself is full (or the database files are unreadable), so neither
+ *   retries nor in-DB eviction can free space — the write is dropped (cache stays authoritative) with
+ *   a single throttled alert + quota snapshot per burst.
  * - UNKNOWN: the provider couldn't classify it — log the full error shape (name + message +
  *   provider) once so it's visible, then bounded retry without eviction.
  */
@@ -804,6 +817,21 @@ function retryOperation<TMethod extends RetriableOnyxOperation>(
     if (errorClass === StorageErrorClass.CAPACITY && !StorageCircuitBreaker.isAllowed()) {
         StorageCircuitBreaker.recordProbeFailure();
         return Promise.resolve();
+    }
+
+    // DISK_PRESSURE: the filesystem around the database is out of space or its files are unreadable, so
+    // neither retries nor in-DB eviction can succeed — every operation fails identically until the OS
+    // frees space, and the burst recovers on its own once it does. Drop the write (the cache stays
+    // authoritative) and log one alert + quota snapshot per interval instead of one per operation; the
+    // quota snapshot carries the free-disk bytes that confirm (or rule out) disk pressure in telemetry.
+    if (errorClass === StorageErrorClass.DISK_PRESSURE) {
+        const now = Date.now();
+        if (now - lastDiskPressureLogTime < DISK_PRESSURE_LOG_INTERVAL_MS) {
+            return Promise.resolve();
+        }
+        lastDiskPressureLogTime = now;
+        Logger.logAlert(`Disk-pressure storage error; skipping retries. provider: ${Storage.getStorageProvider().name}. message: ${error?.message}. onyxMethod: ${onyxMethod.name}.`);
+        return reportStorageQuota(error);
     }
 
     Logger.logInfo(
@@ -1816,6 +1844,7 @@ const OnyxUtils = {
     getCollectionDataAndSendAsObject,
     remove,
     reportStorageQuota,
+    resetDiskPressureLogThrottle,
     retryOperation,
     broadcastUpdate,
     hasPendingMergeForKey,

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -819,11 +819,9 @@ function retryOperation<TMethod extends RetriableOnyxOperation>(
         return Promise.resolve();
     }
 
-    // DISK_PRESSURE: the filesystem around the database is out of space or its files are unreadable, so
-    // neither retries nor in-DB eviction can succeed — every operation fails identically until the OS
-    // frees space, and the burst recovers on its own once it does. Drop the write (the cache stays
-    // authoritative) and log one alert + quota snapshot per interval instead of one per operation; the
-    // quota snapshot carries the free-disk bytes that confirm (or rule out) disk pressure in telemetry.
+    // DISK_PRESSURE: the device disk is full, so neither retries nor eviction can succeed until the OS
+    // frees space. Drop the write (cache stays authoritative) and log one alert + quota snapshot per
+    // interval — the snapshot's free-disk bytes let telemetry confirm (or rule out) disk pressure.
     if (errorClass === StorageErrorClass.DISK_PRESSURE) {
         const now = Date.now();
         if (now - lastDiskPressureLogTime < DISK_PRESSURE_LOG_INTERVAL_MS) {

--- a/lib/storage/errors.ts
+++ b/lib/storage/errors.ts
@@ -15,6 +15,10 @@ const StorageErrorClass = {
     TRANSIENT: 'transient',
     /** Quota exceeded / disk full. Owner: operation layer — evict and retry. */
     CAPACITY: 'capacity',
+    /** Filesystem-level failure around the database files (device disk full, or the files cannot be
+     *  created/read). Owner: operation layer — skip retries and eviction (neither can free OS-level
+     *  space) and log one throttled alert + quota snapshot per burst. */
+    DISK_PRESSURE: 'diskPressure',
     /** Non-serializable payload. Never retriable — the same data will always fail. */
     INVALID_DATA: 'invalidData',
     /** Backing-store corruption. Owner: connection layer — budgeted heal, then give up. */

--- a/lib/storage/providers/SQLiteProvider.ts
+++ b/lib/storage/providers/SQLiteProvider.ts
@@ -325,16 +325,21 @@ const provider: StorageProvider<NitroSQLiteConnection | undefined> = {
             throw new Error('Store is not initialized!');
         }
 
-        return Promise.all([provider.store.executeAsync<PageSizeResult>('PRAGMA page_size;'), provider.store.executeAsync<PageCountResult>('PRAGMA page_count;'), getFreeDiskStorage()]).then(
-            ([pageSizeResult, pageCountResult, bytesRemaining]) => {
+        // The PRAGMAs run on the SQLite connection — the very thing that's broken during disk pressure —
+        // while getFreeDiskStorage() is filesystem-level and still works. Degrade bytesUsed to -1 instead
+        // of failing the snapshot, so the free-disk bytes (the signal that matters) always get logged.
+        const bytesUsedPromise = Promise.all([provider.store.executeAsync<PageSizeResult>('PRAGMA page_size;'), provider.store.executeAsync<PageCountResult>('PRAGMA page_count;')])
+            .then(([pageSizeResult, pageCountResult]) => {
                 const pageSize = pageSizeResult.rows?.item(0)?.page_size ?? 0;
                 const pageCount = pageCountResult.rows?.item(0)?.page_count ?? 0;
-                return {
-                    bytesUsed: pageSize * pageCount,
-                    bytesRemaining,
-                };
-            },
-        );
+                return pageSize * pageCount;
+            })
+            .catch(() => -1);
+
+        return Promise.all([bytesUsedPromise, getFreeDiskStorage()]).then(([bytesUsed, bytesRemaining]) => ({
+            bytesUsed,
+            bytesRemaining,
+        }));
     },
 };
 

--- a/lib/storage/providers/SQLiteProvider.ts
+++ b/lib/storage/providers/SQLiteProvider.ts
@@ -325,9 +325,8 @@ const provider: StorageProvider<NitroSQLiteConnection | undefined> = {
             throw new Error('Store is not initialized!');
         }
 
-        // The PRAGMAs run on the SQLite connection — the very thing that's broken during disk pressure —
-        // while getFreeDiskStorage() is filesystem-level and still works. Degrade bytesUsed to -1 instead
-        // of failing the snapshot, so the free-disk bytes (the signal that matters) always get logged.
+        // The PRAGMAs need the SQLite connection; getFreeDiskStorage() is filesystem-level. Degrade
+        // bytesUsed to -1 instead of failing, so the free-disk bytes always get logged.
         const bytesUsedPromise = Promise.all([provider.store.executeAsync<PageSizeResult>('PRAGMA page_size;'), provider.store.executeAsync<PageCountResult>('PRAGMA page_count;')])
             .then(([pageSizeResult, pageCountResult]) => {
                 const pageSize = pageSizeResult.rows?.item(0)?.page_size ?? 0;

--- a/lib/storage/providers/classifySQLiteError.ts
+++ b/lib/storage/providers/classifySQLiteError.ts
@@ -18,6 +18,15 @@ function classifySQLiteError(error: unknown): ValueOf<typeof StorageErrorClass> 
         return StorageErrorClass.CAPACITY;
     }
 
+    // Filesystem-level failures around the database files, seen when the device disk is (nearly) full.
+    // "disk I/O error" (SQLITE_IOERR) fires on every operation — reads included — after SQLite fails to
+    // size the -shm file while (re)opening the database on a full disk; "unable to open database file"
+    // (SQLITE_CANTOPEN) when the -shm file cannot be created at all; "cannot rollback" is a batch-write
+    // failure whose original error was masked by the ROLLBACK itself failing on the same full disk.
+    if (message.includes('disk i/o error') || message.includes('unable to open database file') || message.includes('cannot rollback - no transaction is active')) {
+        return StorageErrorClass.DISK_PRESSURE;
+    }
+
     return StorageErrorClass.UNKNOWN;
 }
 

--- a/lib/storage/providers/classifySQLiteError.ts
+++ b/lib/storage/providers/classifySQLiteError.ts
@@ -18,11 +18,9 @@ function classifySQLiteError(error: unknown): ValueOf<typeof StorageErrorClass> 
         return StorageErrorClass.CAPACITY;
     }
 
-    // Filesystem-level failures around the database files, seen when the device disk is (nearly) full.
-    // "disk I/O error" (SQLITE_IOERR) fires on every operation — reads included — after SQLite fails to
-    // size the -shm file while (re)opening the database on a full disk; "unable to open database file"
-    // (SQLITE_CANTOPEN) when the -shm file cannot be created at all; "cannot rollback" is a batch-write
-    // failure whose original error was masked by the ROLLBACK itself failing on the same full disk.
+    // Full-disk failures around the database files: SQLITE_IOERR (cannot size the -shm file on reopen,
+    // fails reads too), SQLITE_CANTOPEN (cannot create it), and a failed ROLLBACK masking the original
+    // write error. None can succeed until the OS frees space.
     if (message.includes('disk i/o error') || message.includes('unable to open database file') || message.includes('cannot rollback - no transaction is active')) {
         return StorageErrorClass.DISK_PRESSURE;
     }

--- a/lib/storage/providers/classifySQLiteError.ts
+++ b/lib/storage/providers/classifySQLiteError.ts
@@ -18,15 +18,10 @@ function classifySQLiteError(error: unknown): ValueOf<typeof StorageErrorClass> 
         return StorageErrorClass.CAPACITY;
     }
 
-    // Full-disk failures around the database files: SQLITE_IOERR (cannot size the -shm file on reopen,
-    // fails reads too) and SQLITE_CANTOPEN (cannot create it). Neither can succeed until the OS frees space.
     if (message.includes('disk i/o error') || message.includes('unable to open database file')) {
         return StorageErrorClass.DISK_PRESSURE;
     }
 
-    // "cannot rollback - no transaction is active" lands here deliberately: it is a mask, not a cause —
-    // nitro-sqlite's rollback-on-error replaced the original failure until 9.7.0. UNKNOWN gives it
-    // bounded retry + shape logging instead of a disk-pressure guess.
     return StorageErrorClass.UNKNOWN;
 }
 

--- a/lib/storage/providers/classifySQLiteError.ts
+++ b/lib/storage/providers/classifySQLiteError.ts
@@ -19,9 +19,8 @@ function classifySQLiteError(error: unknown): ValueOf<typeof StorageErrorClass> 
     }
 
     // Full-disk failures around the database files: SQLITE_IOERR (cannot size the -shm file on reopen,
-    // fails reads too), SQLITE_CANTOPEN (cannot create it), and a failed ROLLBACK masking the original
-    // write error. None can succeed until the OS frees space.
-    if (message.includes('disk i/o error') || message.includes('unable to open database file') || message.includes('cannot rollback - no transaction is active')) {
+    // fails reads too) and SQLITE_CANTOPEN (cannot create it). Neither can succeed until the OS frees space.
+    if (message.includes('disk i/o error') || message.includes('unable to open database file')) {
         return StorageErrorClass.DISK_PRESSURE;
     }
 

--- a/lib/storage/providers/classifySQLiteError.ts
+++ b/lib/storage/providers/classifySQLiteError.ts
@@ -24,6 +24,9 @@ function classifySQLiteError(error: unknown): ValueOf<typeof StorageErrorClass> 
         return StorageErrorClass.DISK_PRESSURE;
     }
 
+    // "cannot rollback - no transaction is active" lands here deliberately: it is a mask, not a cause —
+    // nitro-sqlite's rollback-on-error replaced the original failure until 9.7.0. UNKNOWN gives it
+    // bounded retry + shape logging instead of a disk-pressure guess.
     return StorageErrorClass.UNKNOWN;
 }
 

--- a/tests/unit/onyxUtilsTest.ts
+++ b/tests/unit/onyxUtilsTest.ts
@@ -748,8 +748,12 @@ describe('OnyxUtils', () => {
         const diskFullError = new Error('database or disk is full');
         const nonRetriableIdbError = Object.assign(new Error('Internal error opening backing store for indexedDB.open.'), {name: 'UnknownError'});
 
-        // The circuit breaker is process-scoped, so reset it between tests to avoid state leaking.
-        beforeEach(() => StorageCircuitBreaker.reset());
+        // The circuit breaker and the disk-pressure log throttle are process-scoped, so reset them
+        // between tests to avoid state leaking.
+        beforeEach(() => {
+            StorageCircuitBreaker.reset();
+            OnyxUtils.resetDiskPressureLogThrottle();
+        });
 
         it('should retry only one time if the operation is firstly failed and then passed', async () => {
             StorageMock.setItem = jest.fn(StorageMock.setItem).mockRejectedValueOnce(genericError).mockImplementation(StorageMock.setItem);
@@ -806,6 +810,42 @@ describe('OnyxUtils', () => {
 
             // Called once (initial attempt only) -- no recursion, unlike the 6 calls for generic errors
             expect(retryOperationSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it.each([
+            ['[NativeNitroSQLiteException][SqlExecutionError] disk I/O error'],
+            ['[NativeNitroSQLiteException][SqlExecutionError] unable to open database file'],
+            ['[NativeNitroSQLiteException][SqlExecutionError] cannot rollback - no transaction is active'],
+        ])('should not retry disk-pressure errors (%s)', async (message) => {
+            StorageMock.setItem = jest.fn().mockRejectedValue(new Error(message));
+
+            await Onyx.set(ONYXKEYS.TEST_KEY, {test: 'data'});
+
+            // Called once (initial attempt only): retries cannot succeed while the device disk is full.
+            expect(retryOperationSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it('should log a single throttled alert with a quota snapshot for a disk-pressure burst', async () => {
+            const logAlertSpy = jest.spyOn(Logger, 'logAlert');
+            const logInfoSpy = jest.spyOn(Logger, 'logInfo');
+            const diskIOError = new Error('[NativeNitroSQLiteException][SqlExecutionError] disk I/O error');
+            StorageMock.setItem = jest.fn().mockRejectedValue(diskIOError);
+
+            // A burst: several operations all failing with the identical error.
+            await Onyx.set(ONYXKEYS.TEST_KEY, {test: 'data'});
+            await Onyx.set(ONYXKEYS.TEST_KEY, {test: 'data2'});
+            await Onyx.set(ONYXKEYS.TEST_KEY, {test: 'data3'});
+
+            // One alert for the whole burst (the rest are throttled within DISK_PRESSURE_LOG_INTERVAL_MS)...
+            const alerts = logAlertSpy.mock.calls.filter((call) => typeof call[0] === 'string' && call[0].startsWith('Disk-pressure storage error'));
+            expect(alerts).toHaveLength(1);
+            expect(alerts[0][0]).toBe(`Disk-pressure storage error; skipping retries. provider: MemoryOnlyProvider. message: ${diskIOError.message}. onyxMethod: setWithRetry.`);
+            // ...paired with exactly one quota snapshot (carries the free-disk bytes on native platforms).
+            const quotaLogs = logInfoSpy.mock.calls.filter((call) => typeof call[0] === 'string' && call[0].startsWith('Storage Quota Check'));
+            expect(quotaLogs).toHaveLength(1);
+            // And no "failed after N retries" alert: the writes were dropped, not retried to exhaustion.
+            const retryAlerts = logAlertSpy.mock.calls.filter((call) => typeof call[0] === 'string' && call[0].startsWith('Storage operation failed after'));
+            expect(retryAlerts).toHaveLength(0);
         });
 
         it('should skip retry quietly (info, not alert) for fatal connection-layer errors', async () => {

--- a/tests/unit/onyxUtilsTest.ts
+++ b/tests/unit/onyxUtilsTest.ts
@@ -812,18 +812,17 @@ describe('OnyxUtils', () => {
             expect(retryOperationSpy).toHaveBeenCalledTimes(1);
         });
 
-        it.each([
-            ['[NativeNitroSQLiteException][SqlExecutionError] disk I/O error'],
-            ['[NativeNitroSQLiteException][SqlExecutionError] unable to open database file'],
-            ['[NativeNitroSQLiteException][SqlExecutionError] cannot rollback - no transaction is active'],
-        ])('should not retry disk-pressure errors (%s)', async (message) => {
-            StorageMock.setItem = jest.fn().mockRejectedValue(new Error(message));
+        it.each([['[NativeNitroSQLiteException][SqlExecutionError] disk I/O error'], ['[NativeNitroSQLiteException][SqlExecutionError] unable to open database file']])(
+            'should not retry disk-pressure errors (%s)',
+            async (message) => {
+                StorageMock.setItem = jest.fn().mockRejectedValue(new Error(message));
 
-            await Onyx.set(ONYXKEYS.TEST_KEY, {test: 'data'});
+                await Onyx.set(ONYXKEYS.TEST_KEY, {test: 'data'});
 
-            // Called once (initial attempt only): retries cannot succeed while the device disk is full.
-            expect(retryOperationSpy).toHaveBeenCalledTimes(1);
-        });
+                // Called once (initial attempt only): retries cannot succeed while the device disk is full.
+                expect(retryOperationSpy).toHaveBeenCalledTimes(1);
+            },
+        );
 
         it('should log a single throttled alert with a quota snapshot for a disk-pressure burst', async () => {
             const logAlertSpy = jest.spyOn(Logger, 'logAlert');

--- a/tests/unit/storage/providers/SQLiteProviderTest.ts
+++ b/tests/unit/storage/providers/SQLiteProviderTest.ts
@@ -453,5 +453,15 @@ describe('SQLiteProvider', () => {
 
             expect(after.bytesUsed).toBeGreaterThan(before.bytesUsed);
         });
+
+        it('should still report free-disk bytes when the PRAGMAs fail (disk pressure)', async () => {
+            // During disk pressure the SQLite connection itself fails, but free-disk comes from the
+            // filesystem — the snapshot must survive with bytesUsed degraded instead of rejecting.
+            const executeAsyncSpy = jest.spyOn(SQLiteProvider.store!, 'executeAsync').mockRejectedValue(new Error('[NativeNitroSQLiteException][SqlExecutionError] disk I/O error'));
+
+            await expect(SQLiteProvider.getDatabaseSize()).resolves.toEqual({bytesUsed: -1, bytesRemaining: 12345});
+
+            executeAsyncSpy.mockRestore();
+        });
     });
 });


### PR DESCRIPTION
### Details

Fixes the app-side symptom of https://github.com/Expensify/App/issues/87869 — iOS bursts of `NitroSQLiteError: [NativeNitroSQLiteException][SqlExecutionError] disk I/O error` (Sentry APP-19Q).

**Root cause** (reproduced locally on an iOS simulator): when the device disk is full at database (re)open, SQLite fails to ftruncate the `OnyxDB-shm` WAL-index file to 32KB (errno 28 `ENOSPC` → `SQLITE_IOERR_SHMSIZE`), after which **every** read and write returns `disk I/O error` until space frees — then it recovers on its own. Two related shapes of the same condition:

- `unable to open database file` (`SQLITE_CANTOPEN`) — the `-shm` file cannot be created at all
- `cannot rollback - no transaction is active` — a batch-write failure whose original error was masked by the ROLLBACK itself failing (this one is a *mask*, not a cause — any error that already aborted the transaction produces it, so it deliberately stays `UNKNOWN`; nitro-sqlite stops the masking in 9.7.0)

**Before this PR** these errors fell in the `UNKNOWN` storage error class: 5 blind retries per operation (futile — the disk is still full) plus a per-operation alert, amplifying the very log storm being reported (~70x amplification seen in prod logs).

**This PR:**

- Adds a new `DISK_PRESSURE` storage error class (`lib/storage/errors.ts`)
- `classifySQLiteError` routes the two disk-pressure messages above to it (`lib/storage/providers/classifySQLiteError.ts`); the rollback message stays `UNKNOWN` (bounded retry + shape logging) since the real cause is unknowable
- `retryOperation` drops the write (the in-memory cache stays authoritative), skips retries and eviction (neither can free OS-level disk space), and logs a single throttled alert (60s window) plus one storage quota snapshot per burst (`lib/OnyxUtils.ts`)
- On native, the quota snapshot includes `getFreeDiskStorage()` bytes, giving prod telemetry the free-disk data to confirm disk pressure as the root cause

### Related Issues

https://github.com/Expensify/App/issues/97908

### Linked E/App PR

https://github.com/Expensify/App/pull/97944

### Automated Tests

Added to `tests/unit/onyxUtilsTest.ts`:

- `it.each` over the two disk-pressure error strings (`disk I/O error`, `unable to open database file`) asserting the operation is **not** retried
- A burst test asserting exactly one throttled alert + one storage quota snapshot across a burst of failing operations, and no "retries exhausted" alert

Full unit suite passes (569 tests).

### Manual Tests

Regression smoke (no user-facing change in this PR — it only alters error classification/logging):

1. Sign in and use the app normally: open a report, create an expense, send a message.
2. Go offline, create an expense, kill and relaunch the app — verify the offline change is still there and syncs when back online.
3. Verify no crashes or console errors during normal usage.

### Author Checklist

- [x] I linked the correct issue in the `### Related Issues` section above
- [x] I linked the corresponding Expensify/App PR in the `### Linked E/App PR` section above, and verified this change against it (E/App CI passed and manual testing completed)
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>


https://github.com/user-attachments/assets/5766bfb1-ee87-4144-9f91-145308c9a8f5






</details>

