### PR TITLE
Batch collection member removals and coalesce cross-tab sync events

### DIFF
--- a/API-INTERNAL.md
+++ b/API-INTERNAL.md
@@ -525,7 +525,6 @@ that this internal function allows passing an additional `mergeReplaceNullPatche
 | params.collectionKey | e.g. `ONYXKEYS.COLLECTION.REPORT` |
 | params.collection | Object collection keyed by individual collection member keys and values |
 | params.mergeReplaceNullPatches | Record where the key is a collection member key and the value is a list of tuples that we'll use to replace the nested objects of that collection member record with something else. |
-| params.isProcessingCollectionUpdate | whether this is part of a collection update operation. |
 | retryAttempt | retry attempt |
 
 <a name="partialSetCollection"></a>

--- a/API-INTERNAL.md
+++ b/API-INTERNAL.md
@@ -111,10 +111,11 @@ provider) once so it&#39;s visible, then bounded retry without eviction.</li>
 <dt><a href="#broadcastUpdate">broadcastUpdate()</a></dt>
 <dd><p>Notifies subscribers and writes current value to cache</p>
 </dd>
-<dt><a href="#prepareKeyValuePairsForStorage">prepareKeyValuePairsForStorage()</a> ⇒</dt>
+<dt><a href="#prepareKeyValuePairsForStorage">prepareKeyValuePairsForStorage()</a></dt>
 <dd><p>Storage expects array like: [[&quot;@MyApp_user&quot;, value_1], [&quot;@MyApp_key&quot;, value_2]]
 This method transforms an object like {&#39;@MyApp_user&#39;: myUserValue, &#39;@MyApp_key&#39;: myKeyValue}
-to an array of key-value pairs in the above format and removes key-value pairs that are being set to null</p>
+to an array of key-value pairs in the above format, and collects the keys of null values into
+<code>keysToRemove</code> for the caller to delete as one batch (cache drop + notification + batched storage removal).</p>
 </dd>
 <dt><a href="#mergeChanges">mergeChanges(changes, existingValue)</a></dt>
 <dd><p>Merges an array of changes with an existing value or creates a single change.</p>
@@ -376,13 +377,13 @@ Notifies subscribers and writes current value to cache
 **Kind**: global function  
 <a name="prepareKeyValuePairsForStorage"></a>
 
-## prepareKeyValuePairsForStorage() ⇒
+## prepareKeyValuePairsForStorage()
 Storage expects array like: [["@MyApp_user", value_1], ["@MyApp_key", value_2]]
 This method transforms an object like {'@MyApp_user': myUserValue, '@MyApp_key': myKeyValue}
-to an array of key-value pairs in the above format and removes key-value pairs that are being set to null
+to an array of key-value pairs in the above format, and collects the keys of null values into
+`keysToRemove` for the caller to delete as one batch (cache drop + notification + batched storage removal).
 
 **Kind**: global function  
-**Returns**: an array of key - value pairs <[key, value]>  
 <a name="mergeChanges"></a>
 
 ## mergeChanges(changes, existingValue)

--- a/lib/Onyx.ts
+++ b/lib/Onyx.ts
@@ -324,7 +324,7 @@ function merge<TKey extends OnyxKey>(key: TKey, changes: OnyxMergeInput<TKey>): 
  * @param collection Object collection keyed by individual collection member keys and values
  */
 function mergeCollection<TKey extends CollectionKeyBase>(collectionKey: TKey, collection: OnyxMergeCollectionInput<TKey>): Promise<void> {
-    return OnyxUtils.afterInit(() => OnyxUtils.mergeCollectionWithPatches({collectionKey, collection, isProcessingCollectionUpdate: true}));
+    return OnyxUtils.afterInit(() => OnyxUtils.mergeCollectionWithPatches({collectionKey, collection}));
 }
 
 /**
@@ -565,7 +565,6 @@ function update<TKey extends OnyxKey>(data: Array<OnyxUpdate<TKey>>): Promise<vo
                         collectionKey,
                         collection: batchedCollectionUpdates.merge as OnyxMergeCollectionInput<OnyxKey>,
                         mergeReplaceNullPatches: batchedCollectionUpdates.mergeReplaceNullPatches,
-                        isProcessingCollectionUpdate: true,
                     }),
                 );
             }

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -629,12 +629,7 @@ function keysChanged<TKey extends CollectionKeyBase>(
 /**
  * When a key change happens, search for any callbacks matching the key or collection key and trigger those callbacks
  */
-function keyChanged<TKey extends OnyxKey>(
-    key: TKey,
-    value: OnyxValue<TKey>,
-    canUpdateSubscriber: (subscriber?: CallbackToStateMapping<OnyxKey>) => boolean = () => true,
-    isProcessingCollectionUpdate = false,
-): void {
+function keyChanged<TKey extends OnyxKey>(key: TKey, value: OnyxValue<TKey>, canUpdateSubscriber: (subscriber?: CallbackToStateMapping<OnyxKey>) => boolean = () => true): void {
     // Add or remove this key from the recentlyAccessedKeys list
     if (value !== null && value !== undefined) {
         cache.addLastAccessedKey(key, OnyxKeys.isCollectionKey(key));
@@ -678,11 +673,6 @@ function keyChanged<TKey extends OnyxKey>(
                 }
 
                 if (OnyxKeys.isCollectionKey(subscriber.key)) {
-                    // Skip individual key changes during collection updates to prevent duplicate
-                    // callbacks - the collection update will handle this properly.
-                    if (isProcessingCollectionUpdate) {
-                        continue;
-                    }
                     // Cache once per dispatch to ensure all subscribers see a consistent snapshot
                     // even if a previous callback synchronously wrote to the same collection.
                     let cachedCollection = cachedCollections[subscriber.key];
@@ -761,9 +751,9 @@ function getCollectionDataAndSendAsObject<TKey extends OnyxKey>(matchingKeys: Co
 /**
  * Remove a key from Onyx and update the subscribers
  */
-function remove<TKey extends OnyxKey>(key: TKey, isProcessingCollectionUpdate?: boolean): Promise<void> {
+function remove<TKey extends OnyxKey>(key: TKey): Promise<void> {
     cache.drop(key);
-    keyChanged(key, undefined as OnyxValue<TKey>, undefined, isProcessingCollectionUpdate);
+    keyChanged(key, undefined as OnyxValue<TKey>);
 
     if (OnyxKeys.isRamOnlyKey(key)) {
         return Promise.resolve();
@@ -1413,7 +1403,12 @@ function multiSetWithRetry(data: OnyxMultiSetInput, retryAttempt?: number): Prom
         }, {});
     }
 
-    const {pairs: keyValuePairsToSet, keysToRemove} = OnyxUtils.prepareKeyValuePairsForStorage(newData, true);
+    const {pairs: keyValuePairsToSet, keysToRemove: removalCandidates} = OnyxUtils.prepareKeyValuePairsForStorage(newData, true);
+
+    // Removals of keys that are neither cached nor persisted are no-ops and skipped. When the key
+    // index has not been loaded yet (empty set), keep the removal to be safe.
+    const persistedKeys = cache.getAllKeys();
+    const keysToRemove = removalCandidates.filter((key) => cache.get(key) !== undefined || persistedKeys.size === 0 || persistedKeys.has(key));
 
     // Group collection members by their parent collection key so each collection can be notified
     // via a single batched keysChanged() call instead of one keyChanged() per member. For each
@@ -1500,9 +1495,10 @@ function multiSetWithRetry(data: OnyxMultiSetInput, retryAttempt?: number): Prom
 
     const inFlightKeys = new Set<OnyxKey>(keyValuePairsToSet.map(([key]) => key));
 
+    // A failed removal is logged, not retried — keysToRemove cannot be re-derived after the cache update.
     const storagePromises = [Storage.multiSet(keyValuePairsToStore)];
     if (keysToRemoveFromStorage.length > 0) {
-        storagePromises.push(Storage.removeItems(keysToRemoveFromStorage));
+        storagePromises.push(Storage.removeItems(keysToRemoveFromStorage).catch((error) => Logger.logAlert(`multiSet failed to remove keys from storage. Error: ${error}`)));
     }
 
     return Promise.all(storagePromises)
@@ -1578,7 +1574,9 @@ function setCollectionWithRetry<TKey extends CollectionKeyBase>({collectionKey, 
         // Skip subscriber notification on retry — already notified on attempt 0.
         // Collection-root subscribers re-fire on every keysChanged by contract.
         if (!retryAttempt) {
-            keysChanged(collectionKey, mutableCollection, previousCollection);
+            // Removed members are notified as undefined, matching mergeCollection/multiSet.
+            const partialForNotify = Object.fromEntries(Object.entries(mutableCollection).map(([key, value]) => [key, value ?? undefined]));
+            keysChanged(collectionKey, partialForNotify, previousCollection);
         }
 
         // RAM-only keys are not supposed to be saved to storage
@@ -1589,10 +1587,11 @@ function setCollectionWithRetry<TKey extends CollectionKeyBase>({collectionKey, 
 
         const inFlightKeys = new Set<OnyxKey>(keyValuePairs.map(([key]) => key));
 
-        // One batched removal = one cross-tab sync event instead of one per key.
+        // One batched removal = one cross-tab sync event instead of one per key. A failed removal is
+        // logged, not retried — keysToRemove cannot be re-derived after the cache update.
         const storagePromises = [Storage.multiSet(keyValuePairs)];
         if (keysToRemove.length > 0) {
-            storagePromises.push(Storage.removeItems(keysToRemove));
+            storagePromises.push(Storage.removeItems(keysToRemove).catch((error) => Logger.logAlert(`setCollection failed to remove keys from storage. Error: ${error}`)));
         }
 
         return Promise.all(storagePromises)
@@ -1614,11 +1613,10 @@ function setCollectionWithRetry<TKey extends CollectionKeyBase>({collectionKey, 
  * @param params.collection Object collection keyed by individual collection member keys and values
  * @param params.mergeReplaceNullPatches Record where the key is a collection member key and the value is a list of
  * tuples that we'll use to replace the nested objects of that collection member record with something else.
- * @param params.isProcessingCollectionUpdate whether this is part of a collection update operation.
  * @param retryAttempt retry attempt
  */
 function mergeCollectionWithPatches<TKey extends CollectionKeyBase>(
-    {collectionKey, collection, mergeReplaceNullPatches, isProcessingCollectionUpdate = false}: MergeCollectionWithPatchesParams<TKey>,
+    {collectionKey, collection, mergeReplaceNullPatches}: MergeCollectionWithPatchesParams<TKey>,
     retryAttempt?: number,
 ): Promise<void> {
     if (!isValidNonEmptyCollectionForMerge(collection)) {
@@ -1666,6 +1664,21 @@ function mergeCollectionWithPatches<TKey extends CollectionKeyBase>(
                 }
                 return true;
             });
+
+            // Drop removed members before the pre-warm await below, so a concurrent write to one of
+            // these keys during the pre-warm is not wiped out by a late drop.
+            const removedPreviousValues: OnyxInputKeyValueMapping = {};
+            for (const key of keysToRemove) {
+                removedPreviousValues[key] = cache.get(key);
+                cache.drop(key);
+            }
+
+            // One batched removal = one cross-tab sync event instead of one per key. Issued at drop time
+            // so a concurrent later write to a removed key persists after the removal.
+            const removalPromise =
+                !OnyxKeys.isRamOnlyKey(collectionKey) && keysToRemove.length > 0
+                    ? Storage.removeItems(keysToRemove).catch((error) => Logger.logAlert(`mergeCollection failed to remove keys from storage. Error: ${error}`))
+                    : undefined;
 
             const existingKeys = keys.filter((key) => persistedKeys.has(key));
 
@@ -1735,14 +1748,6 @@ function mergeCollectionWithPatches<TKey extends CollectionKeyBase>(
                 // write fails.
                 const previousCollection = getCachedCollection(collectionKey, existingKeys);
 
-                // Removed members join the same keysChanged() batch (as undefined); previous values
-                // are snapshotted before the cache drop so keysChanged() can diff them.
-                const removedPreviousValues: OnyxInputKeyValueMapping = {};
-                for (const key of keysToRemove) {
-                    removedPreviousValues[key] = cache.get(key);
-                    cache.drop(key);
-                }
-
                 cache.merge(finalMergedCollection);
                 // Skip subscriber notification on retry — already notified on attempt 0.
                 // Collection-root subscribers re-fire on every keysChanged by contract.
@@ -1756,9 +1761,8 @@ function mergeCollectionWithPatches<TKey extends CollectionKeyBase>(
 
                 const promises = [];
 
-                // One batched removal = one cross-tab sync event instead of one per key.
-                if (!OnyxKeys.isRamOnlyKey(collectionKey) && keysToRemove.length > 0) {
-                    promises.push(Storage.removeItems(keysToRemove));
+                if (removalPromise) {
+                    promises.push(removalPromise);
                 }
 
                 // New keys go through multiSet and existing keys through multiMerge. multiMerge on a
@@ -1786,7 +1790,6 @@ function mergeCollectionWithPatches<TKey extends CollectionKeyBase>(
                                 collectionKey,
                                 collection: resultCollection as OnyxMergeCollectionInput<TKey>,
                                 mergeReplaceNullPatches,
-                                isProcessingCollectionUpdate,
                             },
                             retryAttempt,
                             inFlightKeys,
@@ -1853,7 +1856,9 @@ function partialSetCollection<TKey extends CollectionKeyBase>({collectionKey, co
         // Skip subscriber notification on retry — already notified on attempt 0.
         // Collection-root subscribers re-fire on every keysChanged by contract.
         if (!retryAttempt) {
-            keysChanged(collectionKey, mutableCollection, previousCollection);
+            // Removed members are notified as undefined, matching mergeCollection/multiSet.
+            const partialForNotify = Object.fromEntries(Object.entries(mutableCollection).map(([key, value]) => [key, value ?? undefined]));
+            keysChanged(collectionKey, partialForNotify, previousCollection);
         }
 
         if (OnyxKeys.isRamOnlyKey(collectionKey)) {
@@ -1863,10 +1868,11 @@ function partialSetCollection<TKey extends CollectionKeyBase>({collectionKey, co
 
         const inFlightKeys = new Set<OnyxKey>(keyValuePairs.map(([key]) => key));
 
-        // One batched removal = one cross-tab sync event instead of one per key.
+        // One batched removal = one cross-tab sync event instead of one per key. A failed removal is
+        // logged, not retried — keysToRemove cannot be re-derived after the cache update.
         const storagePromises = [Storage.multiSet(keyValuePairs)];
         if (keysToRemove.length > 0) {
-            storagePromises.push(Storage.removeItems(keysToRemove));
+            storagePromises.push(Storage.removeItems(keysToRemove).catch((error) => Logger.logAlert(`setCollection failed to remove keys from storage. Error: ${error}`)));
         }
 
         return Promise.all(storagePromises)

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -64,6 +64,12 @@ function resetDiskPressureLogThrottle(): void {
 
 type OnyxMethod = ValueOf<typeof METHOD>;
 
+/** Result of `prepareKeyValuePairsForStorage`: pairs to write and keys whose `null` value marks them for removal. */
+type PreparedKeyValuePairs = {
+    pairs: StorageKeyValuePair[];
+    keysToRemove: OnyxKey[];
+};
+
 // Key/value store of Onyx key and arrays of values to merge
 let mergeQueue: Record<OnyxKey, Array<OnyxValue<OnyxKey>>> = {};
 let mergeQueuePromise: Record<OnyxKey, Promise<void>> = {};
@@ -919,21 +925,20 @@ function hasPendingMergeForKey(key: OnyxKey): boolean {
 /**
  * Storage expects array like: [["@MyApp_user", value_1], ["@MyApp_key", value_2]]
  * This method transforms an object like {'@MyApp_user': myUserValue, '@MyApp_key': myKeyValue}
- * to an array of key-value pairs in the above format and removes key-value pairs that are being set to null
- *
- * @return an array of key - value pairs <[key, value]>
+ * to an array of key-value pairs in the above format, and collects the keys of null values into
+ * `keysToRemove` for the caller to delete as one batch (cache drop + notification + batched storage removal).
  */
 function prepareKeyValuePairsForStorage(
     data: Record<OnyxKey, OnyxInput<OnyxKey>>,
     shouldRemoveNestedNulls?: boolean,
     replaceNullPatches?: MultiMergeReplaceNullPatches,
-    isProcessingCollectionUpdate?: boolean,
-): StorageKeyValuePair[] {
+): PreparedKeyValuePairs {
     const pairs: StorageKeyValuePair[] = [];
+    const keysToRemove: OnyxKey[] = [];
 
     for (const [key, value] of Object.entries(data)) {
         if (value === null) {
-            remove(key, isProcessingCollectionUpdate);
+            keysToRemove.push(key);
             continue;
         }
 
@@ -944,7 +949,7 @@ function prepareKeyValuePairsForStorage(
         }
     }
 
-    return pairs;
+    return {pairs, keysToRemove};
 }
 
 /**
@@ -1408,7 +1413,7 @@ function multiSetWithRetry(data: OnyxMultiSetInput, retryAttempt?: number): Prom
         }, {});
     }
 
-    const keyValuePairsToSet = OnyxUtils.prepareKeyValuePairsForStorage(newData, true);
+    const {pairs: keyValuePairsToSet, keysToRemove} = OnyxUtils.prepareKeyValuePairsForStorage(newData, true);
 
     // Group collection members by their parent collection key so each collection can be notified
     // via a single batched keysChanged() call instead of one keyChanged() per member. For each
@@ -1456,6 +1461,27 @@ function multiSetWithRetry(data: OnyxMultiSetInput, retryAttempt?: number): Prom
         }
     }
 
+    // Null keys join the same per-collection batches (as undefined) and are deleted from storage
+    // in one batched call below, so cross-tab sync raises a single event instead of one per key.
+    for (const key of keysToRemove) {
+        const previousValue = cache.get(key);
+        cache.drop(key);
+
+        const collectionKey = OnyxKeys.getCollectionKey(key);
+        if (collectionKey && OnyxKeys.isCollectionMemberKey(collectionKey, key)) {
+            let batch = collectionBatches.get(collectionKey);
+            if (!batch) {
+                batch = {partial: {}, previous: {}};
+                collectionBatches.set(collectionKey, batch);
+            }
+            batch.partial[key] = undefined;
+            batch.previous[key] = previousValue;
+        } else if (!retryAttempt) {
+            // Skip subscriber notification on retry — already notified on attempt 0.
+            keyChanged(key, undefined);
+        }
+    }
+
     // One keysChanged() per collection — fires each collection-level subscriber once and lets
     // keysChanged() internally decide which individual member subscribers need notification.
     // Skip on retry — already notified on attempt 0 (see same-reason comment above).
@@ -1470,10 +1496,16 @@ function multiSetWithRetry(data: OnyxMultiSetInput, retryAttempt?: number): Prom
         // Filter out the RAM-only key value pairs, as they should not be saved to storage
         return !OnyxKeys.isRamOnlyKey(key);
     });
+    const keysToRemoveFromStorage = keysToRemove.filter((key) => !OnyxKeys.isRamOnlyKey(key));
 
     const inFlightKeys = new Set<OnyxKey>(keyValuePairsToSet.map(([key]) => key));
 
-    return Storage.multiSet(keyValuePairsToStore)
+    const storagePromises = [Storage.multiSet(keyValuePairsToStore)];
+    if (keysToRemoveFromStorage.length > 0) {
+        storagePromises.push(Storage.removeItems(keysToRemoveFromStorage));
+    }
+
+    return Promise.all(storagePromises)
         .then(() => StorageCircuitBreaker.recordWriteSuccess())
         .catch((error) => OnyxUtils.retryOperation(error, multiSetWithRetry, newData, retryAttempt, inFlightKeys))
         .then(() => {
@@ -1534,10 +1566,14 @@ function setCollectionWithRetry<TKey extends CollectionKeyBase>({collectionKey, 
             mutableCollection[key] = null;
         }
 
-        const keyValuePairs = OnyxUtils.prepareKeyValuePairsForStorage(mutableCollection, true, undefined, true);
+        const {pairs: keyValuePairs, keysToRemove: removalCandidates} = OnyxUtils.prepareKeyValuePairsForStorage(mutableCollection, true);
+        // Removals of keys that are neither cached nor persisted are no-ops and skipped.
+        const keysToRemove = removalCandidates.filter((key) => cache.get(key) !== undefined || persistedKeys.has(key));
+        // Snapshot before cache mutations so keysChanged() can diff removed members.
         const previousCollection = OnyxUtils.getCachedCollection(collectionKey);
 
         for (const [key, value] of keyValuePairs) cache.set(key, value);
+        for (const key of keysToRemove) cache.drop(key);
 
         // Skip subscriber notification on retry — already notified on attempt 0.
         // Collection-root subscribers re-fire on every keysChanged by contract.
@@ -1553,7 +1589,13 @@ function setCollectionWithRetry<TKey extends CollectionKeyBase>({collectionKey, 
 
         const inFlightKeys = new Set<OnyxKey>(keyValuePairs.map(([key]) => key));
 
-        return Storage.multiSet(keyValuePairs)
+        // One batched removal = one cross-tab sync event instead of one per key.
+        const storagePromises = [Storage.multiSet(keyValuePairs)];
+        if (keysToRemove.length > 0) {
+            storagePromises.push(Storage.removeItems(keysToRemove));
+        }
+
+        return Promise.all(storagePromises)
             .then(() => StorageCircuitBreaker.recordWriteSuccess())
             .catch((error) => OnyxUtils.retryOperation(error, setCollectionWithRetry, {collectionKey, collection}, retryAttempt, inFlightKeys))
             .then(() => {
@@ -1612,10 +1654,14 @@ function mergeCollectionWithPatches<TKey extends CollectionKeyBase>(
 
     return getAllKeys()
         .then((persistedKeys) => {
-            // Split to keys that exist in storage and keys that don't
+            // Split to keys that exist in storage and keys that don't. Null members are collected
+            // for one batched removal below; nulls that are neither cached nor persisted are no-ops and skipped.
+            const keysToRemove: OnyxKey[] = [];
             const keys = resultCollectionKeys.filter((key) => {
                 if (resultCollection[key] === null) {
-                    remove(key, isProcessingCollectionUpdate);
+                    if (cache.get(key) !== undefined || persistedKeys.has(key)) {
+                        keysToRemove.push(key);
+                    }
                     return false;
                 }
                 return true;
@@ -1658,11 +1704,11 @@ function mergeCollectionWithPatches<TKey extends CollectionKeyBase>(
             // When (multi-)merging the values with the existing values in storage,
             // we don't want to remove nested null values from the data that we pass to the storage layer,
             // because the storage layer uses them to remove nested keys from storage natively.
-            const keyValuePairsForExistingCollection = prepareKeyValuePairsForStorage(existingKeyCollection, false, mergeReplaceNullPatches);
+            const {pairs: keyValuePairsForExistingCollection} = prepareKeyValuePairsForStorage(existingKeyCollection, false, mergeReplaceNullPatches);
 
             // We can safely remove nested null values when using (multi-)set,
             // because we will simply overwrite the existing values in storage.
-            const keyValuePairsForNewCollection = prepareKeyValuePairsForStorage(newCollection, true);
+            const {pairs: keyValuePairsForNewCollection} = prepareKeyValuePairsForStorage(newCollection, true);
 
             // finalMergedCollection contains all the keys that were merged, without the keys of incompatible updates
             const finalMergedCollection = {
@@ -1688,14 +1734,32 @@ function mergeCollectionWithPatches<TKey extends CollectionKeyBase>(
                 // ensuring subscribers still reflect the merged data even if the subsequent storage
                 // write fails.
                 const previousCollection = getCachedCollection(collectionKey, existingKeys);
+
+                // Removed members join the same keysChanged() batch (as undefined); previous values
+                // are snapshotted before the cache drop so keysChanged() can diff them.
+                const removedPreviousValues: OnyxInputKeyValueMapping = {};
+                for (const key of keysToRemove) {
+                    removedPreviousValues[key] = cache.get(key);
+                    cache.drop(key);
+                }
+
                 cache.merge(finalMergedCollection);
                 // Skip subscriber notification on retry — already notified on attempt 0.
                 // Collection-root subscribers re-fire on every keysChanged by contract.
                 if (!retryAttempt) {
-                    keysChanged(collectionKey, finalMergedCollection, previousCollection);
+                    const partialForNotify = keysToRemove.length > 0 ? {...finalMergedCollection, ...Object.fromEntries(keysToRemove.map((key) => [key, undefined]))} : finalMergedCollection;
+                    const previousForNotify = keysToRemove.length > 0 ? {...previousCollection, ...removedPreviousValues} : previousCollection;
+                    if (Object.keys(partialForNotify).length > 0) {
+                        keysChanged(collectionKey, partialForNotify, previousForNotify);
+                    }
                 }
 
                 const promises = [];
+
+                // One batched removal = one cross-tab sync event instead of one per key.
+                if (!OnyxKeys.isRamOnlyKey(collectionKey) && keysToRemove.length > 0) {
+                    promises.push(Storage.removeItems(keysToRemove));
+                }
 
                 // New keys go through multiSet and existing keys through multiMerge. multiMerge on a
                 // missing key stores the value just like multiSet across all backends; splitting them lets
@@ -1777,10 +1841,14 @@ function partialSetCollection<TKey extends CollectionKeyBase>({collectionKey, co
     return getAllKeys().then((persistedKeys) => {
         const mutableCollection: OnyxInputKeyValueMapping = {...resultCollection};
         const existingKeys = resultCollectionKeys.filter((key) => persistedKeys.has(key));
+        const {pairs: keyValuePairs, keysToRemove: removalCandidates} = prepareKeyValuePairsForStorage(mutableCollection, true);
+        // Removals of keys that are neither cached nor persisted are no-ops and skipped.
+        const keysToRemove = removalCandidates.filter((key) => cache.get(key) !== undefined || persistedKeys.has(key));
+        // Snapshot before cache mutations so keysChanged() can diff removed members.
         const previousCollection = getCachedCollection(collectionKey, existingKeys);
-        const keyValuePairs = prepareKeyValuePairsForStorage(mutableCollection, true, undefined, true);
 
         for (const [key, value] of keyValuePairs) cache.set(key, value);
+        for (const key of keysToRemove) cache.drop(key);
 
         // Skip subscriber notification on retry — already notified on attempt 0.
         // Collection-root subscribers re-fire on every keysChanged by contract.
@@ -1795,7 +1863,13 @@ function partialSetCollection<TKey extends CollectionKeyBase>({collectionKey, co
 
         const inFlightKeys = new Set<OnyxKey>(keyValuePairs.map(([key]) => key));
 
-        return Storage.multiSet(keyValuePairs)
+        // One batched removal = one cross-tab sync event instead of one per key.
+        const storagePromises = [Storage.multiSet(keyValuePairs)];
+        if (keysToRemove.length > 0) {
+            storagePromises.push(Storage.removeItems(keysToRemove));
+        }
+
+        return Promise.all(storagePromises)
             .then(() => StorageCircuitBreaker.recordWriteSuccess())
             .catch((error) => retryOperation(error, partialSetCollection, {collectionKey, collection}, retryAttempt, inFlightKeys))
             .then(() => {

--- a/lib/storage/InstanceSync/index.web.ts
+++ b/lib/storage/InstanceSync/index.web.ts
@@ -100,6 +100,10 @@ const InstanceSync = {
     init: (onStorageKeysChanged: OnStorageKeysChanged, store: StorageProvider<unknown>) => {
         storage = store;
 
+        // Coalesce storage events into one dispatch per tick: a per-key sender would otherwise re-run
+        // the whole notification pipeline once per key and can flood the receiving tab into unresponsiveness.
+        let pendingSyncKeys: Set<OnyxKey> | null = null;
+
         // This listener will only be triggered by events coming from other tabs
         global.addEventListener('storage', (event) => {
             // Ignore events that don't originate from the SYNC_ONYX logic
@@ -109,7 +113,19 @@ const InstanceSync = {
 
             const onyxKeys = parseSyncOnyxStorageEventValue(event.newValue);
 
-            storage.multiGet(onyxKeys).then((pairs) => onStorageKeysChanged(pairs));
+            if (pendingSyncKeys) {
+                for (const onyxKey of onyxKeys) {
+                    pendingSyncKeys.add(onyxKey);
+                }
+                return;
+            }
+
+            pendingSyncKeys = new Set(onyxKeys);
+            setTimeout(() => {
+                const keys = Array.from(pendingSyncKeys ?? []);
+                pendingSyncKeys = null;
+                storage.multiGet(keys).then((pairs) => onStorageKeysChanged(pairs));
+            }, 0);
         });
     },
     setItem: raiseStorageSyncEvent,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -342,7 +342,6 @@ type MergeCollectionWithPatchesParams<TKey extends CollectionKeyBase> = {
     collectionKey: TKey;
     collection: OnyxMergeCollectionInput<TKey>;
     mergeReplaceNullPatches?: MultiMergeReplaceNullPatches;
-    isProcessingCollectionUpdate?: boolean;
 };
 
 type RetriableOnyxOperation =

--- a/tests/unit/onyxTest.ts
+++ b/tests/unit/onyxTest.ts
@@ -3110,6 +3110,63 @@ describe('Onyx', () => {
             expect(StorageMock.removeItems).toHaveBeenCalledWith([ONYX_KEYS.OTHER_TEST]);
             expect(cache.get(ONYX_KEYS.OTHER_TEST)).toBeUndefined();
         });
+
+        it('multiSet skips removals of keys that are neither cached nor persisted', async () => {
+            const routeMissing = `${ONYX_KEYS.COLLECTION.ROUTES}Missing`;
+            await Onyx.multiSet({[ONYX_KEYS.OTHER_TEST]: 42});
+
+            (StorageMock.removeItem as jest.Mock).mockClear();
+            (StorageMock.removeItems as jest.Mock).mockClear();
+
+            // Nulling a key that was never stored must not raise any storage removal.
+            await Onyx.multiSet({[routeMissing]: null, [ONYX_KEYS.OTHER_TEST]: 43});
+
+            expect(StorageMock.removeItem).not.toHaveBeenCalled();
+            expect(StorageMock.removeItems).not.toHaveBeenCalled();
+        });
+
+        it('mergeCollection removal does not wipe out a concurrent write issued during the pre-warm read', async () => {
+            await Onyx.mergeCollection(ONYX_KEYS.COLLECTION.ROUTES, {
+                [routeA]: {a: 1},
+                [routeB]: {b: 1},
+            } as GenericCollection);
+
+            // Evict both members' values (their keys stay indexed) so the merge below takes the slow
+            // pre-warm path and awaits a real storage read before applying.
+            cache.set(routeA, undefined);
+            cache.set(routeB, undefined);
+
+            const removal = Onyx.mergeCollection(ONYX_KEYS.COLLECTION.ROUTES, {
+                [routeA]: null,
+                [routeB]: {b: 2},
+            } as GenericCollection);
+            const concurrent = Onyx.merge(routeA, {y: 2});
+            await Promise.all([removal, concurrent]);
+
+            // The merge was issued after the removal, so it must win in both cache and storage.
+            expect(cache.get(routeA)).toEqual(expect.objectContaining({y: 2}));
+            const persisted = await StorageMock.getItem(routeA);
+            expect(persisted).toEqual(expect.objectContaining({y: 2}));
+        });
+
+        it('does not re-run the whole write when only the batched removal fails', async () => {
+            await Onyx.mergeCollection(ONYX_KEYS.COLLECTION.ROUTES, {
+                [routeA]: {name: 'Route A'},
+                [routeB]: {name: 'Route B'},
+            } as GenericCollection);
+
+            (StorageMock.multiSet as jest.Mock).mockClear();
+            (StorageMock.removeItems as jest.Mock).mockImplementationOnce(() => Promise.reject(new Error('storage removal failed')));
+
+            // routeB is missing from the new collection, so its removal is attempted and fails.
+            await Onyx.setCollection(ONYX_KEYS.COLLECTION.ROUTES, {
+                [routeA]: {name: 'New Route A'},
+            } as GenericCollection);
+
+            // The failed removal must not trigger a retry of the (already successful) multiSet.
+            expect(StorageMock.multiSet).toHaveBeenCalledTimes(1);
+            expect(cache.get(routeB)).toBeUndefined();
+        });
     });
 
     describe('clear', () => {

--- a/tests/unit/onyxTest.ts
+++ b/tests/unit/onyxTest.ts
@@ -2981,6 +2981,111 @@ describe('Onyx', () => {
         });
     });
 
+    describe('batched collection member removals', () => {
+        const routeA = `${ONYX_KEYS.COLLECTION.ROUTES}A`;
+        const routeB = `${ONYX_KEYS.COLLECTION.ROUTES}B`;
+
+        it('mergeCollection deletes null members from cache and storage via one batched removeItems call', async () => {
+            await Onyx.mergeCollection(ONYX_KEYS.COLLECTION.ROUTES, {
+                [routeA]: {name: 'Route A'},
+                [routeB]: {name: 'Route B'},
+            } as GenericCollection);
+
+            (StorageMock.removeItem as jest.Mock).mockClear();
+            (StorageMock.removeItems as jest.Mock).mockClear();
+
+            await Onyx.mergeCollection(ONYX_KEYS.COLLECTION.ROUTES, {
+                [routeA]: null,
+                [routeB]: {name: 'Route B v2'},
+            } as GenericCollection);
+
+            // Per-key removals would raise one cross-tab sync event per member; the batch must persist in one call.
+            expect(StorageMock.removeItem).not.toHaveBeenCalled();
+            expect(StorageMock.removeItems).toHaveBeenCalledTimes(1);
+            expect(StorageMock.removeItems).toHaveBeenCalledWith([routeA]);
+
+            expect(cache.get(routeA)).toBeUndefined();
+            const keys = await OnyxUtils.getAllKeys();
+            expect(keys.has(routeA)).toBe(false);
+            expect(keys.has(routeB)).toBe(true);
+        });
+
+        it('mergeCollection notifies member subscribers about batched removals', async () => {
+            await Onyx.mergeCollection(ONYX_KEYS.COLLECTION.ROUTES, {
+                [routeA]: {name: 'Route A'},
+            } as GenericCollection);
+
+            let received: unknown = 'sentinel';
+            connection = Onyx.connect({
+                key: routeA,
+                callback: (value) => (received = value),
+            });
+            await waitForPromisesToResolve();
+            expect(received).toEqual({name: 'Route A'});
+
+            await Onyx.mergeCollection(ONYX_KEYS.COLLECTION.ROUTES, {
+                [routeA]: null,
+            } as GenericCollection);
+
+            expect(received).toBeUndefined();
+        });
+
+        it('mergeCollection skips removals of members that are neither cached nor persisted', async () => {
+            const routeMissing = `${ONYX_KEYS.COLLECTION.ROUTES}Missing`;
+
+            await Onyx.mergeCollection(ONYX_KEYS.COLLECTION.ROUTES, {
+                [routeA]: {name: 'Route A'},
+            } as GenericCollection);
+
+            (StorageMock.removeItem as jest.Mock).mockClear();
+            (StorageMock.removeItems as jest.Mock).mockClear();
+
+            // Nulling a member that was never stored must not raise any storage removal.
+            await Onyx.mergeCollection(ONYX_KEYS.COLLECTION.ROUTES, {
+                [routeMissing]: null,
+                [routeA]: {name: 'Route A v2'},
+            } as GenericCollection);
+
+            expect(StorageMock.removeItem).not.toHaveBeenCalled();
+            expect(StorageMock.removeItems).not.toHaveBeenCalled();
+        });
+
+        it('setCollection deletes missing members via one batched removeItems call', async () => {
+            await Onyx.mergeCollection(ONYX_KEYS.COLLECTION.ROUTES, {
+                [routeA]: {name: 'Route A'},
+                [routeB]: {name: 'Route B'},
+            } as GenericCollection);
+
+            (StorageMock.removeItem as jest.Mock).mockClear();
+            (StorageMock.removeItems as jest.Mock).mockClear();
+
+            await Onyx.setCollection(ONYX_KEYS.COLLECTION.ROUTES, {
+                [routeA]: {name: 'New Route A'},
+            } as GenericCollection);
+
+            expect(StorageMock.removeItem).not.toHaveBeenCalled();
+            expect(StorageMock.removeItems).toHaveBeenCalledTimes(1);
+            expect(StorageMock.removeItems).toHaveBeenCalledWith([routeB]);
+
+            const keys = await OnyxUtils.getAllKeys();
+            expect(keys.has(routeB)).toBe(false);
+        });
+
+        it('multiSet deletes null keys via one batched removeItems call', async () => {
+            await Onyx.multiSet({[ONYX_KEYS.OTHER_TEST]: 42});
+
+            (StorageMock.removeItem as jest.Mock).mockClear();
+            (StorageMock.removeItems as jest.Mock).mockClear();
+
+            await Onyx.multiSet({[ONYX_KEYS.OTHER_TEST]: null});
+
+            expect(StorageMock.removeItem).not.toHaveBeenCalled();
+            expect(StorageMock.removeItems).toHaveBeenCalledTimes(1);
+            expect(StorageMock.removeItems).toHaveBeenCalledWith([ONYX_KEYS.OTHER_TEST]);
+            expect(cache.get(ONYX_KEYS.OTHER_TEST)).toBeUndefined();
+        });
+    });
+
     describe('clear', () => {
         it('should handle RAM-only keys with defaults correctly during clear', async () => {
             // Set a value for RAM-only key

--- a/tests/unit/onyxTest.ts
+++ b/tests/unit/onyxTest.ts
@@ -3071,6 +3071,32 @@ describe('Onyx', () => {
             expect(keys.has(routeB)).toBe(false);
         });
 
+        it('notifies member subscribers when a cached-only (RAM-only) member is removed via a batched set', async () => {
+            const ramKey = `${ONYX_KEYS.COLLECTION.RAM_ONLY_COLLECTION}removal`;
+
+            await Onyx.mergeCollection(ONYX_KEYS.COLLECTION.RAM_ONLY_COLLECTION, {
+                [ramKey]: {name: 'RAM member'},
+            } as GenericCollection);
+
+            let received: unknown = 'sentinel';
+            connection = Onyx.connect({
+                key: ramKey,
+                callback: (value) => (received = value),
+            });
+            await waitForPromisesToResolve();
+            expect(received).toEqual({name: 'RAM member'});
+
+            // Two set updates on members of the same collection are batched into partialSetCollection,
+            // where the removed member exists only in cache (RAM-only keys are never persisted).
+            const ramKeyOther = `${ONYX_KEYS.COLLECTION.RAM_ONLY_COLLECTION}other`;
+            await Onyx.update([
+                {onyxMethod: Onyx.METHOD.SET, key: ramKey, value: null},
+                {onyxMethod: Onyx.METHOD.SET, key: ramKeyOther, value: {name: 'other'}},
+            ]);
+
+            expect(received).toBeUndefined();
+        });
+
         it('multiSet deletes null keys via one batched removeItems call', async () => {
             await Onyx.multiSet({[ONYX_KEYS.OTHER_TEST]: 42});
 

--- a/tests/unit/storage/instanceSyncWebTest.ts
+++ b/tests/unit/storage/instanceSyncWebTest.ts
@@ -109,6 +109,34 @@ describe('InstanceSync (web)', () => {
             expect(multiGet).toHaveBeenCalledWith(['123']);
         });
 
+        it('coalesces a burst of storage events into one multiGet and one dispatch', async () => {
+            // A tab running an older bundle emits one event per key; the burst must collapse into one batch.
+            storageEventHandler({key: SYNC_ONYX, newValue: 'test_1'});
+            storageEventHandler({key: SYNC_ONYX, newValue: JSON.stringify(['test_2', 'test_3'])});
+            storageEventHandler({key: SYNC_ONYX, newValue: 'test_2'});
+            await waitForPromisesToResolve();
+
+            expect(multiGet).toHaveBeenCalledTimes(1);
+            expect(multiGet).toHaveBeenCalledWith(['test_1', 'test_2', 'test_3']);
+            expect(onStorageKeysChanged).toHaveBeenCalledTimes(1);
+            expect(onStorageKeysChanged).toHaveBeenCalledWith([
+                ['test_1', 'value_of_test_1'],
+                ['test_2', 'value_of_test_2'],
+                ['test_3', 'value_of_test_3'],
+            ]);
+        });
+
+        it('dispatches separate batches for separate bursts', async () => {
+            storageEventHandler({key: SYNC_ONYX, newValue: 'test_1'});
+            await waitForPromisesToResolve();
+            storageEventHandler({key: SYNC_ONYX, newValue: 'test_2'});
+            await waitForPromisesToResolve();
+
+            expect(multiGet).toHaveBeenCalledTimes(2);
+            expect(multiGet).toHaveBeenNthCalledWith(1, ['test_1']);
+            expect(multiGet).toHaveBeenNthCalledWith(2, ['test_2']);
+        });
+
         it('ignores storage events that are not SYNC_ONYX', async () => {
             storageEventHandler({key: 'someOtherKey', newValue: 'test_1'});
             storageEventHandler({key: SYNC_ONYX, newValue: null});


### PR DESCRIPTION
### Details

Fixes the two tabs with a heavy account crash both tabs

**Root cause.** A collection write (`mergeCollection`/`multiSet`/`setCollection`/`partialSetCollection`) persists its non-null members in one batched `multiMerge`/`multiSet` call (one cross-tab `SYNC_ONYX` event), but every `null` member went through `remove(key)` individually — one storage call and one cross-tab event **per removed key**, with no check that the key even exists. On a heavy account, OpenApp's `transactionViolations_` mergeCollection contains ~2,000 `null` members on **every boot** (keys that were never stored, so the removals are pure no-ops). Each refresh therefore flooded the other tab with ~2,000 single-key events; each event is its own macrotask, so the receiving tab ran one `keysChanged` → one derived-value recompute (`reportAttributes`, `reportTransactionsAndViolations`) → one `Onyx.set` of an MB-sized derived value **per event**, saturating the main thread for ~1 minute and broadcasting ~4,000 derived-key events back to the first tab, which then performed ~4,000 IndexedDB reads of those MB-sized values. On Applause-sized accounts both tabs run out of memory and crash.

**Fix (two layers):**

1. **Sender — batch and skip removals.** `prepareKeyValuePairsForStorage` no longer removes null keys as a side effect; it returns them as `keysToRemove`. All four collection-write paths now:
   - skip removals that are complete no-ops (key neither cached nor persisted);
   - fold real removals into the existing single `keysChanged()` batch (as `undefined`, with previous values snapshotted for the diff);
   - delete them from storage with **one** `Storage.removeItems()` call, which raises **one** cross-tab event for the whole batch.
2. **Receiver — coalesce event floods.** `InstanceSync` (web) now buffers incoming `SYNC_ONYX` storage events and flushes once per tick (single `multiGet` + single dispatch). A tab still running an older bundle during a deploy emits one event per key; the flush timer is scheduled on the first event of the burst, so every event already in the task queue joins one batch instead of re-running the notification pipeline per key.

**Measured on a heavy (Applause) account, two tabs, per boot:** cross-tab events 1,971 → 41 (zero per-key `transactionViolations_` events); derived-value writes in the other tab 3,891 → 8; no crash; pin/draft/read-unread/message sync, a 19.5 MB state import, and Clear cache and restart all work across tabs without refresh.

### Related Issues

https://github.com/Expensify/App/issues/94839

### Linked E/App PR

https://github.com/Expensify/App/pull/98121

### Automated Tests

- `tests/unit/onyxTest.ts` — new `describe('batched collection member removals')`:
  - `mergeCollection` deletes null members from cache and storage via one batched `removeItems` call (and never per-key `removeItem`);
  - member subscribers are notified about batched removals (`undefined` delivered);
  - removals of members that are neither cached nor persisted are skipped entirely;
  - `setCollection` deletes missing members via one batched `removeItems` call;
  - `multiSet` deletes null keys via one batched `removeItems` call.
- `tests/unit/storage/instanceSyncWebTest.ts` — new coalescing tests:
  - a burst of storage events collapses into one `multiGet` and one dispatch (with key dedup);
  - separate bursts still dispatch separately.

### Manual Tests

With this branch pinned in E/App (web dev build), on a heavy account:

1. Open two tabs signed in to the same heavy account (e.g. Applause).
2. Refresh both tabs and stay in Tab A. Wait ~30 seconds.
3. Assert neither tab crashes and both stay responsive (before this fix: ~2,000 cross-tab events per boot, derived-value recompute storm, eventual crash of both tabs).
4. In Tab A: pin/unpin a report, draft a message in a mid-list report, mark a report unread/read, and send a message. Assert each action syncs to Tab B without refreshing.
5. In Tab A, import a really heavy Onyx state (Account > Troubleshoot > Import Onyx state). Assert Tab B adopts the imported state.
6. Go to Account > Troubleshoot > Clear cache and restart. Assert Tab B is restored to the normal state as well.

### Author Checklist

- [x] I linked the correct issue in the `### Related Issues` section above
- [x] I linked the corresponding Expensify/App PR in the `### Linked E/App PR` section above, and verified this change against it (E/App CI passed and manual testing completed)
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>


https://github.com/user-attachments/assets/5429f69d-ce1a-421a-bf8f-b2a46f0c7cce


https://github.com/user-attachments/assets/06989785-3c6b-493c-9e10-689313c943d9



</details>


