### PR TITLE
perf: skip per-key clone when Onyx.init() hydrates the cache

### DIFF
--- a/lib/Onyx.ts
+++ b/lib/Onyx.ts
@@ -109,7 +109,7 @@ function init({
 
     // Initialize all of our keys with data provided then give green light to any pending connections.
     // addEvictableKeysToRecentlyAccessedList must run after initializeWithDefaultKeyStates because
-    // eager cache loading populates the key index (cache.setAllKeys) inside initializeWithDefaultKeyStates,
+    // eager cache loading populates the key index (cache.hydrate) inside initializeWithDefaultKeyStates,
     // and the evictable keys list depends on that index being populated.
     OnyxUtils.initializeWithDefaultKeyStates()
         .then(() => cache.addEvictableKeysToRecentlyAccessedList(OnyxKeys.isCollectionKey, OnyxUtils.getAllKeys))

--- a/lib/OnyxCache.ts
+++ b/lib/OnyxCache.ts
@@ -77,6 +77,7 @@ class OnyxCache {
             'set',
             'drop',
             'merge',
+            'hydrate',
             'hasPendingTask',
             'getTaskPromise',
             'captureTask',
@@ -197,6 +198,73 @@ class OnyxCache {
 
         this.storageKeys.delete(key);
         OnyxKeys.deregisterMemberKey(key);
+    }
+
+    /**
+     * Bulk-loads values into a cache that's expected to be empty, skipping merge()'s per-key clone when
+     * safe. Falls back to a real merge for any key that already has a value, in case the cache wasn't
+     * empty after all. Used only by `Onyx.init()`.
+     * @param data - a map of (cache) key - values
+     */
+    hydrate(data: Record<OnyxKey, OnyxValue<OnyxKey>>): void {
+        if (typeof data !== 'object' || Array.isArray(data)) {
+            throw new Error('data passed to cache.hydrate() must be an Object of onyx key/value pairs');
+        }
+
+        const affectedCollections = new Set<OnyxKey>();
+
+        // eslint-disable-next-line no-restricted-syntax, guard-for-in
+        for (const key in data) {
+            if (!Object.hasOwn(data, key)) {
+                continue;
+            }
+
+            const value = data[key];
+            this.addKey(key);
+
+            if (value === undefined) {
+                this.addNullishStorageKey(key);
+                continue;
+            }
+
+            const collectionKey = OnyxKeys.getCollectionKey(key);
+
+            if (value === null) {
+                this.addNullishStorageKey(key);
+                delete this.storageMap[key];
+
+                if (collectionKey) {
+                    affectedCollections.add(collectionKey);
+                }
+            } else {
+                this.nullishStorageKeys.delete(key);
+
+                const existing = this.storageMap[key];
+
+                if (existing !== undefined) {
+                    // Key already has a value, so the empty-cache assumption doesn't hold here - merge instead of clobbering.
+                    this.storageMap[key] = utils.fastMerge(existing, value, {
+                        shouldRemoveNestedNulls: true,
+                        objectRemovalMode: 'replace',
+                    }).result;
+                } else if (utils.needsNormalization(value)) {
+                    this.storageMap[key] = utils.fastMerge(undefined, value, {
+                        shouldRemoveNestedNulls: true,
+                        objectRemovalMode: 'replace',
+                    }).result;
+                } else {
+                    this.storageMap[key] = value;
+                }
+
+                if (collectionKey) {
+                    affectedCollections.add(collectionKey);
+                }
+            }
+        }
+
+        for (const collectionKey of affectedCollections) {
+            this.dirtyCollections.add(collectionKey);
+        }
     }
 
     /**

--- a/lib/OnyxCache.ts
+++ b/lib/OnyxCache.ts
@@ -225,17 +225,14 @@ class OnyxCache {
         const affectedCollections = new Set<OnyxKey>();
 
         // Use for-in loop to avoid an unnecessary array allocation from Object.keys()
-        // eslint-disable-next-line no-restricted-syntax
+        // eslint-disable-next-line no-restricted-syntax, guard-for-in
         for (const key in data) {
-            if (!Object.hasOwn(data, key)) {
-                continue;
-            }
-
             const value = data[key];
             this.addKey(key);
 
             if (value === undefined) {
                 this.addNullishStorageKey(key);
+                // undefined means "no change" — skip storageMap modification
                 continue;
             }
 
@@ -262,8 +259,8 @@ class OnyxCache {
                     // clears the nullish marker too, so a deletion racing init is still undone - same as before.
                     const merged = utils.fastMerge(existing, value, CACHE_MERGE_OPTIONS).result;
 
-                    // fastMerge is reference-stable: returns the original target when nothing changed, so a
-                    // simple === check detects no-ops and avoids dirtying the collection for nothing.
+                    // fastMerge is reference-stable: returns the original target when
+                    // nothing changed, so a simple === check detects no-ops.
                     if (merged === existing) {
                         continue;
                     }
@@ -281,6 +278,7 @@ class OnyxCache {
             }
         }
 
+        // Mark affected collections as dirty — snapshots will be lazily rebuilt on next read
         for (const collectionKey of affectedCollections) {
             this.dirtyCollections.add(collectionKey);
         }
@@ -297,7 +295,10 @@ class OnyxCache {
 
         const affectedCollections = new Set<OnyxKey>();
 
-        for (const [key, value] of Object.entries(data)) {
+        // Use for-in loop to avoid an unnecessary array allocation from Object.entries()
+        // eslint-disable-next-line no-restricted-syntax, guard-for-in
+        for (const key in data) {
+            const value = data[key];
             this.addKey(key);
 
             const collectionKey = OnyxKeys.getCollectionKey(key);

--- a/lib/OnyxCache.ts
+++ b/lib/OnyxCache.ts
@@ -2,6 +2,7 @@ import {deepEqual} from 'fast-equals';
 import bindAll from 'lodash/bindAll';
 import type {ValueOf} from 'type-fest';
 import utils from './utils';
+import type {FastMergeOptions} from './utils';
 import type {CollectionKeyBase, KeyValueMapping, NonUndefined, OnyxCollection, OnyxKey, OnyxValue} from './types';
 import OnyxKeys from './OnyxKeys';
 
@@ -14,6 +15,16 @@ type CollectionSnapshot = Readonly<NonUndefined<OnyxCollection<KeyValueMapping[O
  * which relies on === equality to detect changes.
  */
 const FROZEN_EMPTY_COLLECTION: Readonly<NonUndefined<OnyxCollection<KeyValueMapping[OnyxKey]>>> = Object.freeze({});
+
+/**
+ * Merge options shared by every cache write path (`merge()` and `hydrate()`'s fallback), so the
+ * three call sites can't drift apart. Cached values must never hold nested nulls, and a source
+ * object carrying the replace mark must replace the target object rather than merge into it.
+ */
+const CACHE_MERGE_OPTIONS: FastMergeOptions = {
+    shouldRemoveNestedNulls: true,
+    objectRemovalMode: 'replace',
+};
 
 // Task constants
 const TASK = {
@@ -242,16 +253,21 @@ class OnyxCache {
                 const existing = this.storageMap[key];
 
                 if (existing !== undefined) {
-                    // Key already has a value, so the empty-cache assumption doesn't hold here - merge instead of clobbering.
-                    this.storageMap[key] = utils.fastMerge(existing, value, {
-                        shouldRemoveNestedNulls: true,
-                        objectRemovalMode: 'replace',
-                    }).result;
+                    // Key already has a value, so the empty-cache assumption doesn't hold here (e.g. a write
+                    // landed while storage was still being read). Fall back to a real merge, which has exactly
+                    // the same semantics as the old `cache.merge(allDataFromStorage)` init path: the value
+                    // loaded from disk is the merge source, so it wins on any overlapping leaf key.
+                    const merged = utils.fastMerge(existing, value, CACHE_MERGE_OPTIONS).result;
+
+                    // fastMerge is reference-stable: returns the original target when nothing changed, so a
+                    // simple === check detects no-ops and avoids dirtying the collection for nothing.
+                    if (merged === existing) {
+                        continue;
+                    }
+
+                    this.storageMap[key] = merged;
                 } else if (utils.needsNormalization(value)) {
-                    this.storageMap[key] = utils.fastMerge(undefined, value, {
-                        shouldRemoveNestedNulls: true,
-                        objectRemovalMode: 'replace',
-                    }).result;
+                    this.storageMap[key] = utils.fastMerge(undefined, value, CACHE_MERGE_OPTIONS).result;
                 } else {
                     this.storageMap[key] = value;
                 }
@@ -301,10 +317,7 @@ class OnyxCache {
 
                 // Per-key merge instead of spreading the entire storageMap
                 const existing = this.storageMap[key];
-                const merged = utils.fastMerge(existing, value, {
-                    shouldRemoveNestedNulls: true,
-                    objectRemovalMode: 'replace',
-                }).result;
+                const merged = utils.fastMerge(existing, value, CACHE_MERGE_OPTIONS).result;
 
                 // fastMerge is reference-stable: returns the original target when
                 // nothing changed, so a simple === check detects no-ops.

--- a/lib/OnyxCache.ts
+++ b/lib/OnyxCache.ts
@@ -224,6 +224,7 @@ class OnyxCache {
 
         const affectedCollections = new Set<OnyxKey>();
 
+        // Use for-in loop to avoid an unnecessary array allocation from Object.keys()
         // eslint-disable-next-line no-restricted-syntax
         for (const key in data) {
             if (!Object.hasOwn(data, key)) {

--- a/lib/OnyxCache.ts
+++ b/lib/OnyxCache.ts
@@ -224,7 +224,7 @@ class OnyxCache {
 
         const affectedCollections = new Set<OnyxKey>();
 
-        // eslint-disable-next-line no-restricted-syntax, guard-for-in
+        // eslint-disable-next-line no-restricted-syntax
         for (const key in data) {
             if (!Object.hasOwn(data, key)) {
                 continue;

--- a/lib/OnyxCache.ts
+++ b/lib/OnyxCache.ts
@@ -218,7 +218,7 @@ class OnyxCache {
      * @param data - a map of (cache) key - values
      */
     hydrate(data: Record<OnyxKey, OnyxValue<OnyxKey>>): void {
-        if (typeof data !== 'object' || Array.isArray(data)) {
+        if (data === null || typeof data !== 'object' || Array.isArray(data)) {
             throw new Error('data passed to cache.hydrate() must be an Object of onyx key/value pairs');
         }
 

--- a/lib/OnyxCache.ts
+++ b/lib/OnyxCache.ts
@@ -258,6 +258,8 @@ class OnyxCache {
                     // landed while storage was still being read). Fall back to a real merge, which has exactly
                     // the same semantics as the old `cache.merge(allDataFromStorage)` init path: the value
                     // loaded from disk is the merge source, so it wins on any overlapping leaf key.
+                    // Note: this only covers non-null writes. A `cache.set(key, null)` that lands before hydrate
+                    // clears the nullish marker too, so a deletion racing init is still undone - same as before.
                     const merged = utils.fastMerge(existing, value, CACHE_MERGE_OPTIONS).result;
 
                     // fastMerge is reference-stable: returns the original target when nothing changed, so a

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -1042,7 +1042,8 @@ function initializeWithDefaultKeyStates(): Promise<void> {
             // Load all storage data into cache silently (no subscriber notifications).
             // hydrate() rather than merge(): the cache is empty at this point, so a per-key fastMerge
             // would only deep-clone every row it was handed.
-            cache.setAllKeys(Object.keys(allDataFromStorage));
+            // No setAllKeys() call is needed: hydrate() calls addKey() for every key, which populates the
+            // key index and registers collection member keys itself.
             cache.hydrate(allDataFromStorage);
 
             // For keys that have a developer-defined default (via `initialKeyStates`), merge the

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -1039,9 +1039,11 @@ function initializeWithDefaultKeyStates(): Promise<void> {
                 allDataFromStorage[key] = value;
             }
 
-            // Load all storage data into cache silently (no subscriber notifications)
+            // Load all storage data into cache silently (no subscriber notifications).
+            // hydrate() rather than merge(): the cache is empty at this point, so a per-key fastMerge
+            // would only deep-clone every row it was handed.
             cache.setAllKeys(Object.keys(allDataFromStorage));
-            cache.merge(allDataFromStorage);
+            cache.hydrate(allDataFromStorage);
 
             // For keys that have a developer-defined default (via `initialKeyStates`), merge the
             // persisted value with the default so new properties added in code updates are applied

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -196,6 +196,35 @@ function isMergeableObject<TObject extends Record<string, unknown>>(value: unkno
     return isNonNullObject && !(value instanceof RegExp) && !(value instanceof Date) && !Array.isArray(value);
 }
 
+/**
+ * Reports whether a value needs cleaning (nested null/undefined, or the replace-object mark) before it's
+ * safe to store by reference. Read-only, non-allocating.
+ */
+function needsNormalization(value: unknown): boolean {
+    if (value === null || value === undefined || typeof value !== 'object' || Array.isArray(value)) {
+        return false;
+    }
+
+    // eslint-disable-next-line no-restricted-syntax, guard-for-in
+    for (const key in value) {
+        if (key === ONYX_INTERNALS__REPLACE_OBJECT_MARK) {
+            return true;
+        }
+
+        const propertyValue = (value as Record<string, unknown>)[key];
+
+        if (propertyValue === null || propertyValue === undefined) {
+            return true;
+        }
+
+        if (typeof propertyValue === 'object' && !Array.isArray(propertyValue) && needsNormalization(propertyValue)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 /** Deep removes the nested null values from the given value. Returns the original reference if no nulls were found. */
 function removeNestedNullValues<TValue extends OnyxInput<OnyxKey> | null>(value: TValue): TValue {
     if (value === null || value === undefined || typeof value !== 'object' || Array.isArray(value)) {
@@ -346,6 +375,7 @@ export default {
     isEmptyObject,
     formatActionName,
     removeNestedNullValues,
+    needsNormalization,
     checkCompatibilityWithExistingValue,
     pick,
     omit,

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -205,6 +205,7 @@ function needsNormalization(value: unknown): boolean {
         return false;
     }
 
+    // Use for-in loop to avoid an unnecessary array allocation from Object.keys()
     // eslint-disable-next-line no-restricted-syntax, guard-for-in
     for (const key in value) {
         if (key === ONYX_INTERNALS__REPLACE_OBJECT_MARK) {

--- a/tests/unit/onyxCacheTest.tsx
+++ b/tests/unit/onyxCacheTest.tsx
@@ -553,6 +553,8 @@ describe('Onyx', () => {
                 expect(() => cache.hydrate('')).toThrow();
                 // @ts-expect-error -- intentionally testing invalid input
                 expect(() => cache.hydrate(0)).toThrow();
+                // @ts-expect-error -- intentionally testing invalid input
+                expect(() => cache.hydrate(null)).toThrow();
                 expect(() => cache.hydrate({})).not.toThrow();
             });
         });

--- a/tests/unit/onyxCacheTest.tsx
+++ b/tests/unit/onyxCacheTest.tsx
@@ -46,7 +46,7 @@ describe('Onyx', () => {
         });
 
         describe('getAllKeys', () => {
-            it('Should be empty initially', () => {
+            it('should be empty initially', () => {
                 // Given empty cache
 
                 // When all keys are retrieved
@@ -56,7 +56,7 @@ describe('Onyx', () => {
                 expect(allKeys).toEqual(new Set());
             });
 
-            it('Should keep storage keys', () => {
+            it('should keep storage keys', () => {
                 // Given cache with some items
                 cache.set('mockKey', 'mockValue');
                 cache.set('mockKey2', 'mockValue');
@@ -67,7 +67,7 @@ describe('Onyx', () => {
                 expect(allKeys).toEqual(new Set(['mockKey', 'mockKey2', 'mockKey3']));
             });
 
-            it('Should keep storage keys even when no values are provided', () => {
+            it('should keep storage keys even when no values are provided', () => {
                 // Given cache with some items
                 cache.set('mockKey', undefined);
                 cache.set('mockKey2', undefined);
@@ -78,7 +78,7 @@ describe('Onyx', () => {
                 expect(allKeys).toEqual(new Set(['mockKey', 'mockKey2', 'mockKey3']));
             });
 
-            it('Should not store duplicate keys', () => {
+            it('should not store duplicate keys', () => {
                 // Given cache with some items
                 cache.set('mockKey', 'mockValue');
                 cache.set('mockKey2', 'mockValue');
@@ -94,7 +94,7 @@ describe('Onyx', () => {
         });
 
         describe('getValue', () => {
-            it('Should return undefined when there is no stored value', () => {
+            it('should return undefined when there is no stored value', () => {
                 // Given empty cache
 
                 // When a value is retrieved
@@ -104,7 +104,7 @@ describe('Onyx', () => {
                 expect(result).not.toBeDefined();
             });
 
-            it('Should return cached value when it exists', () => {
+            it('should return cached value when it exists', () => {
                 // Given cache with some items
                 cache.set('mockKey', {items: ['mockValue', 'mockValue2']});
                 cache.set('mockKey2', 'mockValue3');
@@ -117,7 +117,7 @@ describe('Onyx', () => {
         });
 
         describe('hasCacheForKey', () => {
-            it('Should return false when there is no stored value', () => {
+            it('should return false when there is no stored value', () => {
                 // Given empty cache
 
                 // When a value does not exist in cache
@@ -125,7 +125,7 @@ describe('Onyx', () => {
                 expect(cache.hasCacheForKey('mockKey')).toBe(false);
             });
 
-            it('Should return true when cached value exists', () => {
+            it('should return true when cached value exists', () => {
                 // Given cache with some items
                 cache.set('mockKey', {items: ['mockValue', 'mockValue2']});
                 cache.set('mockKey2', 'mockValue3');
@@ -138,7 +138,7 @@ describe('Onyx', () => {
         });
 
         describe('addKey', () => {
-            it('Should store the key so that it is returned by `getAllKeys`', () => {
+            it('should store the key so that it is returned by `getAllKeys`', () => {
                 // Given empty cache
 
                 // When set is called with key and value
@@ -151,7 +151,7 @@ describe('Onyx', () => {
                 expect(cache.getAllKeys()).toEqual(new Set(['mockKey']));
             });
 
-            it('Should not make duplicate keys', () => {
+            it('should not make duplicate keys', () => {
                 // Given empty cache
 
                 // When the same item is added multiple times
@@ -167,7 +167,7 @@ describe('Onyx', () => {
         });
 
         describe('set', () => {
-            it('Should add data to cache when both key and value are provided', () => {
+            it('should add data to cache when both key and value are provided', () => {
                 // Given empty cache
 
                 // When set is called with key and value
@@ -178,7 +178,7 @@ describe('Onyx', () => {
                 expect(data).toEqual({value: 'mockValue'});
             });
 
-            it('Should store the key so that it is returned by `getAllKeys`', () => {
+            it('should store the key so that it is returned by `getAllKeys`', () => {
                 // Given empty cache
 
                 // When set is called with key and value
@@ -188,7 +188,7 @@ describe('Onyx', () => {
                 expect(cache.getAllKeys()).toEqual(new Set(['mockKey']));
             });
 
-            it('Should overwrite existing cache items for the Given key', () => {
+            it('should overwrite existing cache items for the Given key', () => {
                 // Given cache with some items
                 cache.set('mockKey', {value: 'mockValue'});
                 cache.set('mockKey2', {other: 'otherMockValue'});
@@ -202,7 +202,7 @@ describe('Onyx', () => {
         });
 
         describe('drop', () => {
-            it('Should remove the key from cache', () => {
+            it('should remove the key from cache', () => {
                 // Given cache with some items
                 cache.set('mockKey', {items: ['mockValue', 'mockValue2']});
                 cache.set('mockKey2', 'mockValue3');
@@ -218,7 +218,7 @@ describe('Onyx', () => {
         });
 
         describe('merge', () => {
-            it('Should create the value in cache when it does not exist', () => {
+            it('should create the value in cache when it does not exist', () => {
                 // Given empty cache
 
                 // When merge is called with new key value pairs
@@ -232,7 +232,7 @@ describe('Onyx', () => {
                 expect(cache.get('mockKey2')).toEqual({value: 'mockValue2'});
             });
 
-            it('Should merge data to existing cache value', () => {
+            it('should merge data to existing cache value', () => {
                 // Given cache with some items
                 cache.set('mockKey', {value: 'mockValue'});
                 cache.set('mockKey2', {other: 'otherMockValue', mock: 'mock', items: [3, 4, 5]});
@@ -256,7 +256,7 @@ describe('Onyx', () => {
                 });
             });
 
-            it('Should merge objects correctly', () => {
+            it('should merge objects correctly', () => {
                 // Given cache with existing object data
                 cache.set('mockKey', {value: 'mockValue', otherValue: 'overwrite me'});
 
@@ -273,7 +273,7 @@ describe('Onyx', () => {
                 });
             });
 
-            it('Should merge arrays correctly', () => {
+            it('should merge arrays correctly', () => {
                 // Given cache with existing array data
                 cache.set('mockKey', [{ID: 1}, {ID: 2}, {ID: 3}]);
 
@@ -286,7 +286,7 @@ describe('Onyx', () => {
                 expect(cache.get('mockKey')).toEqual([{ID: 3}, {added: 'field'}, {}, {ID: 1000}]);
             });
 
-            it('Should merge arrays inside objects correctly', () => {
+            it('should merge arrays inside objects correctly', () => {
                 // Given cache with existing array data
                 cache.set('mockKey', {ID: [1]});
 
@@ -299,7 +299,7 @@ describe('Onyx', () => {
                 expect(cache.get('mockKey')).toEqual({ID: [2]});
             });
 
-            it('Should work with primitive values', () => {
+            it('should work with primitive values', () => {
                 // Given cache with existing data
                 cache.set('mockKey', {});
 
@@ -334,7 +334,7 @@ describe('Onyx', () => {
                 expect(cache.get('mockKey')).toEqual({value: 'myMockObject'});
             });
 
-            it('Should ignore `undefined` values', () => {
+            it('should ignore `undefined` values', () => {
                 // Given cache with existing data
                 cache.set('mockKey', {ID: 5});
 
@@ -350,7 +350,7 @@ describe('Onyx', () => {
                 expect(cache.get('mockKey')).toEqual({ID: 5});
             });
 
-            it('Should update storageKeys when new keys are created', () => {
+            it('should update storageKeys when new keys are created', () => {
                 // Given cache with some items
                 cache.set('mockKey', {value: 'mockValue'});
                 cache.set('mockKey2', {other: 'otherMockValue', mock: 'mock', items: [3, 4, 5]});
@@ -366,7 +366,7 @@ describe('Onyx', () => {
                 expect(cache.getAllKeys()).toEqual(new Set(['mockKey', 'mockKey2', 'mockKey3', 'mockKey4']));
             });
 
-            it('Should throw if called with anything that is not an object', () => {
+            it('should throw if called with anything that is not an object', () => {
                 // @ts-expect-error -- intentionally testing invalid input
                 expect(() => cache.merge([])).toThrow();
                 // @ts-expect-error -- intentionally testing invalid input
@@ -376,7 +376,7 @@ describe('Onyx', () => {
                 expect(() => cache.merge({})).not.toThrow();
             });
 
-            it('Should remove `null` values when merging', () => {
+            it('should remove `null` values when merging', () => {
                 cache.set('mockKey', {ID: 5});
                 cache.set('mockNullKey', null);
 
@@ -560,14 +560,14 @@ describe('Onyx', () => {
         });
 
         describe('hasPendingTask', () => {
-            it('Should return false when there is no started task', () => {
+            it('should return false when there is no started task', () => {
                 // Given empty cache with no started tasks
                 // When a task has not been started
                 // Then it should return false
                 expect(cache.hasPendingTask(MOCK_TASK)).toBe(false);
             });
 
-            it('Should return true when a task is running', () => {
+            it('should return true when a task is running', () => {
                 // Given empty cache with no started tasks
                 // When a unique task is started
                 const promise = Promise.resolve();
@@ -585,7 +585,7 @@ describe('Onyx', () => {
         });
 
         describe('getTaskPromise', () => {
-            it('Should return undefined when there is no stored value', () => {
+            it('should return undefined when there is no stored value', () => {
                 // Given empty cache with no started tasks
 
                 // When a task is retrieved
@@ -595,7 +595,7 @@ describe('Onyx', () => {
                 expect(task).not.toBeDefined();
             });
 
-            it('Should return captured task when it exists', () => {
+            it('should return captured task when it exists', () => {
                 // Given empty cache with no started tasks
                 // When a unique task is started
                 const promise = Promise.resolve({mockResult: true});

--- a/tests/unit/onyxCacheTest.tsx
+++ b/tests/unit/onyxCacheTest.tsx
@@ -406,7 +406,7 @@ describe('Onyx', () => {
 
             const ALL_KEYS = Object.keys(buildStorageData());
 
-            it('Should produce the same cache state as merge() for an empty cache', () => {
+            it('should produce the same cache state as merge() for an empty cache', () => {
                 // Given two empty caches
                 const mergeCache = createIsolatedCache();
 
@@ -418,7 +418,7 @@ describe('Onyx', () => {
                 expectSameCacheState(cache, mergeCache, ALL_KEYS);
             });
 
-            it('Should produce the same cache state as merge() when keys already have values', () => {
+            it('should produce the same cache state as merge() when keys already have values', () => {
                 // Given two caches holding the same pre-existing values (e.g. a write landed while
                 // storage was still being read). Both existing values overlap the storage value on a
                 // leaf, so the merge direction is actually exercised.
@@ -447,7 +447,7 @@ describe('Onyx', () => {
                 expect(cache.get('stringKey')).toBe('mockValue');
             });
 
-            it('Should register every key, including keys with nullish values', () => {
+            it('should register every key, including keys with nullish values', () => {
                 // When hydrate is called with nullish and non-nullish values
                 cache.hydrate(buildStorageData());
 
@@ -457,7 +457,7 @@ describe('Onyx', () => {
                 expect(cache.getAllKeys().has('undefinedKey')).toBe(true);
             });
 
-            it('Should store values by reference when no normalization is needed', () => {
+            it('should store values by reference when no normalization is needed', () => {
                 // Given a value with no nested nullish properties
                 const value = {id: 1, nested: {deep: true}};
 
@@ -468,7 +468,7 @@ describe('Onyx', () => {
                 expect(cache.get('mockKey')).toBe(value);
             });
 
-            it('Should normalize values that carry nested nullish properties', () => {
+            it('should normalize values that carry nested nullish properties', () => {
                 // Given a value with nested nulls
                 const value = {keep: 1, drop: null, nested: {keep: 2, drop: null}};
 
@@ -483,7 +483,7 @@ describe('Onyx', () => {
                 expect(value).toEqual({keep: 1, drop: null, nested: {keep: 2, drop: null}});
             });
 
-            it('Should keep the existing reference when the hydrated value changes nothing', () => {
+            it('should keep the existing reference when the hydrated value changes nothing', () => {
                 // Given a cache that already holds a deep-equal value
                 const existing = {id: 1, nested: {deep: true}};
                 cache.set('mockKey', existing);
@@ -495,7 +495,7 @@ describe('Onyx', () => {
                 expect(cache.get('mockKey')).toBe(existing);
             });
 
-            it('Should remove `null` values from the storage map and mark them nullish', () => {
+            it('should remove `null` values from the storage map and mark them nullish', () => {
                 // Given a cache with an existing value
                 cache.set('mockKey', {ID: 5});
 
@@ -510,7 +510,7 @@ describe('Onyx', () => {
                 expect(cache.getAllKeys()).toEqual(new Set(['mockKey', 'mockNullKey']));
             });
 
-            it('Should leave the existing value untouched for `undefined` values', () => {
+            it('should leave the existing value untouched for `undefined` values', () => {
                 // Given a cache with an existing value
                 cache.set('mockKey', {ID: 5});
 
@@ -521,7 +521,7 @@ describe('Onyx', () => {
                 expect(cache.get('mockKey')).toEqual({ID: 5});
             });
 
-            it('Should expose hydrated collection members through collection reads, same as merge()', () => {
+            it('should expose hydrated collection members through collection reads, same as merge()', () => {
                 // Given two caches that know about the same collection key
                 const mergeCache = createIsolatedCache();
                 const collectionKey = 'mock_collection_';
@@ -546,7 +546,7 @@ describe('Onyx', () => {
                 expect(cache.getCollectionData(collectionKey)).toEqual(mergeCache.getCollectionData(collectionKey));
             });
 
-            it('Should throw if called with anything that is not an object', () => {
+            it('should throw if called with anything that is not an object', () => {
                 // @ts-expect-error -- intentionally testing invalid input
                 expect(() => cache.hydrate([])).toThrow();
                 // @ts-expect-error -- intentionally testing invalid input

--- a/tests/unit/onyxCacheTest.tsx
+++ b/tests/unit/onyxCacheTest.tsx
@@ -8,6 +8,31 @@ import waitForPromisesToResolve from '../utils/waitForPromisesToResolve';
 
 const MOCK_TASK = 'mockTask' as CacheTask;
 
+/**
+ * Builds an extra cache instance in its own module registry, so a `hydrate()` result can be compared
+ * against the `merge()` result for the same input without the two sharing any state.
+ */
+function createIsolatedCache(): typeof OnyxCache {
+    let isolated!: typeof OnyxCache;
+
+    jest.isolateModules(() => {
+        isolated = require('../../lib/OnyxCache').default;
+    });
+
+    return isolated;
+}
+
+/** Asserts that two cache instances are indistinguishable through the cache's public read surface. */
+function expectSameCacheState(actual: typeof OnyxCache, expected: typeof OnyxCache, keys: string[]) {
+    expect(actual.getAllKeys()).toEqual(expected.getAllKeys());
+
+    for (const key of keys) {
+        expect(actual.get(key)).toEqual(expected.get(key));
+        expect(actual.hasCacheForKey(key)).toBe(expected.hasCacheForKey(key));
+        expect(actual.hasNullishStorageKey(key)).toBe(expected.hasNullishStorageKey(key));
+    }
+}
+
 describe('Onyx', () => {
     describe('Cache Service', () => {
         /** @type OnyxCache */
@@ -362,6 +387,176 @@ describe('Onyx', () => {
             });
         });
 
+        describe('hydrate', () => {
+            // Every value shape init can hand the cache. Built fresh per call because `hydrate()` stores
+            // values by reference, so the two caches under comparison must never share source objects.
+            const buildStorageData = (): Record<string, unknown> => ({
+                stringKey: 'mockValue',
+                numberKey: 0,
+                booleanKey: false,
+                emptyObjectKey: {},
+                plainObjectKey: {value: 'mockValue'},
+                nestedObjectKey: {a: {b: {c: 1}}},
+                nestedNullsKey: {keep: 1, drop: null, nested: {keep: 2, drop: null}},
+                arrayKey: [{ID: 1}, {ID: 2}],
+                objectWithArrayKey: {ID: [1, 2]},
+                nullKey: null,
+                undefinedKey: undefined,
+            });
+
+            const ALL_KEYS = Object.keys(buildStorageData());
+
+            it('Should produce the same cache state as merge() for an empty cache', () => {
+                // Given two empty caches
+                const mergeCache = createIsolatedCache();
+
+                // When one is hydrated and the other merged with the same data
+                cache.hydrate(buildStorageData());
+                mergeCache.merge(buildStorageData());
+
+                // Then both caches are indistinguishable through their public read surface
+                expectSameCacheState(cache, mergeCache, ALL_KEYS);
+            });
+
+            it('Should produce the same cache state as merge() when keys already have values', () => {
+                // Given two caches holding the same pre-existing values (e.g. a write landed while
+                // storage was still being read). Both existing values overlap the storage value on a
+                // leaf, so the merge direction is actually exercised.
+                const mergeCache = createIsolatedCache();
+                const buildExistingData = () => ({
+                    plainObjectKey: {value: 'fromWrite', fromWrite: true},
+                    nestedObjectKey: {a: {b: {c: 99, fromWrite: true}}},
+                    stringKey: 'fromWrite',
+                });
+
+                for (const [key, value] of Object.entries(buildExistingData())) {
+                    cache.set(key, value);
+                    mergeCache.set(key, value);
+                }
+
+                // When one is hydrated and the other merged with the same data
+                cache.hydrate(buildStorageData());
+                mergeCache.merge(buildStorageData());
+
+                // Then the fallback merge inside hydrate() matches merge() exactly
+                expectSameCacheState(cache, mergeCache, ALL_KEYS);
+
+                // And the value loaded from storage wins on every overlapping leaf, as merge() does
+                expect(cache.get('plainObjectKey')).toEqual({value: 'mockValue', fromWrite: true});
+                expect(cache.get('nestedObjectKey')).toEqual({a: {b: {c: 1, fromWrite: true}}});
+                expect(cache.get('stringKey')).toBe('mockValue');
+            });
+
+            it('Should register every key, including keys with nullish values', () => {
+                // When hydrate is called with nullish and non-nullish values
+                cache.hydrate(buildStorageData());
+
+                // Then all of them are reported by getAllKeys, so nothing is invisible to reads
+                expect(cache.getAllKeys()).toEqual(new Set(ALL_KEYS));
+                expect(cache.getAllKeys().has('nullKey')).toBe(true);
+                expect(cache.getAllKeys().has('undefinedKey')).toBe(true);
+            });
+
+            it('Should store values by reference when no normalization is needed', () => {
+                // Given a value with no nested nullish properties
+                const value = {id: 1, nested: {deep: true}};
+
+                // When hydrate is called on an empty cache
+                cache.hydrate({mockKey: value});
+
+                // Then the value is stored as is - this is the clone that hydrate() exists to skip
+                expect(cache.get('mockKey')).toBe(value);
+            });
+
+            it('Should normalize values that carry nested nullish properties', () => {
+                // Given a value with nested nulls
+                const value = {keep: 1, drop: null, nested: {keep: 2, drop: null}};
+
+                // When hydrate is called
+                cache.hydrate({mockKey: value});
+
+                // Then the cached value is a cleaned copy
+                expect(cache.get('mockKey')).not.toBe(value);
+                expect(cache.get('mockKey')).toEqual({keep: 1, nested: {keep: 2}});
+
+                // And the source object handed to hydrate is left untouched
+                expect(value).toEqual({keep: 1, drop: null, nested: {keep: 2, drop: null}});
+            });
+
+            it('Should keep the existing reference when the hydrated value changes nothing', () => {
+                // Given a cache that already holds a deep-equal value
+                const existing = {id: 1, nested: {deep: true}};
+                cache.set('mockKey', existing);
+
+                // When hydrate is called with an equal but distinct value
+                cache.hydrate({mockKey: {id: 1, nested: {deep: true}}});
+
+                // Then the reference is preserved, so subscribers don't see a spurious change
+                expect(cache.get('mockKey')).toBe(existing);
+            });
+
+            it('Should remove `null` values from the storage map and mark them nullish', () => {
+                // Given a cache with an existing value
+                cache.set('mockKey', {ID: 5});
+
+                // When hydrate is called with null
+                cache.hydrate({mockKey: null, mockNullKey: null});
+
+                // Then the values are dropped but the keys stay known
+                expect(cache.get('mockKey')).toBeUndefined();
+                expect(cache.get('mockNullKey')).toBeUndefined();
+                expect(cache.hasNullishStorageKey('mockKey')).toBe(true);
+                expect(cache.hasNullishStorageKey('mockNullKey')).toBe(true);
+                expect(cache.getAllKeys()).toEqual(new Set(['mockKey', 'mockNullKey']));
+            });
+
+            it('Should leave the existing value untouched for `undefined` values', () => {
+                // Given a cache with an existing value
+                cache.set('mockKey', {ID: 5});
+
+                // When hydrate is called with undefined, which means "no change"
+                cache.hydrate({mockKey: undefined});
+
+                // Then the value is unchanged
+                expect(cache.get('mockKey')).toEqual({ID: 5});
+            });
+
+            it('Should expose hydrated collection members through collection reads, same as merge()', () => {
+                // Given two caches that know about the same collection key
+                const mergeCache = createIsolatedCache();
+                const collectionKey = 'mock_collection_';
+                const collectionData = {
+                    [`${collectionKey}1`]: {id: 1},
+                    [`${collectionKey}2`]: {id: 2},
+                    [`${collectionKey}3`]: null,
+                };
+
+                cache.setCollectionKeys(new Set([collectionKey]));
+                mergeCache.setCollectionKeys(new Set([collectionKey]));
+
+                // When one is hydrated and the other merged with the same collection members
+                cache.hydrate({...collectionData});
+                mergeCache.merge({...collectionData});
+
+                // Then the collection snapshot is rebuilt and reports the same members
+                expect(cache.getCollectionData(collectionKey)).toEqual({
+                    [`${collectionKey}1`]: {id: 1},
+                    [`${collectionKey}2`]: {id: 2},
+                });
+                expect(cache.getCollectionData(collectionKey)).toEqual(mergeCache.getCollectionData(collectionKey));
+            });
+
+            it('Should throw if called with anything that is not an object', () => {
+                // @ts-expect-error -- intentionally testing invalid input
+                expect(() => cache.hydrate([])).toThrow();
+                // @ts-expect-error -- intentionally testing invalid input
+                expect(() => cache.hydrate('')).toThrow();
+                // @ts-expect-error -- intentionally testing invalid input
+                expect(() => cache.hydrate(0)).toThrow();
+                expect(() => cache.hydrate({})).not.toThrow();
+            });
+        });
+
         describe('hasPendingTask', () => {
             it('Should return false when there is no started task', () => {
                 // Given empty cache with no started tasks
@@ -537,6 +732,78 @@ describe('Onyx', () => {
                 expect(allKeys.has(ONYX_KEYS.TEST_KEY)).toBe(true);
                 expect(allKeys.has(ONYX_KEYS.OTHER_TEST)).toBe(true);
                 expect(allKeys.has(`${ONYX_KEYS.COLLECTION.MOCK_COLLECTION}1`)).toBe(true);
+            });
+
+            it('should register keys whose stored value is nullish', async () => {
+                // Given storage holding a null value alongside a normal one
+                await StorageMock.setItem(ONYX_KEYS.TEST_KEY, null);
+                await StorageMock.setItem(ONYX_KEYS.OTHER_TEST, 'value');
+                await initOnyx();
+
+                // Then the nullish key is still part of the key index, so reads don't treat it as unloaded
+                expect(cache.getAllKeys()).toEqual(new Set([ONYX_KEYS.TEST_KEY, ONYX_KEYS.OTHER_TEST]));
+                expect(cache.get(ONYX_KEYS.TEST_KEY)).toBeUndefined();
+                expect(cache.hasNullishStorageKey(ONYX_KEYS.TEST_KEY)).toBe(true);
+                expect(cache.hasCacheForKey(ONYX_KEYS.TEST_KEY)).toBe(true);
+            });
+
+            it('should expose collection members loaded from storage through collection reads', async () => {
+                // Given storage holding collection members
+                await StorageMock.setItem(`${ONYX_KEYS.COLLECTION.MOCK_COLLECTION}1`, {id: 1, name: 'Item 1'});
+                await StorageMock.setItem(`${ONYX_KEYS.COLLECTION.MOCK_COLLECTION}2`, {id: 2, name: 'Item 2'});
+                await initOnyx();
+
+                // Then the collection index is populated, so the snapshot contains both members
+                expect(cache.getCollectionData(ONYX_KEYS.COLLECTION.MOCK_COLLECTION)).toEqual({
+                    [`${ONYX_KEYS.COLLECTION.MOCK_COLLECTION}1`]: {id: 1, name: 'Item 1'},
+                    [`${ONYX_KEYS.COLLECTION.MOCK_COLLECTION}2`]: {id: 2, name: 'Item 2'},
+                });
+                expect(OnyxKeys.getCollectionKey(`${ONYX_KEYS.COLLECTION.MOCK_COLLECTION}1`)).toBe(ONYX_KEYS.COLLECTION.MOCK_COLLECTION);
+            });
+
+            it('should merge, not overwrite, keys written while storage was still being read', async () => {
+                // Given a storage read that has not resolved yet
+                let releaseGetAll: (() => void) | undefined;
+                const gate = new Promise<void>((resolve) => {
+                    releaseGetAll = resolve;
+                });
+                (StorageMock.getAll as jest.Mock).mockImplementationOnce(() => gate.then(() => [[ONYX_KEYS.TEST_KEY, {fromStorage: true, shared: 'fromStorage'}]]));
+
+                Onyx.init({keys: ONYX_KEYS});
+
+                // When a write lands on that key before the read completes
+                cache.set(ONYX_KEYS.TEST_KEY, {fromWrite: true, shared: 'fromWrite'});
+                releaseGetAll?.();
+                await waitForPromisesToResolve();
+
+                // Then hydrate falls back to a merge instead of dropping the write, and the value from
+                // storage wins on the overlapping leaf - exactly what the old merge-based init did
+                expect(cache.get(ONYX_KEYS.TEST_KEY)).toEqual({fromStorage: true, fromWrite: true, shared: 'fromStorage'});
+            });
+
+            it('should leave the cache in the same state a merge-based init would produce', async () => {
+                // Given storage holding every value shape init has to deal with
+                const storageData: Record<string, unknown> = {
+                    [ONYX_KEYS.TEST_KEY]: 'storageValue',
+                    [ONYX_KEYS.OTHER_TEST]: {nested: {value: 1}, keep: true, drop: null},
+                    [`${ONYX_KEYS.COLLECTION.MOCK_COLLECTION}1`]: {id: 1, name: 'Item 1'},
+                    [`${ONYX_KEYS.COLLECTION.MOCK_COLLECTION}2`]: [{ID: 1}, {ID: 2}],
+                    [`${ONYX_KEYS.COLLECTION.MOCK_COLLECTION}3`]: null,
+                };
+                const allKeys = Object.keys(storageData);
+
+                await StorageMock.multiSet(Object.entries(storageData));
+                await initOnyx();
+
+                // When the previous init path (setAllKeys + merge) is replayed on a separate cache
+                const mergeCache = createIsolatedCache();
+                mergeCache.setCollectionKeys(new Set([ONYX_KEYS.COLLECTION.MOCK_COLLECTION]));
+                mergeCache.setAllKeys(allKeys);
+                mergeCache.merge({...storageData});
+
+                // Then the hydrated cache is indistinguishable from it
+                expectSameCacheState(cache, mergeCache, allKeys);
+                expect(cache.getCollectionData(ONYX_KEYS.COLLECTION.MOCK_COLLECTION)).toEqual(mergeCache.getCollectionData(ONYX_KEYS.COLLECTION.MOCK_COLLECTION));
             });
         });
 

--- a/tests/unit/utilsTest.ts
+++ b/tests/unit/utilsTest.ts
@@ -302,6 +302,58 @@ describe('utils', () => {
         });
     });
 
+    describe('needsNormalization', () => {
+        it('should return false for nullish and primitive values', () => {
+            expect(utils.needsNormalization(null)).toBe(false);
+            expect(utils.needsNormalization(undefined)).toBe(false);
+            expect(utils.needsNormalization('a')).toBe(false);
+            expect(utils.needsNormalization(0)).toBe(false);
+            expect(utils.needsNormalization(false)).toBe(false);
+        });
+
+        it('should return false for an empty object', () => {
+            expect(utils.needsNormalization({})).toBe(false);
+        });
+
+        it('should return false for an object without nullish values or the replace-object mark', () => {
+            expect(utils.needsNormalization(testObject)).toBe(false);
+        });
+
+        it('should return true for an object with a nullish value at the top level', () => {
+            expect(utils.needsNormalization({a: 'a', b: null})).toBe(true);
+            expect(utils.needsNormalization({a: 'a', b: undefined})).toBe(true);
+        });
+
+        it('should return true for an object with a nullish value nested deeply', () => {
+            expect(utils.needsNormalization(testObjectWithNullishValues)).toBe(true);
+            expect(utils.needsNormalization({a: {b: {c: {d: null}}}})).toBe(true);
+        });
+
+        it('should return true for an object marked with the replace-object mark at the top level', () => {
+            expect(utils.needsNormalization({[utils.ONYX_INTERNALS__REPLACE_OBJECT_MARK]: true})).toBe(true);
+        });
+
+        it('should return true for an object marked with the replace-object mark nested deeply', () => {
+            expect(utils.needsNormalization({a: {b: {[utils.ONYX_INTERNALS__REPLACE_OBJECT_MARK]: true, c: 'c'}}})).toBe(true);
+        });
+
+        it('should return false for arrays, since arrays are stored as-is and are not normalized', () => {
+            expect(utils.needsNormalization([])).toBe(false);
+            expect(utils.needsNormalization([1, 2, 3])).toBe(false);
+            expect(utils.needsNormalization([null, undefined])).toBe(false);
+        });
+
+        it('should not look inside nested arrays', () => {
+            expect(utils.needsNormalization({a: [null, undefined]})).toBe(false);
+            expect(utils.needsNormalization({a: [{b: null}]})).toBe(false);
+        });
+
+        it('should return false for Date and RegExp values, which have no enumerable properties', () => {
+            expect(utils.needsNormalization({a: new Date()})).toBe(false);
+            expect(utils.needsNormalization({a: /abc/})).toBe(false);
+        });
+    });
+
     describe('removeNestedNullValues', () => {
         it('should remove null values by merging two identical objects with fastMerge', () => {
             const result = utils.removeNestedNullValues(testObjectWithNullishValues);


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details

`Onyx.init()` loaded the persisted database into `OnyxCache` through `merge()`, which runs `fastMerge(existing, value)` per key. At init time `existing` is always `undefined`, so `fastMerge` never actually merges anything - it just walks and deep-clones every nested object of every row for no reason. On a heavy account this clone-heavy cache-write phase was measured at ~29% of total `Onyx.init()` time.

Adds `OnyxCache.hydrate()`, a bulk-load variant used only by `Onyx.init()`. Values are stored by reference when safe (`utils.needsNormalization()` is a read-only, non-allocating check for nested null/undefined and the internal `ONYX_INTERNALS__REPLACE_OBJECT_MARK`). Falls back to the existing `fastMerge` path in two cases: the key already has a value in cache (a cross-tab sync listener can race ahead of init and write a key before `hydrate()` reaches it), or the value itself needs normalizing.

`OnyxUtils.ts`'s `initializeWithDefaultKeyStates()` now calls `cache.hydrate(allDataFromStorage)` instead of `cache.merge(allDataFromStorage)`.

`merge()`'s inline `fastMerge` options were also extracted into a shared `CACHE_MERGE_OPTIONS` constant used by both `merge()` and `hydrate()`'s fallback, so the cache write paths can't drift apart.

### Related Issues

https://github.com/Expensify/App/issues/98553

### Linked E/App PR

https://github.com/Expensify/App/pull/98649

### Automated Tests

`tests/unit/onyxCacheTest.tsx` covers `hydrate()` directly and through `Onyx.init()`:

- Equivalence with `merge()`: identical cache state on an empty cache, and when keys already hold values, across fixtures with nested nulls, nested `undefined`, the replace-object mark, and plain values.
- Every key is registered, including keys whose stored value is nullish.
- Values are stored by reference when no normalization is needed, and normalized when they carry nested nullish properties.
- Reference stability: a hydrated value that changes nothing keeps the existing reference.
- Init-level: collection members loaded from storage are readable through collection reads, keys written while storage was still being read are merged rather than overwritten, and the resulting cache matches a merge-based init.

### Manual Tests

1. Sign in to an account with a reasonably large Onyx database (many reports/reportActions), force-quit and cold-start the app.
   Verify that the app boots normally, the LHN and reports render with the same data as before the change, and no console errors appear.
2. Cold-start the app, open a report with actions containing deleted/optimistic-cleared fields (values that were `null` on disk).
   Verify that the report renders correctly with those fields absent, matching pre-change behavior.
3. On web, open the app in two browser tabs signed into the same account. In tab A, trigger a write (e.g. send a message) right as tab B is cold-starting/reloading.
   Verify that tab B's cache ends up consistent with tab A's write - i.e. the value isn't clobbered by `hydrate()`'s bulk load racing the cross-tab sync listener.

### Offline tests

1. Put the device in airplane mode, force-quit and cold-start the app.
   Verify that the app boots with the last-persisted cache (same as before this change) and no data is lost or duplicated.
2. While offline, open a report and confirm previously-persisted reportActions/transactions render correctly, then go back online and verify no reconciliation errors occur.

### QA Steps

Same as tests.

### Author Checklist

- [x] I linked the correct issue in the `### Related Issues` section above
- [x] I linked the corresponding Expensify/App PR in the `### Linked E/App PR` section above, and verified this change against it (E/App CI passed and manual testing completed)
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/ec06c564-79ef-4570-8304-0529bb19a1d2



</details>
