### PR TITLE
Serialize Error.cause when degrading storage

### DIFF
--- a/lib/storage/index.ts
+++ b/lib/storage/index.ts
@@ -20,7 +20,8 @@ type Storage = {
  * Degrade performance by removing the storage provider and only using cache
  */
 function degradePerformance(error: Error) {
-    Logger.logHmmm(`Error while using ${provider.name}. Falling back to only using cache and dropping storage.\n Error: ${error.message}\n Stack: ${error.stack}\n Cause: ${error.cause}`);
+    const causeMessage = error.cause instanceof Error ? error.cause.message : typeof error.cause === 'string' ? error.cause : '';
+    Logger.logHmmm(`Error while using ${provider.name}. Falling back to only using cache and dropping storage.\n Error: ${error.message}\n Stack: ${error.stack}\n Cause: ${causeMessage}`);
     console.error(error);
     provider = MemoryOnlyProvider;
 }

--- a/lib/storage/index.ts
+++ b/lib/storage/index.ts
@@ -20,7 +20,12 @@ type Storage = {
  * Degrade performance by removing the storage provider and only using cache
  */
 function degradePerformance(error: Error) {
-    const causeMessage = error.cause instanceof Error ? error.cause.message : typeof error.cause === 'string' ? error.cause : '';
+    let causeMessage = '';
+    if (error.cause instanceof Error) {
+        causeMessage = error.cause.message;
+    } else if (typeof error.cause === 'string') {
+        causeMessage = error.cause;
+    }
     Logger.logHmmm(`Error while using ${provider.name}. Falling back to only using cache and dropping storage.\n Error: ${error.message}\n Stack: ${error.stack}\n Cause: ${causeMessage}`);
     console.error(error);
     provider = MemoryOnlyProvider;

--- a/tests/unit/storage/tryOrDegradePerformanceTest.ts
+++ b/tests/unit/storage/tryOrDegradePerformanceTest.ts
@@ -69,6 +69,24 @@ describe('storage/tryOrDegradePerformance', () => {
         expect(storage.getStorageProvider().name).toBe('MemoryOnlyProvider');
     });
 
+    it('serializes Error.cause as a readable string in the degrade log', async () => {
+        const {storage, Logger} = loadIsolatedStorage();
+        const capturedLogs: CapturedLog[] = [];
+        Logger.registerLogger((data: LogData) => capturedLogs.push({level: data.level, message: data.message}));
+
+        storage.init();
+
+        const originalProvider = storage.getStorageProvider();
+        const targetError = new Error('IDBKeyVal store could not be created', {cause: new Error('underlying disk is full')});
+        originalProvider.getAllKeys = jest.fn().mockReturnValue(Promise.reject(targetError));
+
+        await expect(storage.getAllKeys()).rejects.toBe(targetError);
+
+        const degradeLog = capturedLogs.find((log) => log.level === 'hmmm' && log.message.includes('Falling back to only using cache'));
+        expect(degradeLog?.message).toContain('Cause: underlying disk is full');
+        expect(degradeLog?.message).not.toContain('[object Object]');
+    });
+
     it('propagates async rejections with unrelated messages without falling back', async () => {
         const {storage, Logger} = loadIsolatedStorage();
         const capturedLogs: CapturedLog[] = [];


### PR DESCRIPTION
### Details
When storage degrades to cache-only, the fallback alert interpolated `error.cause` directly. A non-string cause becomes `[object Object]` in logs.

Serialize `Error.cause` to a message string (Error message, or the string itself) before logging.

Split out of https://github.com/Expensify/react-native-onyx/pull/802.

### Related Issues
For https://github.com/Expensify/react-native-onyx/pull/802

### Linked E/App PR
https://github.com/Expensify/App/pull/99225


### Automated Tests
No new tests. Logging-only change in `degradePerformance`.

### Manual Tests
1. Open the Expensify App against this Onyx SHA.
2. Use the app normally so storage writes succeed.
3. If a storage degrade occurs, confirm the Cause field in the Hmmm log is a readable string, not `[object Object]`.

### Author Checklist

- [x] I linked the correct issue in the `### Related Issues` section above
- [x] I linked the corresponding Expensify/App PR in the `### Linked E/App PR` section above, and verified this change against it (E/App CI passed and manual testing completed)
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>


