### PR TITLE
fix: add getSnapshot memoizedShallowEqual to skip rerenders

### DIFF
--- a/lib/useOnyx.ts
+++ b/lib/useOnyx.ts
@@ -108,6 +108,12 @@ function useOnyx<TKey extends OnyxKey, TReturnValue = OnyxValue<TKey>>(key: TKey
         if (!shouldGetCachedValueRef.current) {
             const cachedResult = onyxSnapshotCache.getCachedResult<UseOnyxResult<TReturnValue>>(key, cacheKey);
             if (cachedResult !== undefined) {
+                // The slot is shared by all subscribers of the same (key, selector) pair, so it can hold a content-equal
+                // result computed by another subscriber. Keep our own result then, otherwise we would needlessly change
+                // this hook's result identity and re-render its consumer.
+                if (cachedResult !== resultRef.current && memoizedShallowEqual(cachedResult[0], resultRef.current[0]) && cachedResult[1].status === resultRef.current[1].status) {
+                    return resultRef.current;
+                }
                 resultRef.current = cachedResult;
                 return cachedResult;
             }

--- a/tests/unit/useOnyxTest.ts
+++ b/tests/unit/useOnyxTest.ts
@@ -574,6 +574,28 @@ describe('useOnyx', () => {
             expect(oldResult).toBe(result.current);
         });
 
+        it('should keep result identity when a new subscriber with the same key and selector mounts', async () => {
+            Onyx.set(ONYXKEYS.TEST_KEY, {id: 'test_id', name: 'test_name'});
+
+            const selector = ((entry: OnyxEntry<{id: string; name: string}>) => ({id: entry?.id})) as UseOnyxSelector<OnyxKey, {id?: string}>;
+
+            const {result, rerender} = renderHook(() => useOnyx(ONYXKEYS.TEST_KEY, {selector}));
+
+            await act(async () => waitForPromisesToResolve());
+
+            const oldResult = result.current;
+
+            // A subscriber that mounts later computes its own content-equal selector output and publishes it into the shared snapshot cache slot.
+            renderHook(() => useOnyx(ONYXKEYS.TEST_KEY, {selector}));
+
+            await act(async () => waitForPromisesToResolve());
+
+            rerender(undefined);
+
+            // must be the same reference — the new subscriber's content-equal result must not replace it
+            expect(result.current).toBe(oldResult);
+        });
+
         it('should always use the current selector reference to return new data', async () => {
             Onyx.set(ONYXKEYS.TEST_KEY, {id: 'test_id', name: 'test_name'});
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

`useOnyx` no longer changes its result identity when the shared snapshot cache holds a content-equal result from another subscriber

The snapshot cache slot is shared by every subscriber of the same `(key, selector)` pair, while each subscriber's memoized selector owns a distinct output object. A subscriber that mounts later (its per-hook memoization cache is empty) computes a fresh object, content-equal but referentially new, and publishes it into the slot. Existing subscribers then adopted it blindly in the `getSnapshot()` fast path, which changed their result identity and re-rendered their memoized subtrees for no reason. The fast path now keeps the hook's own result when the cached one is content-equal (`memoizedShallowEqual` on the value plus a status match).

### Why

We hit this in E/App. In a Concierge chat, every sent message and every Concierge reply re-rendered the whole `ReportActionsList` content. React DevTools Profiler blamed the `report` prop of `ReportActionsListItemRenderer`, and prop-diff instrumentation showed the tell-tale signature on each message: `report prop (stableReport <id>): NEW REFERENCE, but every field is shallow-equal`. A pure object-identity change with zero data change.

Root cause: every report row (`ActionContentRouter`) and the report list itself subscribe to the same `report_<id>` key with the same shared `getStableReportSelector`. Every incoming message mounts a new row, which republished a fresh identity into the shared slot. That flipped the `report` prop of every `ReportActionsListItemRenderer` and re-rendered the entire chat list on each message, even though the selected data never changed. The stable-report projection exists precisely to prevent this class of re-render, and the shared slot was silently defeating it.

### Where the fresh object comes from

A projection selector builds a fresh object literal on every call (`return {reportID: report.reportID, ...}`), so two calls with the same input produce two content-equal objects with different identities. Identity stability is never provided by the selector itself. It comes from the per-hook memoized wrapper (`createMemoizedSelector`), which deep-compares each recompute against its `lastOutput` and returns the old reference when equal. A newly mounted subscriber has no `lastOutput` yet, so the fresh literal becomes its output and gets published into the shared slot, where the other subscribers' fast paths adopted it.

### Why a per-call-site selector wrapper also "fixes" it (and why it's not the fix)

The slot key is `${key}_${selectorID}`, where `selectorID` is assigned per function identity. Wrapping the shared selector in a module-level function (`const stableReportSelectorForList = (report) => getStableReportSelector(report)`) mints a new identity, giving that call site a private slot with a single writer and reader, which is the always-working sole-subscriber case. But that only shields one call site. All remaining subscribers of the shared selector keep flipping each other in their shared slot. The fast-path guard fixes the adoption itself, making sharing safe for every consumer without per-call-site workarounds. (The wrapper must be module-level. Defined inside a component it would mint a new identity every render, causing cache-slot churn and a selector recompute per render.)

### Why this implementation

- Guard only the fast path. The recompute path already preserves identity via the `memoizedShallowEqual` check on `previousValueRef`. The fast path was the single place adopting a result without any comparison.
- Near-zero cost. Converged and single-subscriber hits short-circuit on the first `!==` pointer compare. Distinct-but-equal objects pay one top-level walk, memoized by identity pair in the `memoizedShallowEqual` WeakMap, so N hooks comparing the same two objects pay for one walk total. Real content changes arrive via slot invalidation (recompute path), so the guard rarely sees them.
- Status must match too. A cached `loaded` result never masks this hook's `loading` state (and vice versa). Value equality alone isn't enough to skip adoption.
- Regression test reproduces the exact failure: an existing subscriber's result identity must survive a new subscriber mounting with the same key and selector. It fails on the previous code at the identity assertion and passes with the guard. The full `useOnyx` suite is unaffected.


Before:

<img width="1359" height="909" alt="concierge baseline" src="https://github.com/user-attachments/assets/2f595e15-5cab-43fd-86ba-0627b9086a6c" />

After:

<img width="1359" height="909" alt="concierge fixed" src="https://github.com/user-attachments/assets/47a588ae-a926-4d6c-8f9d-83b6957d6049" />

| Scenario | Before | After | Change |
| --- | ---: | ---: | ---: |
| ManualSendMessage - Concierge chat (narrow web) | 301 ms | 237 ms | -21.1% |
| ManualSendMessage - DM test | 465 ms | 336 ms | -27.7% |

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/App/issues/95584

### Linked E/App PR
<!--
Every Onyx PR must ship with a corresponding Expensify/App PR that pins Onyx to this PR's HEAD via git+https
(e.g. "react-native-onyx": "git+https://github.com/Expensify/react-native-onyx.git#<commit_sha>").
That linked PR runs the full E/App test suite signals that the Onyx
change is safe. After this PR is merged and published to npm, swap the linked E/App PR to the pinned version
(e.g. "react-native-onyx": "3.0.72") and request a final review — it becomes the bump PR.

Paste the full Expensify/App PR URL below (e.g. https://github.com/Expensify/App/pull/12345):
--> 
https://github.com/Expensify/App/pull/97952


### Automated Tests
<!---
Most changes to Onyx should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->

### Manual Tests
<!---
Each set of changes should be tested against the Expensify/App repo on all platforms to verify it does not break our staging App.
--->

No visible changes. Smoke tests:

#### Test 1: Send messages in open report
1. As account A, open Report A
2. Send 5 messages in quick succession
3. Confirm each message appears
4. Confirm the LHN row for Report A shows the last sent message as its preview

#### Test 2: Rapid report switching
1. As account A, switch between Report A and Report B 5 times quickly
2. Confirm each report shows its own content immediately
3. Confirm no report gets stuck in a loading skeleton
4. Send a message mid-switching and confirm it lands in the right report

#### Test 3: New subscriber mounts on an already-open report
1. As account A, open Report A and note its content
2. Open the report details page (header click), then a thread on any message
3. Close both and return to the report
4. As account B, send a message to Report A
5. Confirm the message appears in the open report and the LHN preview updates

#### Test 4: Report data change reaches all subscribers
1. As account A, open a group chat or workspace room
2. Rename the room (or update its description)
3. Confirm the header, the report screen, and the LHN row all show the new name
4. Pin and unpin the report and confirm the LHN reorders both times

#### Test 5: Receive messages while report is open
1. As account A, keep Report A open
2. As account B, send 3 messages to Report A, one with an edit right after sending
3. Confirm all messages and the edit appear for account A in real time
4. As account B, add a reaction to the last message and confirm it appears for account A

#### Test 6: Fresh key and loading transitions
1. As account A, sign out and sign back in
2. Open a chat that was never o
3. Confirm the skeleton is replaced by content and never gets stuck on loading
4. Start a brand-new DM with a new user and send a message
5. Confirm the new chat renders and appears in the LHN



### Author Checklist

- [x] I linked the correct issue in the `### Related Issues` section above
- [x] I linked the corresponding Expensify/App PR in the `### Linked E/App PR` section above, and verified this change against it (E/App CI passed and manual testing completed)
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos

Android: Native

Android: mWeb 

ChromeiOS: Native

iOS: mWeb Safari

MacOS: Chrome / Safari

Test 1-2:

https://github.com/user-attachments/assets/667cf6e3-b92c-42c6-956d-8c723d56a5a2

Test 3:


https://github.com/user-attachments/assets/cae34314-a866-4f26-8c29-9db5e3fdc8b3


Test 4:


https://github.com/user-attachments/assets/56efff9d-890b-4b6b-bcdf-500ba7c2266d


Test 5:


https://github.com/user-attachments/assets/15f5b04e-d287-408c-af46-54232d2055e0


Test 6:


https://github.com/user-attachments/assets/67020400-6798-4813-8ca7-fa7fee34935c

