### PR TITLE
Skip keyless update entries in updateSnapshots instead of crashing

### DIFF
--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -1211,6 +1211,12 @@ function updateSnapshots<TKey extends OnyxKey>(data: Array<OnyxUpdate<TKey>>, me
         let updatedData: Record<string, unknown> = {};
 
         for (const {key, value} of data) {
+            // `clear`/`multiset` updates legitimately carry no key (and `Onyx.update` skips other keyless
+            // entries), so ignore them here too instead of crashing on `key.startsWith` below.
+            if (typeof key !== 'string') {
+                continue;
+            }
+
             // snapshots are normal keys so we want to skip update if they are written to Onyx
             if (OnyxKeys.isCollectionMemberKey(snapshotCollectionKey, key)) {
                 continue;

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -1202,6 +1202,15 @@ function updateSnapshots<TKey extends OnyxKey>(data: Array<OnyxUpdate<TKey>>, me
 
     const snapshotCollection = getCachedCollection(snapshotCollectionKey);
 
+    // Multiset entries are keyless but update every key of their payload, so expand them into
+    // per-key entries to keep cached snapshots in sync with the real Onyx data.
+    const flattenedData = data.flatMap<{onyxMethod: OnyxMethod; key: unknown; value?: unknown}>((entry) => {
+        if (entry.onyxMethod === METHOD.MULTI_SET && typeof entry.key !== 'string' && entry.value && typeof entry.value === 'object' && !Array.isArray(entry.value)) {
+            return Object.entries(entry.value).map(([key, value]) => ({onyxMethod: METHOD.SET, key, value}));
+        }
+        return entry;
+    });
+
     for (const [snapshotEntryKey, snapshotEntryValue] of Object.entries(snapshotCollection)) {
         // Snapshots may not be present in cache. We don't know how to update them so we skip.
         if (!snapshotEntryValue) {
@@ -1210,11 +1219,11 @@ function updateSnapshots<TKey extends OnyxKey>(data: Array<OnyxUpdate<TKey>>, me
 
         let updatedData: Record<string, unknown> = {};
 
-        for (const {key, value, onyxMethod} of data) {
+        for (const {key, value, onyxMethod} of flattenedData) {
             if (typeof key !== 'string') {
-                // clear/multiset entries legitimately carry no key; snapshots have nothing to update for them
+                // clear entries legitimately carry no key, and malformed multiset payloads are already logged by update() itself
                 if (onyxMethod !== METHOD.CLEAR && onyxMethod !== METHOD.MULTI_SET) {
-                    Logger.logInfo(`Invalid ${typeof key} key (method: ${onyxMethod}, key: ${String(key).slice(0, 50)}) provided in Onyx update. Skipping snapshot update for this entry.`);
+                    Logger.logHmmm(`Invalid ${typeof key} key (method: ${onyxMethod}, key: ${String(key).slice(0, 50)}) provided in Onyx update. Skipping snapshot update for this entry.`);
                 }
                 continue;
             }

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -1210,9 +1210,12 @@ function updateSnapshots<TKey extends OnyxKey>(data: Array<OnyxUpdate<TKey>>, me
 
         let updatedData: Record<string, unknown> = {};
 
-        for (const {key, value} of data) {
+        for (const {key, value, onyxMethod} of data) {
             if (typeof key !== 'string') {
-                Logger.logInfo(`Invalid ${typeof key} key provided in Onyx update. Key must be of type string. Skipping snapshot update for this entry.`);
+                // clear/multiset entries legitimately carry no key; snapshots have nothing to update for them
+                if (onyxMethod !== METHOD.CLEAR && onyxMethod !== METHOD.MULTI_SET) {
+                    Logger.logInfo(`Invalid ${typeof key} key (method: ${onyxMethod}, key: ${String(key).slice(0, 50)}) provided in Onyx update. Skipping snapshot update for this entry.`);
+                }
                 continue;
             }
 

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -1212,6 +1212,7 @@ function updateSnapshots<TKey extends OnyxKey>(data: Array<OnyxUpdate<TKey>>, me
 
         for (const {key, value} of data) {
             if (typeof key !== 'string') {
+                Logger.logInfo(`Invalid ${typeof key} key provided in Onyx update. Key must be of type string. Skipping snapshot update for this entry.`);
                 continue;
             }
 

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -1211,8 +1211,6 @@ function updateSnapshots<TKey extends OnyxKey>(data: Array<OnyxUpdate<TKey>>, me
         let updatedData: Record<string, unknown> = {};
 
         for (const {key, value} of data) {
-            // `clear`/`multiset` updates legitimately carry no key (and `Onyx.update` skips other keyless
-            // entries), so ignore them here too instead of crashing on `key.startsWith` below.
             if (typeof key !== 'string') {
                 continue;
             }

--- a/tests/unit/onyxTest.ts
+++ b/tests/unit/onyxTest.ts
@@ -1562,6 +1562,32 @@ describe('Onyx', () => {
         expect(callback.mock.calls.at(-1)?.[0]).toEqual({[snapshot1]: {data: {[cat]: finalValue}}});
     });
 
+    it('should expand keyless multiSet updates into per-key Snapshot updates', async () => {
+        const cat = `${ONYX_KEYS.COLLECTION.ANIMALS}cat`;
+        const dog = `${ONYX_KEYS.COLLECTION.ANIMALS}dog`;
+        const snapshot1 = `${ONYX_KEYS.COLLECTION.SNAPSHOT}1`;
+
+        await Onyx.set(cat, {name: 'Fluffy'});
+        await Onyx.set(dog, {name: 'Rex'});
+        await Onyx.set(snapshot1, {data: {[cat]: {name: 'Fluffy'}}});
+
+        const callback = jest.fn();
+
+        Onyx.connect({
+            key: ONYX_KEYS.COLLECTION.SNAPSHOT,
+            callback,
+        });
+
+        await waitForPromisesToResolve();
+
+        const multiSetUpdate = {onyxMethod: Onyx.METHOD.MULTI_SET, value: {[cat]: {name: 'Kitty'}, [dog]: {name: 'Buddy'}}} as unknown as OnyxUpdate<OnyxKey>;
+
+        await Onyx.update([multiSetUpdate]);
+
+        // Only the key that exists in the snapshot is updated there, so it stays in sync with the real Onyx value.
+        expect(callback.mock.calls.at(-1)?.[0]).toEqual({[snapshot1]: {data: {[cat]: {name: 'Kitty'}}}});
+    });
+
     describe('update', () => {
         let logInfoFn = jest.fn();
 

--- a/tests/unit/onyxTest.ts
+++ b/tests/unit/onyxTest.ts
@@ -1535,6 +1535,35 @@ describe('Onyx', () => {
         expect(callback.mock.calls[1][1]).toBe(ONYX_KEYS.COLLECTION.SNAPSHOT);
     });
 
+    it('should skip update entries without a key when updating Snapshots instead of rejecting', async () => {
+        const cat = `${ONYX_KEYS.COLLECTION.ANIMALS}cat`;
+        const snapshot1 = `${ONYX_KEYS.COLLECTION.SNAPSHOT}1`;
+
+        const initialValue = {name: 'Fluffy'};
+        const finalValue = {name: 'Kitty'};
+
+        await Onyx.set(cat, initialValue);
+        await Onyx.set(snapshot1, {data: {[cat]: initialValue}});
+
+        const callback = jest.fn();
+
+        Onyx.connect({
+            key: ONYX_KEYS.COLLECTION.SNAPSHOT,
+            callback,
+        });
+
+        await waitForPromisesToResolve();
+
+        // A keyless entry (e.g. a malformed server update) used to crash updateSnapshots with
+        // "can't access property 'startsWith', key is undefined" and reject the whole update.
+        const keylessUpdate = {onyxMethod: Onyx.METHOD.MERGE, value: {name: 'Ghost'}} as unknown as OnyxUpdate<OnyxKey>;
+
+        await expect(Onyx.update([keylessUpdate, {key: cat, value: finalValue, onyxMethod: Onyx.METHOD.MERGE}])).resolves.not.toThrow();
+
+        // The valid update still lands in the snapshot.
+        expect(callback.mock.calls.at(-1)?.[0]).toEqual({[snapshot1]: {data: {[cat]: finalValue}}});
+    });
+
     describe('update', () => {
         let logInfoFn = jest.fn();
 

--- a/tests/unit/onyxTest.ts
+++ b/tests/unit/onyxTest.ts
@@ -1554,8 +1554,6 @@ describe('Onyx', () => {
 
         await waitForPromisesToResolve();
 
-        // A keyless entry (e.g. a malformed server update) used to crash updateSnapshots with
-        // "can't access property 'startsWith', key is undefined" and reject the whole update.
         const keylessUpdate = {onyxMethod: Onyx.METHOD.MERGE, value: {name: 'Ghost'}} as unknown as OnyxUpdate<OnyxKey>;
 
         await expect(Onyx.update([keylessUpdate, {key: cat, value: finalValue, onyxMethod: Onyx.METHOD.MERGE}])).resolves.not.toThrow();


### PR DESCRIPTION
### Details

Came from [this slack thread](https://callstack-hq.slack.com/archives/C08CZDJFJ77/p1785928288177769)

Fixes a production crash in `OnyxUtils.updateSnapshots`: `TypeError: Cannot read properties of undefined (reading 'startsWith')` ([Sentry APP-6NT](https://expensify.sentry.io/issues/APP-6NT), ~94 events / ~35 users since 2026-03-01, plus duplicate groupings APP-JT0, APP-961, APP-H8X, APP-ED8 — all on web, mostly 2FA pages).

**Root cause:** `Onyx.update` validates its entries and skips any with a non-string `key` (and `clear`/`multiset` entries legitimately carry no key at all), but then passes the **unfiltered** update array to `OnyxUtils.updateSnapshots`. There, `OnyxKeys.isCollectionMemberKey(snapshotCollectionKey, key)` calls `key.startsWith(collectionKey)` with no guard, so any keyless entry throws and rejects the whole `Onyx.update` promise. It only reproduces when the snapshot collection is non-empty (i.e. the user has cached search snapshots), which is why the volume is low.

In Expensify/App this surfaced as an unhandled rejection from `QueuedOnyxUpdates.flushQueue` (the deferred WRITE flush), and Sentry mis-attributed the newest grouping (APP-JT0) to Expensify/App PR [#97098](https://github.com/Expensify/App/pull/97098), which merely touched those lines.

**Fix:** in `updateSnapshots`, skip entries where `typeof key !== 'string'` before calling `isCollectionMemberKey` — mirroring the per-entry validation `Onyx.update` already performs.

Fixes APP-6NT

https://github.com/Expensify/App/pull/97857 (TESTING ONLY pin of this PR's HEAD, so the full E/App CI suite runs against it). The fix itself is self-contained in Onyx and requires no App-side change; for context, https://github.com/Expensify/App/pull/97098 is the App PR that Sentry falsely attributed the newest crash grouping to.

### Related Issues

https://github.com/Expensify/App/issues/98438

### Linked E/App PR

https://github.com/Expensify/App/pull/97857

### Automated Tests

Added a regression test in `tests/unit/onyxTest.ts` — "should skip update entries without a key when updating Snapshots instead of rejecting": dispatches an `Onyx.update` containing a keyless `merge` entry alongside a valid one while a snapshot is cached. Without the fix it reproduces the exact production crash (`TypeError: Cannot read properties of undefined (reading 'startsWith')` rejecting `Onyx.update`); with the fix, `Onyx.update` resolves and the valid entry still lands in the snapshot.

Verification run: 173 unit tests pass (`onyxTest` + `onyxUtilsTest`), `tsc --noEmit` clean, ESLint clean, Prettier clean. Also verified the new test fails with the exact production stack trace when the guard is stashed.

### Manual Tests

On Android / iOS (native or mWeb) against staging:

1. Sign in with an account that has chats and expenses.
2. Go to the **Reports/Search** tab and run a search (e.g. All expenses). Scroll through the results and open one or two of them. *(This caches search snapshot data — the precondition for the code path this PR touches.)*
3. Go back to **Inbox** and, in a report that appeared in those search results: send a message, edit an expense amount, and mark the report as unread.
4. Return to the **Search** tab and re-open the search. Verify the results reflect the changes (new amount, latest message) and the app does not crash or freeze at any point.
5. Enable airplane mode. Make 2–3 more changes (add a comment, rename a report, edit an expense). Disable airplane mode and wait for sync to finish. Verify the app stays responsive, nothing crashes, and search results reflect the offline changes.
6. Sign out and sign back in. Verify no crash during sign-out/sign-in.

Expected: no crash and no stuck/undelivered updates in any step. (Before this fix, a malformed keyless entry in any server update batch would crash the app with a `startsWith` TypeError whenever a search had previously been run — steps 2–5 keep that code path continuously active.)

<details>
<summary>Deterministic developer repro (web console)</summary>

1. In Expensify/App (web), sign in and run a Search so at least one `snapshot_` collection entry is cached.
2. In the dev console, dispatch an update containing a keyless entry alongside a valid one, e.g. `Onyx.update([{onyxMethod: 'merge', key: 'session', value: {}}, {onyxMethod: 'merge', value: {}}])`.
3. Without this fix: the promise rejects with `TypeError: Cannot read properties of undefined (reading 'startsWith')` from `updateSnapshots`.
4. With this fix: the promise resolves, the keyless entry is skipped, and the valid entry is applied to the cached snapshot.

</details>

### QA Steps

Same as Manual Tests.

### Author Checklist

- [x] I linked the correct issue in the `### Related Issues` section above
- [x] I linked the corresponding Expensify/App PR in the `### Linked E/App PR` section above, and verified this change against it (E/App CI passed and manual testing completed)
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

N/A — non-UI library fix, covered by the unit regression test.

</details>

<details>
<summary>Android: mWeb Chrome</summary>

N/A — non-UI library fix, covered by the unit regression test.

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/fc78d56f-bcbd-492e-8033-d8f9d116f595



</details>

<details>
<summary>iOS: mWeb Safari</summary>

N/A — non-UI library fix, covered by the unit regression test.

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

N/A — non-UI library fix, covered by the unit regression test.

</details>


