### PR TITLE
Classify WebKit 'without an in-progress transaction' IndexedDB errors as transient

### DIFF
--- a/lib/storage/providers/IDBKeyValProvider/classifyError.ts
+++ b/lib/storage/providers/IDBKeyValProvider/classifyError.ts
@@ -1,5 +1,4 @@
 import type {ValueOf} from 'type-fest';
-
 import {StorageErrorClass, getErrorParts} from '../../errors';
 
 /**
@@ -34,12 +33,7 @@ function classifyIDBError(error: unknown): ValueOf<typeof StorageErrorClass> {
         name.includes('aborterror') ||
         message.includes('connection to indexed database server lost') ||
         message.includes('connection is closing') ||
-        // WebKit's IDB server tore the transaction down under a live connection (page reload or
-        // foregrounding after process suspension). Emitted as UnknownError with messages like
-        // "Attempt to get a record from database without an in-progress transaction" — the shared
-        // suffix covers the whole family. A fresh connection heals it.
         message.includes('without an in-progress transaction') ||
-        // This is related to https://github.com/Expensify/react-native-onyx/pull/796 — remove this comment when #796 is merged.
         message.includes('idb write transaction aborted without an error')
     ) {
         return StorageErrorClass.TRANSIENT;

--- a/lib/storage/providers/IDBKeyValProvider/classifyError.ts
+++ b/lib/storage/providers/IDBKeyValProvider/classifyError.ts
@@ -1,4 +1,5 @@
 import type {ValueOf} from 'type-fest';
+
 import {StorageErrorClass, getErrorParts} from '../../errors';
 
 /**
@@ -33,6 +34,11 @@ function classifyIDBError(error: unknown): ValueOf<typeof StorageErrorClass> {
         name.includes('aborterror') ||
         message.includes('connection to indexed database server lost') ||
         message.includes('connection is closing') ||
+        // WebKit's IDB server tore the transaction down under a live connection (page reload or
+        // foregrounding after process suspension). Emitted as UnknownError with messages like
+        // "Attempt to get a record from database without an in-progress transaction" — the shared
+        // suffix covers the whole family. A fresh connection heals it.
+        message.includes('without an in-progress transaction') ||
         // This is related to https://github.com/Expensify/react-native-onyx/pull/796 — remove this comment when #796 is merged.
         message.includes('idb write transaction aborted without an error')
     ) {

--- a/tests/unit/storage/providers/createStoreTest.ts
+++ b/tests/unit/storage/providers/createStoreTest.ts
@@ -1,7 +1,6 @@
 import * as IDB from 'idb-keyval';
-
-import * as Logger from '../../../../lib/Logger';
 import createStore from '../../../../lib/storage/providers/IDBKeyValProvider/createStore';
+import * as Logger from '../../../../lib/Logger';
 
 const STORE_NAME = 'teststore';
 let testDbCounter = 0;

--- a/tests/unit/storage/providers/createStoreTest.ts
+++ b/tests/unit/storage/providers/createStoreTest.ts
@@ -1,6 +1,7 @@
 import * as IDB from 'idb-keyval';
-import createStore from '../../../../lib/storage/providers/IDBKeyValProvider/createStore';
+
 import * as Logger from '../../../../lib/Logger';
+import createStore from '../../../../lib/storage/providers/IDBKeyValProvider/createStore';
 
 const STORE_NAME = 'teststore';
 let testDbCounter = 0;
@@ -130,6 +131,60 @@ describe('createStore', () => {
                 }),
             );
             expect(logAlertSpy).not.toHaveBeenCalled();
+        });
+
+        it('should retry once and succeed on a WebKit "without an in-progress transaction" UnknownError', async () => {
+            const store = createStore(uniqueDBName(), STORE_NAME);
+
+            await store('readwrite', (s) => {
+                s.put('initial', 'key1');
+                return IDB.promisifyRequest(s.transaction);
+            });
+
+            const original = IDBDatabase.prototype.transaction;
+            let callCount = 0;
+            jest.spyOn(IDBDatabase.prototype, 'transaction').mockImplementation(function (this: IDBDatabase, ...args) {
+                callCount += 1;
+                if (callCount === 1) {
+                    throw new DOMException('Attempt to get a record from database without an in-progress transaction', 'UnknownError');
+                }
+                return original.apply(this, args);
+            });
+
+            const result = await store('readonly', (s) => IDB.promisifyRequest(s.get('key1')));
+
+            expect(result).toBe('initial');
+            expect(callCount).toBe(2);
+            expect(logInfoSpy).toHaveBeenCalledWith(expect.stringContaining('IDB transient error'), expect.anything());
+        });
+
+        it('should retry once and succeed on a WebKit "generate key" UnknownError during a write', async () => {
+            const store = createStore(uniqueDBName(), STORE_NAME);
+
+            await store('readwrite', (s) => {
+                s.put('initial', 'key1');
+                return IDB.promisifyRequest(s.transaction);
+            });
+
+            const original = IDBDatabase.prototype.transaction;
+            let callCount = 0;
+            jest.spyOn(IDBDatabase.prototype, 'transaction').mockImplementation(function (this: IDBDatabase, ...args) {
+                callCount += 1;
+                if (callCount === 1) {
+                    throw new DOMException('Attempt to generate key in database without an in-progress transaction', 'UnknownError');
+                }
+                return original.apply(this, args);
+            });
+
+            await store('readwrite', (s) => {
+                s.put('written', 'key1');
+                return IDB.promisifyRequest(s.transaction);
+            });
+
+            const result = await store('readonly', (s) => IDB.promisifyRequest(s.get('key1')));
+
+            expect(result).toBe('written');
+            expect(callCount).toBe(3);
         });
 
         it('should preserve data integrity after a successful retry', async () => {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details

WebKit's IndexedDB server can tear down transactions under a live connection (page reload, or foregrounding a tab after process suspension). When that happens, every in-flight operation fails with an `UnknownError` DOMException from the same family:

- `Attempt to get a record from database without an in-progress transaction`
- `Attempt to get records from database without an in-progress transaction`
- `Attempt to generate key in database without an in-progress transaction`

These are emitted by WebKit's [`SQLiteIDBBackingStore`](https://github.com/WebKit/WebKit/blob/main/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp) and only ever occur on WebKit browsers (iOS Safari, Chrome/Edge/Google iOS shells, macOS Safari) — Sentry tag distribution on the linked issue is 100% WebKit.

`classifyIDBError` currently classifies them as `UNKNOWN`, so the connection layer propagates them without retrying. The visible damage is at app boot: the initial `getAll` fails and Onyx boots with default key states only ("Failed to load data from storage during init"), dropping the whole local cache for that session even though the data is intact on disk.

Production logs show that sibling errors from the very same failure episodes (`AbortError`-flavored aborts) are already classified `TRANSIENT` and recover on the same-instant reopen-and-retry. This PR extends the `TRANSIENT` bucket to the `without an in-progress transaction` family (matched on the shared message suffix), so the connection layer drops the stale cached connection and retries once with a fresh one instead of giving up.

### Related Issues

https://github.com/Expensify/App/issues/100046

### Linked E/App PR

https://github.com/Expensify/App/pull/99900

### Automated Tests

Added two tests to `createStoreTest.ts` mirroring the existing transient-retry coverage:

- `should retry once and succeed on a WebKit "without an in-progress transaction" UnknownError` — read path: first transaction fails with the WebKit `UnknownError`, the connection layer logs `IDB transient error`, reopens, and the read succeeds.
- `should retry once and succeed on a WebKit "generate key" UnknownError during a write` — write path: same recovery for a `readwrite` transaction, and the written value is readable afterwards.

### Manual Tests

1. Run the App web build with this Onyx version and sign in.
2. In the browser console, force the next IDB transaction to fail with the WebKit error:
    ```js
    const original = IDBDatabase.prototype.transaction;
    let thrown = false;
    IDBDatabase.prototype.transaction = function (...args) {
        if (!thrown) {
            thrown = true;
            throw new DOMException('Attempt to get a record from database without an in-progress transaction', 'UnknownError');
        }
        return original.apply(this, args);
    };
    ```
3. Trigger Onyx activity (open a report, send a message).
4. Verify the console shows `[Onyx] IDB transient error — dropping cached connection and retrying once` (instead of `IDB error not recoverable at the connection layer, propagating`), the action completes, and the data survives a page reload.

### Author Checklist

- [x] I linked the correct issue in the `### Related Issues` section above
- [x] I linked the corresponding Expensify/App PR in the `### Linked E/App PR` section above, and verified this change against it (E/App CI passed and manual testing completed)
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>