### PR TITLE
Rename circuit-breaker state half-open to halfOpen

### DIFF
--- a/lib/CircuitBreaker/AbstractCircuitBreaker.ts
+++ b/lib/CircuitBreaker/AbstractCircuitBreaker.ts
@@ -7,7 +7,7 @@ import type {CircuitBreakerOptions, CircuitBreakerState} from './types';
  *
  * - **closed**: requests are allowed; failures are counted.
  * - **open**: requests are rejected until {@link resetTimeoutMs} elapses.
- * - **half-open**: the recovery-probe state. After the open timeout, the breaker admits exactly ONE
+ * - **halfOpen**: the recovery-probe state. After the open timeout, the breaker admits exactly ONE
  *   probe request: success means the dependency recovered, so the circuit closes. Failure means it's
  *   still down, so the circuit reopens. This single-request probe prevents a "thundering herd" where
  *   every caller fails loudly when the service hasn't recovered yet.
@@ -69,10 +69,10 @@ abstract class AbstractCircuitBreaker {
     /**
      * Whether a request may proceed.
      *
-     * Returns `false` while open. In half-open, the FIRST caller is admitted as the recovery probe and
+     * Returns `false` while open. In halfOpen, the FIRST caller is admitted as the recovery probe and
      * `isProbeInFlight` is latched so every subsequent caller is rejected until that probe resolves
      * (via {@link recordSuccess} → close, or {@link recordFailure} → reopen). That single-probe gate is
-     * the whole point of half-open: it tests recovery with one request instead of letting a herd of
+     * the whole point of halfOpen: it tests recovery with one request instead of letting a herd of
      * waiting callers stampede a dependency that may still be down.
      */
     isAllowed(): boolean {
@@ -82,7 +82,7 @@ abstract class AbstractCircuitBreaker {
             return false;
         }
 
-        if (currentState === 'half-open') {
+        if (currentState === 'halfOpen') {
             if (this.isProbeInFlight) {
                 return false;
             }
@@ -93,7 +93,7 @@ abstract class AbstractCircuitBreaker {
     }
 
     /**
-     * Record a failed request. May open the circuit from closed or half-open.
+     * Record a failed request. May open the circuit from closed or halfOpen.
      * @returns `true` when the circuit is open after recording (the request must not proceed).
      */
     recordFailure(): boolean {
@@ -101,7 +101,7 @@ abstract class AbstractCircuitBreaker {
             return true;
         }
 
-        if (this.machine.state === 'half-open') {
+        if (this.machine.state === 'halfOpen') {
             this.trip();
             return true;
         }
@@ -115,9 +115,9 @@ abstract class AbstractCircuitBreaker {
         return false;
     }
 
-    /** Record a successful request. Closes the circuit from half-open and clears failure counts. */
+    /** Record a successful request. Closes the circuit from halfOpen and clears failure counts. */
     recordSuccess(): void {
-        if (this.machine.state === 'half-open') {
+        if (this.machine.state === 'halfOpen') {
             this.close();
             return;
         }
@@ -129,7 +129,7 @@ abstract class AbstractCircuitBreaker {
 
     /**
      * The current state WITHOUT advancing recovery — a pure query, safe to call without side effects.
-     * The open→half-open transition is applied only at the admission point ({@link isAllowed}); by the
+     * The open→halfOpen transition is applied only at the admission point ({@link isAllowed}); by the
      * time a caller queries state after being admitted, that transition has already happened.
      */
     peekState(): CircuitBreakerState {
@@ -166,7 +166,7 @@ abstract class AbstractCircuitBreaker {
     }
 
     private close(): void {
-        // close() only ever runs from half-open (see recordSuccess), and half-open → closed is the one
+        // close() only ever runs from halfOpen (see recordSuccess), and halfOpen → closed is the one
         // legal closing transition — so go through transition() to keep the illegal open → closed jump
         // an error rather than silently constructing a fresh closed machine.
         this.machine = this.machine.transition('closed');
@@ -177,9 +177,9 @@ abstract class AbstractCircuitBreaker {
     }
 
     /**
-     * Lazily advance open → half-open once the reset timeout has elapsed. This is checked on read
+     * Lazily advance open → halfOpen once the reset timeout has elapsed. This is checked on read
      * (via {@link getCurrentState}) rather than on a timer, so there's nothing to schedule or clean up:
-     * the transition simply becomes visible to the next caller after the window. Entering half-open
+     * the transition simply becomes visible to the next caller after the window. Entering halfOpen
      * clears `isProbeInFlight` so the next admitted request becomes the recovery probe.
      */
     private maybeRecover(): void {
@@ -191,7 +191,7 @@ abstract class AbstractCircuitBreaker {
             return;
         }
 
-        this.machine = this.machine.transition('half-open');
+        this.machine = this.machine.transition('halfOpen');
         this.isProbeInFlight = false;
     }
 }

--- a/lib/CircuitBreaker/types.ts
+++ b/lib/CircuitBreaker/types.ts
@@ -5,7 +5,7 @@
  * - **open**: tripped; requests are rejected outright so a known-bad dependency isn't hammered.
  * - **half-open**: a trial state entered after the open timeout — see {@link CIRCUIT_BREAKER_TRANSITIONS}.
  */
-type CircuitBreakerState = 'closed' | 'open' | 'half-open';
+type CircuitBreakerState = 'closed' | 'open' | 'halfOpen';
 
 /**
  * Legal state transitions. The flow is closed → open → half-open → (closed | open).
@@ -24,8 +24,8 @@ type CircuitBreakerState = 'closed' | 'open' | 'half-open';
  */
 const CIRCUIT_BREAKER_TRANSITIONS = {
     closed: ['open'],
-    open: ['half-open'],
-    'half-open': ['closed', 'open'],
+    open: ['halfOpen'],
+    halfOpen: ['closed', 'open'],
 } as const satisfies Record<CircuitBreakerState, readonly CircuitBreakerState[]>;
 
 type CircuitBreakerOptions = {

--- a/lib/StorageCircuitBreaker.ts
+++ b/lib/StorageCircuitBreaker.ts
@@ -68,7 +68,7 @@ class StorageCircuitBreaker extends AbstractCircuitBreaker {
         // failure that triggered it must not re-trip the circuit. Let it proceed; the probe's outcome
         // is the verdict — recordWriteSuccess (retry landed) closes, recordProbeFailure (retry failed,
         // re-entering retryOperation) reopens.
-        if (this.peekState() === 'half-open') {
+        if (this.peekState() === 'halfOpen') {
             return false;
         }
         return this.recordFailure();

--- a/tests/unit/StorageCircuitBreakerTest.ts
+++ b/tests/unit/StorageCircuitBreakerTest.ts
@@ -140,10 +140,12 @@ describe('StorageCircuitBreaker', () => {
             StorageCircuitBreaker.recordCapacityFailure();
         }
         expectAdmissionOpen();
+        expect(StorageCircuitBreaker.peekState()).toBe('open');
 
         advance(ROLLING_WINDOW_MS);
 
         expectAdmissionHalfOpen();
+        expect(StorageCircuitBreaker.peekState()).toBe('halfOpen');
     });
 
     it('should admit only one capacity retry while half-open', () => {


### PR DESCRIPTION
### Details
For an eslint-config-expensify upgrade. Split out of https://github.com/Expensify/react-native-onyx/pull/802 to reduce that diff.

Rename the circuit-breaker state identifier from `half-open` to `halfOpen` so it follows our naming convention rules.

Behavior is unchanged.

### Related Issues
For https://github.com/Expensify/react-native-onyx/pull/802

### Linked E/App PR
https://github.com/Expensify/App/pull/99228

### Automated Tests
Existing `StorageCircuitBreakerTest` covers functionality.

### Manual Tests
n/a

### Author Checklist

- [x] I linked the correct issue in the `### Related Issues` section above
- [x] I linked the corresponding Expensify/App PR in the `### Linked E/App PR` section above, and verified this change against it (E/App CI passed and manual testing completed)
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

