### PR TITLE
Stringify thrown errors in logAlert

### DIFF
--- a/lib/Onyx.ts
+++ b/lib/Onyx.ts
@@ -301,7 +301,7 @@ function merge<TKey extends OnyxKey>(key: TKey, changes: OnyxMergeInput<TKey>): 
                     OnyxUtils.sendActionToDevTools(OnyxUtils.METHOD.MERGE, key, changes, mergedValue);
                 });
             } catch (error) {
-                Logger.logAlert(`An error occurred while applying merge for key: ${key}, Error: ${error}`);
+                Logger.logAlert(`An error occurred while applying merge for key: ${key}, Error: ${error instanceof Error ? error.message : String(error)}`);
                 return Promise.resolve();
             }
         });

--- a/lib/Onyx.ts
+++ b/lib/Onyx.ts
@@ -301,7 +301,7 @@ function merge<TKey extends OnyxKey>(key: TKey, changes: OnyxMergeInput<TKey>): 
                     OnyxUtils.sendActionToDevTools(OnyxUtils.METHOD.MERGE, key, changes, mergedValue);
                 });
             } catch (error) {
-                Logger.logAlert(`An error occurred while applying merge for key: ${key}, Error: ${error instanceof Error ? error.message : String(error)}`);
+                Logger.logAlert(`An error occurred while applying merge for key: ${key}, Error: ${error instanceof Error ? error.toString() : String(error)}`);
                 return Promise.resolve();
             }
         });

--- a/lib/OnyxConnectionManager.ts
+++ b/lib/OnyxConnectionManager.ts
@@ -138,7 +138,7 @@ class OnyxConnectionManager {
                     (callback as DefaultConnectCallback<OnyxKey>)(connection.cachedCallbackValue, connection.cachedCallbackKey as OnyxKey);
                 }
             } catch (error) {
-                Logger.logAlert(`[ConnectionManager] Subscriber callback threw an error for key '${connection.onyxKey}': ${error}`);
+                Logger.logAlert(`[ConnectionManager] Subscriber callback threw an error for key '${connection.onyxKey}': ${String(error)}`);
             }
         }
     }

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -63,7 +63,7 @@ function resetDiskPressureLogThrottle(): void {
 }
 
 function formatCaughtError(error: unknown): string {
-    return error instanceof Error ? error.message : String(error);
+    return error instanceof Error ? error.toString() : String(error);
 }
 
 type OnyxMethod = ValueOf<typeof METHOD>;

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -62,6 +62,10 @@ function resetDiskPressureLogThrottle(): void {
     lastDiskPressureLogTime = 0;
 }
 
+function formatCaughtError(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}
+
 type OnyxMethod = ValueOf<typeof METHOD>;
 
 /** Result of `prepareKeyValuePairsForStorage`: pairs to write and keys whose `null` value marks them for removal. */
@@ -598,7 +602,7 @@ function keysChanged<TKey extends CollectionKeyBase>(
             lastConnectionCallbackData.set(subscriber.subscriptionID, {value: cachedCollection, matchedKey: subscriber.key});
             subscriber.callback(cachedCollection, subscriber.key);
         } catch (error) {
-            Logger.logAlert(`[OnyxUtils.keysChanged] Subscriber callback threw an error for key '${collectionKey}': ${error}`);
+            Logger.logAlert(`[OnyxUtils.keysChanged] Subscriber callback threw an error for key '${collectionKey}': ${formatCaughtError(error)}`);
         }
     }
 
@@ -621,7 +625,7 @@ function keysChanged<TKey extends CollectionKeyBase>(
                 matchedKey: subscriber.key,
             });
         } catch (error) {
-            Logger.logAlert(`[OnyxUtils.keysChanged] Subscriber callback threw an error for key '${collectionKey}': ${error}`);
+            Logger.logAlert(`[OnyxUtils.keysChanged] Subscriber callback threw an error for key '${collectionKey}': ${formatCaughtError(error)}`);
         }
     }
 }
@@ -694,7 +698,7 @@ function keyChanged<TKey extends OnyxKey>(key: TKey, value: OnyxValue<TKey>, can
                 });
                 continue;
             } catch (error) {
-                Logger.logAlert(`[OnyxUtils.keyChanged] Subscriber callback threw an error for key '${key}': ${error}`);
+                Logger.logAlert(`[OnyxUtils.keyChanged] Subscriber callback threw an error for key '${key}': ${formatCaughtError(error)}`);
             }
 
             continue;


### PR DESCRIPTION
### Details
Split from https://github.com/Expensify/react-native-onyx/pull/802. This PR only stringifies thrown values before they are interpolated into `Logger.logAlert`.

Raw `Error` objects become `[object Object]` when interpolated in some runtimes, which makes merge and subscriber-callback failures unreadable. This change:

- Adds `formatCaughtError()` in `lib/OnyxUtils.ts` and uses it at the three existing `keysChanged` / `keyChanged` `logAlert` sites that currently interpolate `: ${error}`.
- In `lib/Onyx.ts` merge catch, logs `error.message` when the thrown value is an `Error`, otherwise `String(error)`.
- In `lib/OnyxConnectionManager.ts` `fireCallbacks` catch, uses `String(error)`.

No eslint changes, no type changes, and no `Onyx.update` handler hoist.

### Related Issues
For https://github.com/Expensify/react-native-onyx/pull/802

### Linked E/App PR
https://github.com/Expensify/App/pull/99242

### Automated Tests
No new tests. This is logging-only: the catch paths already swallow the error and continue. The change only affects the string passed to `logAlert`.

### Manual Tests
1. In the companion App PR, pin `react-native-onyx` to this PR HEAD and install dependencies.
2. Start the web app (`npm run web`).
3. Use the app normally (open reports, create/edit an expense, navigate between chats).
4. Confirm the app still loads and Onyx updates apply as expected.
5. Confirm there is no new console noise from Onyx merge or subscriber-callback failures.

### Author Checklist

- [x] I linked the correct issue in the `### Related Issues` section above
- [x] I linked the corresponding Expensify/App PR in the `### Linked E/App PR` section above, and verified this change against it (E/App CI passed and manual testing completed)
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
